### PR TITLE
BG-MC-002: Add Mission Control intelligence schemas

### DIFF
--- a/docs/mission-control/INTELLIGENCE_SCHEMAS.md
+++ b/docs/mission-control/INTELLIGENCE_SCHEMAS.md
@@ -126,7 +126,7 @@ action contains `action_id`, `title`, `owner_ref`, `success_measure`, optional
 
 ## Product Intelligence
 
-Stores a traceable synthesis that can informâ€”but cannot automatically changeâ€”a
+Stores a traceable synthesis that can inform - but cannot automatically change - a
 product decision.
 
 Required fields:
@@ -151,4 +151,3 @@ These schemas do not:
 - collect analytics;
 - approve launches or change the roadmap;
 - define any UI.
-

--- a/docs/mission-control/INTELLIGENCE_SCHEMAS.md
+++ b/docs/mission-control/INTELLIGENCE_SCHEMAS.md
@@ -1,0 +1,154 @@
+# Mission Control Intelligence Schemas v1
+
+## Purpose
+
+These contracts define the evidence-backed intelligence records used by Mission
+Control. They are deterministic data contracts only. They do not define routes,
+storage, orchestration, analytics, model calls or user interfaces.
+
+The executable Zod definitions live in
+`src/mission-control/intelligence-schemas.js`.
+
+## Shared rules
+
+- Every object is strict: undeclared fields fail validation.
+- Identifiers and human-readable text must be non-empty strings after trimming.
+- Timestamps are ISO 8601 strings with a timezone offset.
+- Numeric confidence is between `0` and `1`; a non-empty qualitative confidence
+  statement is also accepted to remain compatible with the Finding contract.
+- Completed or decision-grade intelligence requires explicit evidence references.
+- References are opaque identifiers. These schemas do not resolve or fetch them.
+- Customer records use `participant_ref`; the contract does not solicit names,
+  contact details or raw personal data.
+
+## Competitor Review
+
+Records an evidence-backed assessment of one competitor within a named scope.
+
+Required fields:
+
+- `competitor_review_id`, `review_id`, `created_at`
+- `competitor_ref`, `competitor_name`, `scope`, `summary`
+- `strengths[]`, `weaknesses[]`, `opportunities[]`, `threats[]`
+- `evidence_refs[]` with at least one reference
+- `status`: `draft | ready | running | completed | failed`
+
+## Benchmark Review
+
+Compares a subject with a named benchmark using one or more explicit metrics.
+
+Required fields:
+
+- `benchmark_review_id`, `review_id`, `created_at`
+- `subject_ref`, `benchmark_name`, `summary`
+- `metrics[]`, each containing unique `metric_id`, `name`, `subject_value`,
+  `benchmark_value`, optional `unit`, `direction`, `comparison` and evidence
+- `evidence_refs[]` with at least one reference
+- `status`: `draft | ready | running | completed | failed`
+
+Metric `direction` is `higher_is_better | lower_is_better | target_match`.
+Metric `comparison` is `ahead | at_par | behind | not_comparable`.
+
+## Multi-Lens Review
+
+Preserves independent assessments and disagreement before producing a synthesis.
+
+Required fields:
+
+- `multi_lens_review_id`, `review_id`, `created_at`, `subject`
+- `lens_assessments[]` with at least two uniquely identified lenses
+- Each lens contains `lens_id`, `reviewer_role`, `provider`, `conclusion`,
+  `confidence`, `risks[]`, `opportunities[]` and `evidence_refs[]`
+- `synthesis`, `disagreements[]`, `evidence_refs[]`
+- `status`: `draft | ready | running | completed | failed`
+
+## Customer Interview
+
+Captures structured interview evidence without requiring direct personal data.
+
+Required fields:
+
+- `customer_interview_id`, `created_at`
+- `participant_ref`, `customer_segment`, `interviewer_ref`, `objective`
+- `insights[]`, `evidence_refs[]`
+- `status`: `scheduled | completed | cancelled`
+
+`conducted_at` and `summary` are optional until completion. A completed interview
+requires both plus at least one evidence reference. Insight identifiers must be
+unique within the interview.
+
+## Launch Decision
+
+Records a human-governed launch decision and its supporting evidence.
+
+Required fields:
+
+- `launch_decision_id`, `review_id`, `created_at`, `launch_ref`
+- `decision`: `go | conditional_go | no_go | defer`
+- `rationale`, `conditions[]`, `approved_by[]`, `evidence_refs[]`
+- `status`: `draft | approved | rejected | superseded`
+
+`conditional_go` requires at least one condition. An approved record requires at
+least one approver reference. Validation does not grant approval or perform a
+launch.
+
+## Feature Evidence
+
+Links a bounded piece of evidence to a feature without changing a roadmap.
+
+Required fields:
+
+- `feature_evidence_id`, `feature_ref`, `created_at`
+- `evidence_type`, `title`, `description`, `impact`, `confidence`
+- `source_refs[]` with at least one reference
+- `status`: `active | invalidated | superseded`
+
+Evidence type is `customer_interview | customer_request | usage | experiment |
+commercial | support | competitive | technical | other`.
+
+Impact is `supports | neutral | challenges`.
+
+## Engineering Retrospective
+
+Captures an evidence-backed engineering learning cycle and measurable actions.
+
+Required fields:
+
+- `engineering_retrospective_id`, `review_id`, `created_at`
+- `period_start`, `period_end`, `scope`, `summary`
+- `went_well[]`, `went_poorly[]`, `lessons[]`, `actions[]`
+- `evidence_refs[]` with at least one reference
+- `status`: `draft | completed`
+
+The period cannot end before it starts. Action identifiers must be unique. Each
+action contains `action_id`, `title`, `owner_ref`, `success_measure`, optional
+`target_date` and status `pending | in_progress | completed | cancelled`.
+
+## Product Intelligence
+
+Stores a traceable synthesis that can informâ€”but cannot automatically changeâ€”a
+product decision.
+
+Required fields:
+
+- `product_intelligence_id`, `created_at`
+- `intelligence_type`, `title`, `description`, `confidence`
+- `implications[]`, `recommended_actions[]`
+- `source_refs[]` with at least one reference
+- `status`: `draft | validated | rejected | superseded`
+
+Intelligence type is `customer | competitive | product | commercial | technical |
+risk | opportunity`.
+
+## Explicit boundaries
+
+These schemas do not:
+
+- create endpoints or authentication rules;
+- generate identifiers or timestamps;
+- persist, query or migrate records;
+- call AI providers or score records;
+- collect analytics;
+- approve launches or change the roadmap;
+- define any UI.
+

