### PR TITLE
BG-CI-002 add non-deploying container artifact checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,19 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check diff whitespace
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if [[ -n "$BASE_SHA" ]]; then
+            git diff --check "$BASE_SHA...HEAD"
+          else
+            git diff --check HEAD^ HEAD
+          fi
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -42,3 +55,83 @@ jobs:
         run: |
           node --check index.js
           find src test -type f -name '*.js' -print0 | xargs -0 -n1 node --check
+
+  container-artifacts:
+    name: Docker and Buildpack artifact checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      DOCKER_IMAGE: bizgenie-api:ci-docker
+      BUILDPACK_IMAGE: bizgenie-api:ci-buildpack
+      BUILDPACK_BUILDER: gcr.io/buildpacks/builder:google-22
+      PACK_VERSION: 0.40.8
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Create disposable local admin key
+        shell: bash
+        run: |
+          admin_key="bg-ci-002-$(openssl rand -hex 16)"
+          echo "::add-mask::$admin_key"
+          echo "ADMIN_KEY=$admin_key" >> "$GITHUB_ENV"
+
+      - name: Build Dockerfile image locally
+        shell: bash
+        run: |
+          docker version
+          docker build --tag "$DOCKER_IMAGE" .
+          docker image inspect --format 'Docker image ID: {{.Id}}' \
+            "$DOCKER_IMAGE"
+
+      - name: Verify Docker image Node 20 runtime
+        shell: bash
+        run: |
+          node_version="$(docker run --rm "$DOCKER_IMAGE" node --version)"
+          echo "Docker image Node version: $node_version"
+          [[ "$node_version" == v20.* ]]
+
+      - name: Smoke test Dockerfile image
+        run: bash scripts/smoke-container.sh "$DOCKER_IMAGE" bizgenie-ci-docker
+
+      - name: Install pinned pack CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --show-error --silent --location \
+            "https://github.com/buildpacks/pack/releases/download/v${PACK_VERSION}/pack-v${PACK_VERSION}-linux.tgz" \
+            --output /tmp/pack.tgz
+          sudo tar --extract --gzip --file /tmp/pack.tgz \
+            --directory /usr/local/bin --no-same-owner pack
+          rm /tmp/pack.tgz
+          pack version
+
+      - name: Build Google Buildpack image locally
+        shell: bash
+        run: |
+          echo "Google Buildpack builder: $BUILDPACK_BUILDER"
+          pack build "$BUILDPACK_IMAGE" \
+            --builder "$BUILDPACK_BUILDER" \
+            --path . \
+            --pull-policy if-not-present
+          docker image inspect --format 'Buildpack image ID: {{.Id}}' \
+            "$BUILDPACK_IMAGE"
+
+      - name: Verify Buildpack image Node 20 runtime
+        shell: bash
+        run: |
+          node_version="$(
+            docker run --rm --entrypoint launcher \
+              "$BUILDPACK_IMAGE" -- node --version
+          )"
+          echo "Buildpack image Node version: $node_version"
+          [[ "$node_version" == v20.* ]]
+
+      - name: Smoke test Buildpack image
+        run: bash scripts/smoke-container.sh "$BUILDPACK_IMAGE" bizgenie-ci-buildpack
+
+      - name: Remove local images
+        if: always()
+        run: docker image rm --force "$DOCKER_IMAGE" "$BUILDPACK_IMAGE" || true
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,4 +134,3 @@ jobs:
       - name: Remove local images
         if: always()
         run: docker image rm --force "$DOCKER_IMAGE" "$BUILDPACK_IMAGE" || true
-

