### PR TITLE
BG-REL-007: Align production and CI with Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test:
-    name: Node 20 tests and syntax
+    name: Node 22 tests and syntax
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -57,7 +57,7 @@ jobs:
           find src test -type f -name '*.js' -print0 | xargs -0 -n1 node --check
 
   container-artifacts:
-    name: Docker and Buildpack artifact checks
+    name: Node 22 Docker and Buildpack artifact checks
     runs-on: ubuntu-latest
     timeout-minutes: 35
     env:
@@ -85,12 +85,12 @@ jobs:
           docker image inspect --format 'Docker image ID: {{.Id}}' \
             "$DOCKER_IMAGE"
 
-      - name: Verify Docker image Node 20 runtime
+      - name: Verify Docker image Node 22 runtime
         shell: bash
         run: |
           node_version="$(docker run --rm "$DOCKER_IMAGE" node --version)"
           echo "Docker image Node version: $node_version"
-          [[ "$node_version" == v20.* ]]
+          [[ "$node_version" == v22.* ]]
 
       - name: Smoke test Dockerfile image
         run: bash scripts/smoke-container.sh "$DOCKER_IMAGE" bizgenie-ci-docker
@@ -118,7 +118,7 @@ jobs:
           docker image inspect --format 'Buildpack image ID: {{.Id}}' \
             "$BUILDPACK_IMAGE"
 
-      - name: Verify Buildpack image Node 20 runtime
+      - name: Verify Buildpack image Node 22 runtime
         shell: bash
         run: |
           node_version="$(
@@ -126,7 +126,7 @@ jobs:
               "$BUILDPACK_IMAGE" -- node --version
           )"
           echo "Buildpack image Node version: $node_version"
-          [[ "$node_version" == v20.* ]]
+          [[ "$node_version" == v22.* ]]
 
       - name: Smoke test Buildpack image
         run: bash scripts/smoke-container.sh "$BUILDPACK_IMAGE" bizgenie-ci-buildpack

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use official Node 20 LTS image
-FROM node:20-slim
+# Use official Node 22 LTS image
+FROM node:22-slim
 
 # Create app directory
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ BizGenie Cloud Run API
 
 ## Local setup
 
-Requires Node.js 20 LTS and npm.
+Requires Node.js 22 LTS and npm.
 
 ```bash
 npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "bizgenie-api",
       "version": "1.0.0",
       "engines": {
-        "node": "20.x"
+        "node": "22.x"
       },
       "dependencies": {
         "@google-cloud/vertexai": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "index.js",
   "engines": {
-    "node": "20.x"
+    "node": "22.x"
   },
   "scripts": {
     "start": "node index.js",


### PR DESCRIPTION
## Release summary

Minimal runtime hotfix aligning BizGenie with Node 22 LTS for the production Google Buildpacks `google-24` builder and repository CI.

## Root cause

Cloud Build `c6cdbf59-35a6-4de7-a202-25ec7c4f6647` used `gcr.io/buildpacks/builder:latest`, now resolving to the Ubuntu 24 / google-24 builder. The repository requested Node `20.x`, but that builder offered Node 22, 24, and 26 only. Buildpack step 0 failed before image creation; Push and Deploy never ran.

The existing Cloud Run revision `bizgenie-apii-00011-9hr` remains healthy and receives 100% of traffic.

## Exact scope

Only these five files change:

- `Dockerfile`
- `.github/workflows/ci.yml`
- `package.json`
- `package-lock.json`
- `README.md`

Changes:

- use official `node:22-slim`
- run GitHub Actions on Node 22 and name both jobs accordingly
- assert Node major version 22 in Docker and Buildpack artifacts
- declare `engines.node` as `22.x` in both package manifests
- require Node 22 LTS in the README
- retain `gcr.io/buildpacks/builder:google-22` for CI Buildpack verification
- leave every dependency version unchanged

## Validation evidence

Local validation on Node `v22.23.2` / npm `10.9.8`:

- `npm ci --no-audit --no-fund` completed without a dependency engine warning
- 31 tests passed; 0 failed
- JavaScript syntax checks passed
- `git diff --check` passed
- application source, route code, tests, smoke-test script, schemas, and configuration are unchanged

GitHub Actions run [#22](https://github.com/shirrie01/bizgenie-api/actions/runs/31057078684), associated with exact PR head `1b66d7a64f6a25fb312a9c476aa51497db9570ff`, passed:

- `Node 22 tests and syntax`: success on Node `v22.23.1` / npm `10.9.8`; 31 tests passed
- `Node 22 Docker and Buildpack artifact checks`: success
- Docker base: official `node:22-slim`
- Docker artifact: `sha256:8c51b0f1a7d2ce32f610e336e754f79f5a52653428770b40339bcc3e1adbc4ab`
- Docker runtime: Node `v22.23.2`
- Docker route-contract smoke tests: passed
- Buildpack builder: `gcr.io/buildpacks/builder:google-22`
- pack CLI: `0.40.8`
- Buildpack artifact: `sha256:39be01e5ff60475dc3295bf9d3ba0b3c684efa6a9411d229a07fb41a5ad3b180`
- Buildpack runtime: Node `v22.23.2`
- Buildpack route-contract smoke tests: passed
- no image was pushed and no cloud state was changed by CI

## Production safety

This PR does not change Cloud Build triggers, Cloud Run, traffic, environment variables, secrets, Make, Glide, or any production resource. No build was retried and no deployment was performed. Do not merge until the production release is explicitly authorised.