--- a/src/mission-control/index.js
+++ b/src/mission-control/index.js
@@ -3,11 +3,14 @@ const {
   MissionControlRepository,
 } = require("./repository");
 const { createMissionControlRouter } = require("./router");
+const intelligenceSchemas = require("./intelligence-schemas");
 const schemas = require("./schemas");
 
 module.exports = {
   InMemoryMissionControlRepository,
   MissionControlRepository,
   createMissionControlRouter,
+  ...intelligenceSchemas,
   ...schemas,
 };
+

--- a/src/mission-control/index.js
+++ b/src/mission-control/index.js
@@ -13,4 +13,3 @@ module.exports = {
   ...intelligenceSchemas,
   ...schemas,
 };
-

--- a/src/mission-control/intelligence-schemas.js
+++ b/src/mission-control/intelligence-schemas.js
@@ -330,4 +330,3 @@ module.exports = {
   productIntelligenceTypes,
   retrospectiveActionStatuses,
 };
-

--- a/src/mission-control/intelligence-schemas.js
+++ b/src/mission-control/intelligence-schemas.js
@@ -1,0 +1,333 @@
+const { z } = require("zod");
+
+const identifier = z.string().trim().min(1);
+const timestamp = z.string().datetime({ offset: true });
+const nonEmptyText = z.string().trim().min(1);
+const confidence = z.union([
+  z.number().finite().min(0).max(1),
+  nonEmptyText,
+]);
+const evidenceRefs = z.array(identifier).min(1);
+
+const reviewStatuses = ["draft", "ready", "running", "completed", "failed"];
+
+function requireUnique(items, key, context, path) {
+  const seen = new Set();
+  items.forEach((item, index) => {
+    if (seen.has(item[key])) {
+      context.addIssue({
+        code: "custom",
+        path: [path, index, key],
+        message: `${key} values must be unique`,
+      });
+    }
+    seen.add(item[key]);
+  });
+}
+
+const CompetitorReviewSchema = z
+  .object({
+    competitor_review_id: identifier,
+    review_id: identifier,
+    created_at: timestamp,
+    competitor_ref: identifier,
+    competitor_name: nonEmptyText,
+    scope: nonEmptyText,
+    summary: nonEmptyText,
+    strengths: z.array(nonEmptyText),
+    weaknesses: z.array(nonEmptyText),
+    opportunities: z.array(nonEmptyText),
+    threats: z.array(nonEmptyText),
+    evidence_refs: evidenceRefs,
+    status: z.enum(reviewStatuses),
+  })
+  .strict();
+
+const BenchmarkMetricSchema = z
+  .object({
+    metric_id: identifier,
+    name: nonEmptyText,
+    subject_value: z.union([z.number().finite(), nonEmptyText]),
+    benchmark_value: z.union([z.number().finite(), nonEmptyText]),
+    unit: nonEmptyText.optional(),
+    direction: z.enum([
+      "higher_is_better",
+      "lower_is_better",
+      "target_match",
+    ]),
+    comparison: z.enum(["ahead", "at_par", "behind", "not_comparable"]),
+    evidence_refs: evidenceRefs,
+  })
+  .strict();
+
+const BenchmarkReviewSchema = z
+  .object({
+    benchmark_review_id: identifier,
+    review_id: identifier,
+    created_at: timestamp,
+    subject_ref: identifier,
+    benchmark_name: nonEmptyText,
+    summary: nonEmptyText,
+    metrics: z.array(BenchmarkMetricSchema).min(1),
+    evidence_refs: evidenceRefs,
+    status: z.enum(reviewStatuses),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    requireUnique(value.metrics, "metric_id", context, "metrics");
+  });
+
+const LensAssessmentSchema = z
+  .object({
+    lens_id: identifier,
+    reviewer_role: nonEmptyText,
+    provider: nonEmptyText,
+    conclusion: nonEmptyText,
+    confidence,
+    risks: z.array(nonEmptyText),
+    opportunities: z.array(nonEmptyText),
+    evidence_refs: evidenceRefs,
+  })
+  .strict();
+
+const MultiLensReviewSchema = z
+  .object({
+    multi_lens_review_id: identifier,
+    review_id: identifier,
+    created_at: timestamp,
+    subject: nonEmptyText,
+    lens_assessments: z.array(LensAssessmentSchema).min(2),
+    synthesis: nonEmptyText,
+    disagreements: z.array(nonEmptyText),
+    evidence_refs: evidenceRefs,
+    status: z.enum(reviewStatuses),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    requireUnique(
+      value.lens_assessments,
+      "lens_id",
+      context,
+      "lens_assessments"
+    );
+  });
+
+const CustomerInsightSchema = z
+  .object({
+    insight_id: identifier,
+    title: nonEmptyText,
+    description: nonEmptyText,
+    confidence,
+    evidence_refs: evidenceRefs,
+  })
+  .strict();
+
+const customerInterviewStatuses = ["scheduled", "completed", "cancelled"];
+
+const CustomerInterviewSchema = z
+  .object({
+    customer_interview_id: identifier,
+    created_at: timestamp,
+    conducted_at: timestamp.optional(),
+    participant_ref: identifier,
+    customer_segment: nonEmptyText,
+    interviewer_ref: identifier,
+    objective: nonEmptyText,
+    summary: nonEmptyText.optional(),
+    insights: z.array(CustomerInsightSchema),
+    evidence_refs: z.array(identifier),
+    status: z.enum(customerInterviewStatuses),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    requireUnique(value.insights, "insight_id", context, "insights");
+
+    if (value.status === "completed") {
+      if (!value.conducted_at) {
+        context.addIssue({
+          code: "custom",
+          path: ["conducted_at"],
+          message: "conducted_at is required when status is completed",
+        });
+      }
+      if (!value.summary) {
+        context.addIssue({
+          code: "custom",
+          path: ["summary"],
+          message: "summary is required when status is completed",
+        });
+      }
+      if (value.evidence_refs.length === 0) {
+        context.addIssue({
+          code: "custom",
+          path: ["evidence_refs"],
+          message: "evidence_refs must contain evidence when status is completed",
+        });
+      }
+    }
+  });
+
+const launchDecisions = ["go", "conditional_go", "no_go", "defer"];
+const launchDecisionStatuses = ["draft", "approved", "rejected", "superseded"];
+
+const LaunchDecisionSchema = z
+  .object({
+    launch_decision_id: identifier,
+    review_id: identifier,
+    created_at: timestamp,
+    launch_ref: identifier,
+    decision: z.enum(launchDecisions),
+    rationale: nonEmptyText,
+    conditions: z.array(nonEmptyText),
+    approved_by: z.array(identifier),
+    evidence_refs: evidenceRefs,
+    status: z.enum(launchDecisionStatuses),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.decision === "conditional_go" && value.conditions.length === 0) {
+      context.addIssue({
+        code: "custom",
+        path: ["conditions"],
+        message: "conditions are required for a conditional_go decision",
+      });
+    }
+    if (value.status === "approved" && value.approved_by.length === 0) {
+      context.addIssue({
+        code: "custom",
+        path: ["approved_by"],
+        message: "approved_by is required when status is approved",
+      });
+    }
+  });
+
+const featureEvidenceTypes = [
+  "customer_interview",
+  "customer_request",
+  "usage",
+  "experiment",
+  "commercial",
+  "support",
+  "competitive",
+  "technical",
+  "other",
+];
+const featureEvidenceImpacts = ["supports", "neutral", "challenges"];
+const featureEvidenceStatuses = ["active", "invalidated", "superseded"];
+
+const FeatureEvidenceSchema = z
+  .object({
+    feature_evidence_id: identifier,
+    feature_ref: identifier,
+    created_at: timestamp,
+    evidence_type: z.enum(featureEvidenceTypes),
+    title: nonEmptyText,
+    description: nonEmptyText,
+    impact: z.enum(featureEvidenceImpacts),
+    confidence,
+    source_refs: evidenceRefs,
+    status: z.enum(featureEvidenceStatuses),
+  })
+  .strict();
+
+const retrospectiveActionStatuses = [
+  "pending",
+  "in_progress",
+  "completed",
+  "cancelled",
+];
+
+const RetrospectiveActionSchema = z
+  .object({
+    action_id: identifier,
+    title: nonEmptyText,
+    owner_ref: identifier,
+    success_measure: nonEmptyText,
+    target_date: timestamp.optional(),
+    status: z.enum(retrospectiveActionStatuses),
+  })
+  .strict();
+
+const EngineeringRetrospectiveSchema = z
+  .object({
+    engineering_retrospective_id: identifier,
+    review_id: identifier,
+    created_at: timestamp,
+    period_start: timestamp,
+    period_end: timestamp,
+    scope: nonEmptyText,
+    summary: nonEmptyText,
+    went_well: z.array(nonEmptyText),
+    went_poorly: z.array(nonEmptyText),
+    lessons: z.array(nonEmptyText),
+    actions: z.array(RetrospectiveActionSchema),
+    evidence_refs: evidenceRefs,
+    status: z.enum(["draft", "completed"]),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    requireUnique(value.actions, "action_id", context, "actions");
+    if (Date.parse(value.period_end) < Date.parse(value.period_start)) {
+      context.addIssue({
+        code: "custom",
+        path: ["period_end"],
+        message: "period_end must be on or after period_start",
+      });
+    }
+  });
+
+const productIntelligenceTypes = [
+  "customer",
+  "competitive",
+  "product",
+  "commercial",
+  "technical",
+  "risk",
+  "opportunity",
+];
+const productIntelligenceStatuses = [
+  "draft",
+  "validated",
+  "rejected",
+  "superseded",
+];
+
+const ProductIntelligenceSchema = z
+  .object({
+    product_intelligence_id: identifier,
+    created_at: timestamp,
+    intelligence_type: z.enum(productIntelligenceTypes),
+    title: nonEmptyText,
+    description: nonEmptyText,
+    confidence,
+    implications: z.array(nonEmptyText),
+    recommended_actions: z.array(nonEmptyText),
+    source_refs: evidenceRefs,
+    status: z.enum(productIntelligenceStatuses),
+  })
+  .strict();
+
+module.exports = {
+  BenchmarkMetricSchema,
+  BenchmarkReviewSchema,
+  CompetitorReviewSchema,
+  CustomerInsightSchema,
+  CustomerInterviewSchema,
+  EngineeringRetrospectiveSchema,
+  FeatureEvidenceSchema,
+  LaunchDecisionSchema,
+  LensAssessmentSchema,
+  MultiLensReviewSchema,
+  ProductIntelligenceSchema,
+  RetrospectiveActionSchema,
+  customerInterviewStatuses,
+  featureEvidenceImpacts,
+  featureEvidenceStatuses,
+  featureEvidenceTypes,
+  launchDecisionStatuses,
+  launchDecisions,
+  productIntelligenceStatuses,
+  productIntelligenceTypes,
+  retrospectiveActionStatuses,
+};
+

