### PR TITLE
BG-IP-001: Add configurable branding layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,37 @@ Mission Control validation failures return HTTP `400` with a stable shape:
 
 An unknown review returns `404` with error code `REVIEW_NOT_FOUND`.
 
+## Branding configuration
+
+All product-facing branding values are centralised in
+`config/branding.json` and validated by `src/config/branding.js`. The
+contract covers the app name, logo, colours, favicon, legal name, copyright,
+support email, named URLs and named marketing strings.
+
+Values that have not been approved are deliberately `null` or empty maps.
+The checked-in defaults preserve the existing API output.
+
+Deployments may apply partial overrides with `BRANDING_CONFIG_JSON`. Nested
+colour, URL and marketing-string maps are merged with the checked-in defaults:
+
+```bash
+BRANDING_CONFIG_JSON='{
+  "appName": "Configured Brand",
+  "logo": "/assets/logo.svg",
+  "colors": { "primary": "#112233" },
+  "supportEmail": "support@example.com",
+  "urls": { "marketing": "https://example.com" },
+  "marketingStrings": { "serviceStatus": "Configured service is up" }
+}'
+```
+
+Configuration is validated at startup. Invalid JSON, email addresses, URLs or
+field types fail fast rather than silently applying partial branding.
+
 ## Environment variables
 
 - `ADMIN_KEY` — required for all administration and script-generation routes.
+- `BRANDING_CONFIG_JSON` — optional validated partial override for the central branding configuration.
 - `GOOGLE_CLOUD_PROJECT`, `GCLOUD_PROJECT`, or `GCP_PROJECT` — Google Cloud
   project used by the existing script generator.
 - `VERTEX_LOCATION` — optional; defaults to `europe-west1`.

