### PR TITLE
BG-REL-002: Align repository runtime to Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test:
-    name: Node 18 tests and syntax
+    name: Node 20 tests and syntax
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use official Node 18 image
-FROM node:18-slim
+# Use official Node 20 LTS image
+FROM node:20-slim
 
 # Create app directory
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ BizGenie Cloud Run API
 
 ## Local setup
 
-Requires Node.js and npm.
+Requires Node.js 20 LTS and npm.
 
 ```bash
 npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "bizgenie-api",
       "version": "1.0.0",
+      "engines": {
+        "node": "20.x"
+      },
       "dependencies": {
         "@google-cloud/vertexai": "^1.0.0",
         "express": "^4.19.2",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "main": "index.js",
+  "engines": {
+    "node": "20.x"
+  },
   "scripts": {
     "start": "node index.js",
     "test": "node --test"


### PR DESCRIPTION
## What changed

- use Node 20 LTS in the Docker image
- run GitHub Actions CI on Node 20
- declare Node 20 in package and lock metadata
- document Node 20 LTS as the local runtime requirement

## Why

Issue #13 identifies a release-blocking runtime mismatch: the locked `@google/genai@1.52.0` requires Node 20 while Docker and CI used Node 18.

## Impact

Runtime declarations are aligned to Node 20. Dependency versions, application source, routes, behavior, and cloud infrastructure are unchanged.

## Validation

Run with Node v20.20.2 / npm 10.8.2:

- `npm ci --no-audit --no-fund` — passed; 143 packages installed with no Node engine incompatibility warning
- `npm test` — passed; 23 tests across 7 suites
- JavaScript syntax checks for `index.js`, `src/**/*.js`, and `test/**/*.js` — passed; 10 files checked
- `git diff --check` — passed

Closes #13.