### PR TITLE
BG-REL-004: Remove Canon trailing whitespace

### DIFF
--- a/docs/product/BizGenie_Canon_v2.md
+++ b/docs/product/BizGenie_Canon_v2.md
@@ -1,9 +1,9 @@
 # BizGenie Canon v2.0
 
-**Document ID:** BG-DOC-001  
-**Status:** Canonical  
-**Scope:** Product philosophy and launch principles  
-**Audience:** Product, engineering, design, operations and commercial teams  
+**Document ID:** BG-DOC-001
+**Status:** Canonical
+**Scope:** Product philosophy and launch principles
+**Audience:** Product, engineering, design, operations and commercial teams
 **Change class:** Controlled product-governance document
 
 ## Authority and purpose


### PR DESCRIPTION
## What changed

Removed the Markdown double-space line endings from Canon v2 metadata lines 3–6.

## Why

BG-REL-003 identified these four trailing-whitespace findings as the remaining release-hygiene failure in `git diff --check`.

## Impact

Documentation wording, launch boundaries, application behavior, routes, tests, CI, Docker, package metadata, and cloud infrastructure are unchanged. The diff is limited to one file and eight trailing space characters.

## Validation

- `git diff --check` — passed with no output
- `git diff --cached --check` — passed with no output
- `npm ci --no-audit --no-fund` — passed; 143 packages installed
- `npm test` — passed; 31 tests, 8 suites, 0 failures
- `node --check index.js` — passed
- syntax checks across all JavaScript files under `src/` and `test/` — passed (11 files)

No production, deployment, Cloud Build, Cloud Run, or other cloud change was made.