--- a/config/branding.json
+++ b/config/branding.json
@@ -1,0 +1,14 @@
+{
+  "appName": "BizGenie",
+  "logo": null,
+  "colors": {},
+  "favicon": null,
+  "legalName": null,
+  "copyright": null,
+  "supportEmail": null,
+  "urls": {},
+  "marketingStrings": {
+    "apiBooting": "BizGenie API booting",
+    "serviceStatus": "BizGenie Cloud Run is up"
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,4 +1,9 @@
-console.log("🚀 BizGenie API booting");
+const {
+  BrandingConfigSchema,
+  brandingConfig,
+} = require("./src/config/branding");
+
+console.log(`🚀 ${brandingConfig.marketingStrings.apiBooting}`);
 
 const express = require("express");
 const { VertexAI } = require("@google-cloud/vertexai");
@@ -30,9 +35,9 @@ function requireAdmin(req, res, next) {
   next();
 }
 
-function buildSystemInstruction() {
+function buildSystemInstruction(branding = brandingConfig) {
   return `
-You are BizGenie Phase 1 script generation engine.
+You are ${branding.appName} Phase 1 script generation engine.
 
 You MUST return a COMPLETE structured output.
 
@@ -63,7 +68,10 @@ Do not truncate sections.
 `.trim();
 }
 
-async function generateScriptWithVertex(compiledPrompt) {
+async function generateScriptWithVertex(
+  compiledPrompt,
+  { branding = brandingConfig } = {}
+) {
   if (!PROJECT_ID) {
     throw new Error("Missing GOOGLE_CLOUD_PROJECT environment variable");
   }
@@ -77,7 +85,7 @@ async function generateScriptWithVertex(compiledPrompt) {
     model: MODEL_NAME,
     systemInstruction: {
       role: "system",
-      parts: [{ text: buildSystemInstruction() }],
+      parts: [{ text: buildSystemInstruction(branding) }],
     },
     generationConfig: {
       maxOutputTokens: 2048,
@@ -110,12 +118,14 @@ async function generateScriptWithVertex(compiledPrompt) {
 
 function createApp({
   missionControlRepository = new InMemoryMissionControlRepository(),
+  branding = brandingConfig,
 } = {}) {
+  const resolvedBranding = BrandingConfigSchema.parse(branding);
   const app = express();
   app.use(express.json());
 
   app.get("/", (_req, res) => {
-    res.send("BizGenie Cloud Run is up");
+    res.send(resolvedBranding.marketingStrings.serviceStatus);
   });
 
   app.get("/_admin/ping", requireAdmin, (_req, res) => {
@@ -145,7 +155,9 @@ function createApp({
         });
       }
 
-      const text = await generateScriptWithVertex(compiled_prompt);
+      const text = await generateScriptWithVertex(compiled_prompt, {
+        branding: resolvedBranding,
+      });
 
       return res.json({
         status: "completed",

--- a/src/config/branding.js
+++ b/src/config/branding.js
@@ -1,0 +1,121 @@
+const { z } = require("zod");
+const defaultBranding = require("../../config/branding.json");
+
+const NonEmptyString = z.string().trim().min(1);
+const NullableString = NonEmptyString.nullable();
+
+const BrandingConfigSchema = z
+  .object({
+    appName: NonEmptyString,
+    logo: NullableString,
+    colors: z.record(z.string(), NonEmptyString),
+    favicon: NullableString,
+    legalName: NullableString,
+    copyright: NullableString,
+    supportEmail: z.string().trim().email().nullable(),
+    urls: z.record(z.string(), z.string().trim().url()),
+    marketingStrings: z
+      .object({
+        apiBooting: NonEmptyString,
+        serviceStatus: NonEmptyString,
+      })
+      .catchall(NonEmptyString),
+  })
+  .strict();
+
+const BrandingOverridesSchema = z
+  .object({
+    appName: NonEmptyString.optional(),
+    logo: NullableString.optional(),
+    colors: z.record(z.string(), NonEmptyString).optional(),
+    favicon: NullableString.optional(),
+    legalName: NullableString.optional(),
+    copyright: NullableString.optional(),
+    supportEmail: z.string().trim().email().nullable().optional(),
+    urls: z.record(z.string(), z.string().trim().url()).optional(),
+    marketingStrings: z.record(z.string(), NonEmptyString).optional(),
+  })
+  .strict();
+
+function formatIssues(issues) {
+  return issues
+    .map((issue) => {
+      const path = issue.path.length ? issue.path.join(".") : "root";
+      return `${path}: ${issue.message}`;
+    })
+    .join("; ");
+}
+
+function parseBrandingOverrides(rawValue) {
+  if (!rawValue) {
+    return {};
+  }
+
+  let value;
+  try {
+    value = JSON.parse(rawValue);
+  } catch {
+    throw new Error("Invalid BRANDING_CONFIG_JSON: must be valid JSON");
+  }
+
+  const parsed = BrandingOverridesSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new Error(
+      `Invalid BRANDING_CONFIG_JSON: ${formatIssues(parsed.error.issues)}`
+    );
+  }
+
+  return parsed.data;
+}
+
+function deepFreeze(value) {
+  Object.freeze(value);
+
+  for (const child of Object.values(value)) {
+    if (child && typeof child === "object" && !Object.isFrozen(child)) {
+      deepFreeze(child);
+    }
+  }
+
+  return value;
+}
+
+function loadBrandingConfig({
+  env = process.env,
+  baseConfig = defaultBranding,
+} = {}) {
+  const parsedBase = BrandingConfigSchema.safeParse(baseConfig);
+  if (!parsedBase.success) {
+    throw new Error(
+      `Invalid config/branding.json: ${formatIssues(parsedBase.error.issues)}`
+    );
+  }
+
+  const overrides = parseBrandingOverrides(env.BRANDING_CONFIG_JSON);
+  const merged = {
+    ...parsedBase.data,
+    ...overrides,
+    colors: {
+      ...parsedBase.data.colors,
+      ...overrides.colors,
+    },
+    urls: {
+      ...parsedBase.data.urls,
+      ...overrides.urls,
+    },
+    marketingStrings: {
+      ...parsedBase.data.marketingStrings,
+      ...overrides.marketingStrings,
+    },
+  };
+
+  return deepFreeze(BrandingConfigSchema.parse(merged));
+}
+
+const brandingConfig = loadBrandingConfig();
+
+module.exports = {
+  BrandingConfigSchema,
+  brandingConfig,
+  loadBrandingConfig,
+};

--- a/test/branding.test.js
+++ b/test/branding.test.js
@@ -1,0 +1,105 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+const request = require("supertest");
+const { createApp } = require("../index");
+const {
+  BrandingConfigSchema,
+  brandingConfig,
+  loadBrandingConfig,
+} = require("../src/config/branding");
+
+describe("branding configuration", () => {
+  it("exposes every branding concern through one validated contract", () => {
+    assert.equal(brandingConfig.appName, "BizGenie");
+    assert.deepEqual(Object.keys(brandingConfig).sort(), [
+      "appName",
+      "colors",
+      "copyright",
+      "favicon",
+      "legalName",
+      "logo",
+      "marketingStrings",
+      "supportEmail",
+      "urls",
+    ]);
+    assert.equal(
+      BrandingConfigSchema.safeParse(brandingConfig).success,
+      true
+    );
+  });
+
+  it("preserves the existing service response by default", async () => {
+    const response = await request(createApp()).get("/");
+
+    assert.equal(response.status, 200);
+    assert.equal(response.text, "BizGenie Cloud Run is up");
+  });
+
+  it("applies partial runtime overrides without losing default strings", async () => {
+    const branding = loadBrandingConfig({
+      env: {
+        BRANDING_CONFIG_JSON: JSON.stringify({
+          appName: "Configured Brand",
+          logo: "/assets/logo.svg",
+          colors: {
+            primary: "#112233",
+          },
+          favicon: "/assets/favicon.ico",
+          legalName: "Configured Brand Limited",
+          copyright: "Configured copyright",
+          supportEmail: "support@example.com",
+          urls: {
+            marketing: "https://example.com",
+            terms: "https://example.com/terms",
+          },
+          marketingStrings: {
+            serviceStatus: "Configured service is up",
+            tagline: "Configured marketing tagline",
+          },
+        }),
+      },
+    });
+
+    assert.equal(branding.appName, "Configured Brand");
+    assert.equal(branding.colors.primary, "#112233");
+    assert.equal(branding.marketingStrings.apiBooting, "BizGenie API booting");
+    assert.equal(
+      branding.marketingStrings.tagline,
+      "Configured marketing tagline"
+    );
+
+    const response = await request(createApp({ branding })).get("/");
+    assert.equal(response.text, "Configured service is up");
+  });
+
+  it("fails fast for malformed or invalid runtime configuration", () => {
+    assert.throws(
+      () =>
+        loadBrandingConfig({
+          env: { BRANDING_CONFIG_JSON: "{" },
+        }),
+      /Invalid BRANDING_CONFIG_JSON: must be valid JSON/
+    );
+
+    assert.throws(
+      () =>
+        loadBrandingConfig({
+          env: {
+            BRANDING_CONFIG_JSON: JSON.stringify({
+              supportEmail: "not-an-email",
+            }),
+          },
+        }),
+      /Invalid BRANDING_CONFIG_JSON: supportEmail/
+    );
+  });
+
+  it("returns immutable configuration", () => {
+    const branding = loadBrandingConfig();
+
+    assert.equal(Object.isFrozen(branding), true);
+    assert.equal(Object.isFrozen(branding.colors), true);
+    assert.equal(Object.isFrozen(branding.urls), true);
+    assert.equal(Object.isFrozen(branding.marketingStrings), true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a centralized, validated branding configuration layer without changing existing API behavior.

## Scope

- Adds `config/branding.json` as the single default branding source.
- Covers app name, logo, colours, favicon, legal name, copyright, support email, URLs, and marketing strings.
- Adds validated partial runtime overrides through `BRANDING_CONFIG_JSON`.
- Replaces existing API branding literals with configuration lookups while preserving their exact defaults.
- Adds focused branding tests and README documentation.

Unknown founder-owned values are explicitly `null` or empty maps; no legal identity, contact details, brand assets, colours, or URLs were invented.

## Behavior preservation

- `/` still returns `BizGenie Cloud Run is up` by default.
- `/_admin/ping` is unchanged.
- `/generate-script` routes, validation, and default prompt wording are unchanged.
- No endpoints, packages, UI, or deployment configuration were added or changed.

## Validation

Executed in an isolated checkout with Node.js v24.14.0:

- `node --test`: 23 passed, 0 failed.
- `node --check` across `index.js`, `src/**/*.js`, and `test/**/*.js`: 10 files passed.
- Production branding literal scan: literals exist only in `config/branding.json` as configurable defaults.

Note: the bundled validation runtime did not include npm, so `node --test` was run directly; this is the exact command behind the repository's `npm test` script.

## Environment variable

- `BRANDING_CONFIG_JSON` — optional JSON object containing partial validated overrides.

## Limitations

- Logo, colours, favicon, legal/contact data, URLs, and additional marketing copy are configuration-ready but intentionally unset until approved values are supplied.
- The repository is an API service, so visual branding fields are not rendered here.

Draft only. Do not merge or deploy as part of this task.