--- a/test/mission-control-intelligence.test.js
+++ b/test/mission-control-intelligence.test.js
@@ -1,0 +1,260 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+const {
+  BenchmarkReviewSchema,
+  CompetitorReviewSchema,
+  CustomerInterviewSchema,
+  EngineeringRetrospectiveSchema,
+  FeatureEvidenceSchema,
+  LaunchDecisionSchema,
+  MultiLensReviewSchema,
+  ProductIntelligenceSchema,
+} = require("../src/mission-control");
+
+const createdAt = "2026-08-02T12:00:00.000Z";
+const evidenceRefs = ["github:issue:6"];
+
+describe("Mission Control intelligence schemas", () => {
+  it("validates a Competitor Review", () => {
+    const value = {
+      competitor_review_id: "competitor_review_001",
+      review_id: "review_001",
+      created_at: createdAt,
+      competitor_ref: "competitor_001",
+      competitor_name: "Example competitor",
+      scope: "Launch positioning",
+      summary: "The competitor is strong in template breadth.",
+      strengths: ["Template breadth"],
+      weaknesses: ["Limited orchestration"],
+      opportunities: ["Outcome-first workflow"],
+      threats: ["Established distribution"],
+      evidence_refs: evidenceRefs,
+      status: "completed",
+    };
+
+    assert.deepEqual(CompetitorReviewSchema.parse(value), value);
+    assert.equal(
+      CompetitorReviewSchema.safeParse({ ...value, unknown: true }).success,
+      false
+    );
+  });
+
+  it("validates a Benchmark Review and rejects duplicate metrics", () => {
+    const metric = {
+      metric_id: "activation_time",
+      name: "Time to first approved script",
+      subject_value: 8,
+      benchmark_value: 10,
+      unit: "minutes",
+      direction: "lower_is_better",
+      comparison: "ahead",
+      evidence_refs: evidenceRefs,
+    };
+    const value = {
+      benchmark_review_id: "benchmark_review_001",
+      review_id: "review_001",
+      created_at: createdAt,
+      subject_ref: "bizgenie:launch",
+      benchmark_name: "Launch activation benchmark",
+      summary: "Activation is ahead of the launch benchmark.",
+      metrics: [metric],
+      evidence_refs: evidenceRefs,
+      status: "completed",
+    };
+
+    assert.deepEqual(BenchmarkReviewSchema.parse(value), value);
+    assert.equal(
+      BenchmarkReviewSchema.safeParse({ ...value, metrics: [metric, metric] })
+        .success,
+      false
+    );
+  });
+
+  it("requires multiple unique lenses in a Multi-Lens Review", () => {
+    const lens = {
+      lens_id: "product",
+      reviewer_role: "Product and customer advocate",
+      provider: "test-provider",
+      conclusion: "The launch scope addresses the primary job.",
+      confidence: 0.8,
+      risks: ["Onboarding clarity"],
+      opportunities: ["Faster activation"],
+      evidence_refs: evidenceRefs,
+    };
+    const value = {
+      multi_lens_review_id: "multi_lens_review_001",
+      review_id: "review_001",
+      created_at: createdAt,
+      subject: "Launch readiness",
+      lens_assessments: [
+        lens,
+        {
+          ...lens,
+          lens_id: "engineering",
+          reviewer_role: "Technical and security architect",
+        },
+      ],
+      synthesis: "The launch is viable with onboarding monitoring.",
+      disagreements: [],
+      evidence_refs: evidenceRefs,
+      status: "completed",
+    };
+
+    assert.deepEqual(MultiLensReviewSchema.parse(value), value);
+    assert.equal(
+      MultiLensReviewSchema.safeParse({ ...value, lens_assessments: [lens] })
+        .success,
+      false
+    );
+    assert.equal(
+      MultiLensReviewSchema.safeParse({
+        ...value,
+        lens_assessments: [lens, lens],
+      }).success,
+      false
+    );
+  });
+
+  it("validates Customer Interview completion evidence", () => {
+    const value = {
+      customer_interview_id: "customer_interview_001",
+      created_at: createdAt,
+      conducted_at: createdAt,
+      participant_ref: "customer_ref_001",
+      customer_segment: "Founder-led small business",
+      interviewer_ref: "team_member_001",
+      objective: "Understand script approval friction.",
+      summary: "The participant needs clearer tone guidance.",
+      insights: [
+        {
+          insight_id: "insight_001",
+          title: "Tone clarity",
+          description: "The desired tone is difficult to specify.",
+          confidence: 0.9,
+          evidence_refs: ["interview:customer_ref_001:note:4"],
+        },
+      ],
+      evidence_refs: ["interview:customer_ref_001"],
+      status: "completed",
+    };
+
+    assert.deepEqual(CustomerInterviewSchema.parse(value), value);
+    assert.equal(
+      CustomerInterviewSchema.safeParse({
+        ...value,
+        conducted_at: undefined,
+      }).success,
+      false
+    );
+  });
+
+  it("requires approval evidence and conditional launch conditions", () => {
+    const value = {
+      launch_decision_id: "launch_decision_001",
+      review_id: "review_001",
+      created_at: createdAt,
+      launch_ref: "launch:v1",
+      decision: "conditional_go",
+      rationale: "Core acceptance criteria pass.",
+      conditions: ["Confirm deployment trigger"],
+      approved_by: ["founder_001"],
+      evidence_refs: evidenceRefs,
+      status: "approved",
+    };
+
+    assert.deepEqual(LaunchDecisionSchema.parse(value), value);
+    assert.equal(
+      LaunchDecisionSchema.safeParse({ ...value, conditions: [] }).success,
+      false
+    );
+    assert.equal(
+      LaunchDecisionSchema.safeParse({ ...value, approved_by: [] }).success,
+      false
+    );
+  });
+
+  it("validates Feature Evidence with bounded impact and confidence", () => {
+    const value = {
+      feature_evidence_id: "feature_evidence_001",
+      feature_ref: "feature:brand-brain",
+      created_at: createdAt,
+      evidence_type: "customer_interview",
+      title: "Customers need persistent tone memory",
+      description: "Repeated tone setup slows approval.",
+      impact: "supports",
+      confidence: 0.85,
+      source_refs: ["customer_interview_001"],
+      status: "active",
+    };
+
+    assert.deepEqual(FeatureEvidenceSchema.parse(value), value);
+    assert.equal(
+      FeatureEvidenceSchema.safeParse({ ...value, confidence: 1.1 }).success,
+      false
+    );
+  });
+
+  it("validates Engineering Retrospective chronology and action identity", () => {
+    const action = {
+      action_id: "action_001",
+      title: "Add release checks",
+      owner_ref: "engineering_001",
+      success_measure: "Every pull request runs tests.",
+      target_date: "2026-08-09T12:00:00.000Z",
+      status: "pending",
+    };
+    const value = {
+      engineering_retrospective_id: "engineering_retro_001",
+      review_id: "review_001",
+      created_at: createdAt,
+      period_start: "2026-07-01T00:00:00.000Z",
+      period_end: "2026-07-31T23:59:59.000Z",
+      scope: "Mission Control foundation",
+      summary: "The foundation shipped with deterministic validation.",
+      went_well: ["Atomic scope"],
+      went_poorly: ["CI arrived later"],
+      lessons: ["Establish checks before parallel changes"],
+      actions: [action],
+      evidence_refs: evidenceRefs,
+      status: "completed",
+    };
+
+    assert.deepEqual(EngineeringRetrospectiveSchema.parse(value), value);
+    assert.equal(
+      EngineeringRetrospectiveSchema.safeParse({
+        ...value,
+        period_end: "2026-06-30T23:59:59.000Z",
+      }).success,
+      false
+    );
+    assert.equal(
+      EngineeringRetrospectiveSchema.safeParse({
+        ...value,
+        actions: [action, action],
+      }).success,
+      false
+    );
+  });
+
+  it("validates evidence-backed Product Intelligence", () => {
+    const value = {
+      product_intelligence_id: "product_intelligence_001",
+      created_at: createdAt,
+      intelligence_type: "opportunity",
+      title: "Persistent brand context reduces setup effort",
+      description: "Interview and feature evidence point to reusable context.",
+      confidence: 0.8,
+      implications: ["Prioritise Brand Brain discovery"],
+      recommended_actions: ["Validate with three further interviews"],
+      source_refs: ["feature_evidence_001", "customer_interview_001"],
+      status: "validated",
+    };
+
+    assert.deepEqual(ProductIntelligenceSchema.parse(value), value);
+    assert.equal(
+      ProductIntelligenceSchema.safeParse({ ...value, source_refs: [] }).success,
+      false
+    );
+  });
+});
+