--- a/scripts/smoke-container.sh
+++ b/scripts/smoke-container.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+image="${1:?image name is required}"
+container_name="${2:?container name is required}"
+: "${ADMIN_KEY:?ADMIN_KEY must be set to a disposable local value}"
+response_dir="$(mktemp -d)"
+
+cleanup() {
+  exit_code=$?
+  if (( exit_code != 0 )); then
+    docker logs "$container_name" 2>&1 || true
+  fi
+  docker rm --force "$container_name" >/dev/null 2>&1 || true
+  rm -rf "$response_dir"
+  trap - EXIT
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+docker run --detach \
+  --name "$container_name" \
+  -p 127.0.0.1::8080 \
+  --env PORT=8080 \
+  --env ADMIN_KEY \
+  "$image" >/dev/null
+
+host_binding="$(docker port "$container_name" 8080/tcp)"
+host_port="${host_binding##*:}"
+base_url="http://127.0.0.1:${host_port}"
+
+ready=false
+for _ in {1..30}; do
+  status="$(
+    curl --silent --output /dev/null --write-out '%{http_code}' \
+      --connect-timeout 2 --max-time 5 "$base_url/" || true
+  )"
+  if [[ "$status" == "200" ]]; then
+    ready=true
+    break
+  fi
+  sleep 1
+done
+
+if [[ "$ready" != "true" ]]; then
+  echo "Container did not become ready within 30 attempts" >&2
+  exit 1
+fi
+
+assert_response() {
+  local name="$1"
+  local expected_status="$2"
+  local expected_body="$3"
+  shift 3
+
+  local response_file="$response_dir/${name}.body"
+  local actual_status
+  local actual_body
+
+  actual_status="$(
+    curl --silent --show-error --output "$response_file" \
+      --write-out '%{http_code}' --connect-timeout 2 --max-time 5 "$@"
+  )"
+  actual_body="$(<"$response_file")"
+
+  if [[ "$actual_status" != "$expected_status" ]]; then
+    echo "$name: expected HTTP $expected_status, got $actual_status" >&2
+    exit 1
+  fi
+  if [[ "$actual_body" != "$expected_body" ]]; then
+    echo "$name: response body did not match the existing contract" >&2
+    exit 1
+  fi
+
+  echo "$name: HTTP $actual_status and exact body verified"
+}
+
+assert_response root 200 'BizGenie Cloud Run is up' \
+  "$base_url/"
+assert_response admin-unauthorised 403 '{"error":"Forbidden"}' \
+  "$base_url/_admin/ping"
+assert_response admin-authorised 200 '{"status":"ok"}' \
+  --header "x-admin-key: $ADMIN_KEY" \
+  "$base_url/_admin/ping"
+assert_response generate-empty 400 \
+  '{"status":"failed","error":"Missing required fields","script_body":""}' \
+  --request POST \
+  --header 'content-type: application/json' \
+  --header "x-admin-key: $ADMIN_KEY" \
+  --data '{}' \
+  "$base_url/generate-script"
+

--- a/scripts/smoke-container.sh
+++ b/scripts/smoke-container.sh
@@ -89,4 +89,3 @@ assert_response generate-empty 400 \
   --header "x-admin-key: $ADMIN_KEY" \
   --data '{}' \
   "$base_url/generate-script"
-


### PR DESCRIPTION
## Summary

- preserve the existing Node 20 install, test, and syntax job
- add meaningful `git diff --check` validation
- build the Dockerfile image locally, verify Node 20, and run exact route-contract smoke checks
- install pinned Cloud Native Buildpacks `pack` CLI 0.40.8
- build a local image with `gcr.io/buildpacks/builder:google-22`, verify Node 20, and run the same smoke checks
- generate and mask a disposable local admin key
- use bounded readiness checks, job timeouts, and unconditional container/image cleanup

## Safety

- repository permissions remain `contents: read`
- no GitHub secrets or production credentials
- no registry authentication or image push/publish
- no gcloud authentication, Cloud Build, Cloud Run, deployment, or traffic changes
- the Vertex success path is not invoked

## Validation

GitHub Actions is the authoritative validation environment because Docker and `pack` run on the GitHub-hosted Ubuntu runner. The draft PR checks cover:

- existing Node 20 tests and JavaScript syntax
- `git diff --check`
- Docker build, Node runtime, and four exact smoke contracts
- Google Buildpack build, Node runtime, and the same four exact smoke contracts

Closes #16