### PR TITLE
BG-CI-001: Add GitHub Actions continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - architecture/red-team-engine-v1
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Node 18 tests and syntax
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Run automated tests
+        run: npm test
+
+      - name: Check JavaScript syntax
+        shell: bash
+        run: |
+          node --check index.js
+          find src test -type f -name '*.js' -print0 | xargs -0 -n1 node --check


### PR DESCRIPTION
## Objective

Add the minimum GitHub Actions quality gate for BizGenie without changing product behaviour.

## What changed

Adds `.github/workflows/ci.yml` with one Node 18 job that runs:

- `npm ci --no-audit --no-fund`
- `npm test`
- `node --check` for the application, Mission Control source and tests

The workflow runs on every pull request, pushes to `main` and `architecture/red-team-engine-v1`, and manual dispatch.

## Engineering safeguards

- read-only repository permission
- production-compatible Node 18
- npm dependency caching
- 10-minute timeout
- concurrency cancellation for superseded runs

## Scope

CI configuration only. No application, API, package, dependency, documentation, deployment or product behaviour changes.

Targets `architecture/red-team-engine-v1` so the workflow becomes part of aggregate release PR #2 before that branch reaches `main`.