--- a/test/mission-control-intelligence.test.js
+++ b/test/mission-control-intelligence.test.js
@@ -257,4 +257,3 @@ describe("Mission Control intelligence schemas", () => {
     );
   });
 });
-


### PR DESCRIPTION
## Summary

Adds deterministic, strict Mission Control intelligence contracts for:

- Competitor Review
- Benchmark Review
- Multi-Lens Review
- Customer Interview
- Launch Decision
- Feature Evidence
- Engineering Retrospective
- Product Intelligence

## Scope

- Adds executable Zod schemas and bounded enums.
- Adds cross-field validation for unique nested identifiers, completed interview evidence, conditional launch requirements, human approval references, and retrospective chronology.
- Exports the contracts through the existing Mission Control domain entry point.
- Documents the v1 contracts and explicit boundaries.
- Adds schema success and rejection tests.

## Explicitly unchanged

- No routes or endpoint behavior.
- No repository or persistence behavior.
- No authentication behavior.
- No database or migration.
- No analytics, model calls, orchestration, UI, roadmap changes, deployment, or package changes.

Existing `/`, `/_admin/ping`, `/generate-script`, Mission Control review, and Finding behavior remains unchanged.

## Validation

Executed in an isolated checkout with Node.js v24.14.0:

- `node --test`: 26 passed, 0 failed.
- `node --check` across `index.js`, `src/**/*.js`, and `test/**/*.js`: 10 files passed.
- `git diff --check`: passed.

The bundled environment did not include npm, so `node --test` was run directly; this is the exact command behind `npm test`.

## Contract assumptions

- Schema records receive identifiers and timestamps from their eventual caller; this task does not generate them.
- References are opaque identifiers and are not resolved by validation.
- Customer Interview uses a participant reference and does not introduce direct personal-data fields.
- Confidence retains compatibility with Finding: `0..1` numeric or a non-empty qualitative statement.
- Launch validation records approval evidence but does not grant approval or launch anything.

Draft only. Do not merge or deploy as part of this task.