### PR TITLE
BG-REL-008: Protect generation completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,3 +167,33 @@ field types fail fast rather than silently applying partial branding.
 
 Mission Control introduces no new environment variables. Its repository is
 process-local and is reset whenever the process restarts.
+
+## Generation completion protection
+
+`POST /generate-script` requests one candidate with a bounded 4,096-token
+output budget. The service assembles every text part in that candidate, records
+safe provider completion and token-count metadata, and requires non-empty
+content for Hook, Concept, Script, CTA, Caption, Hashtags, and Filming
+instructions before returning `status: "completed"`.
+
+Token exhaustion, empty output, a non-success provider stop reason, or a
+missing required section returns HTTP `502` without returning the partial text:
+
+```json
+{
+  "status": "failed",
+  "error": {
+    "code": "GENERATION_INCOMPLETE",
+    "message": "The model response ended before all required sections were completed",
+    "details": {
+      "finish_reason": "MAX_TOKENS",
+      "missing_sections": ["CTA", "Caption", "Hashtags", "Filming instructions"],
+      "retryable": true
+    }
+  },
+  "script_body": ""
+}
+```
+
+The endpoint does not retry provider requests automatically. This avoids
+duplicate persistence or charge risks in upstream orchestration.

--- a/index.js
+++ b/index.js
@@ -6,23 +6,15 @@ const {
 console.log(`🚀 ${brandingConfig.marketingStrings.apiBooting}`);
 
 const express = require("express");
-const { VertexAI } = require("@google-cloud/vertexai");
 const {
   InMemoryMissionControlRepository,
   createMissionControlRouter,
 } = require("./src/mission-control");
-
-const PROJECT_ID =
-  process.env.GOOGLE_CLOUD_PROJECT ||
-  process.env.GCLOUD_PROJECT ||
-  process.env.GCP_PROJECT;
-
-const LOCATION = process.env.VERTEX_LOCATION || "europe-west1";
-const MODEL_NAME = process.env.VERTEX_MODEL || "gemini-2.5-flash";
-
-if (!PROJECT_ID) {
-  console.warn("⚠️ GOOGLE_CLOUD_PROJECT is not set");
-}
+const {
+  GENERATION_INCOMPLETE_CODE,
+  GenerationIncompleteError,
+  generateScriptWithVertex,
+} = require("./src/generation");
 
 function requireAdmin(req, res, next) {
   const adminKey = process.env.ADMIN_KEY;
@@ -35,90 +27,11 @@ function requireAdmin(req, res, next) {
   next();
 }
 
-function buildSystemInstruction(branding = brandingConfig) {
-  return `
-You are ${branding.appName} Phase 1 script generation engine.
-
-You MUST return a COMPLETE structured output.
-
-STRICT RULES:
-- Do NOT stop early
-- ALL sections must be included
-- If any section is missing, the response is invalid
-
-Return ONLY plain text. No JSON. No markdown.
-
-FOR SHORT-FORM VIDEO OUTPUT:
-You MUST include ALL sections below:
-
-Hook (1 sentence)
-Concept (1-2 sentences)
-Script (MAX 120 words)
-CTA (1 line)
-Caption (MAX 2 lines)
-Hashtags (MAX 8 hashtags)
-Filming instructions (bullet points, MAX 6 bullets)
-
-Each section must be clearly labeled.
-
-Keep everything concise and complete.
-
-Do not exceed limits.
-Do not truncate sections.
-`.trim();
-}
-
-async function generateScriptWithVertex(
-  compiledPrompt,
-  { branding = brandingConfig } = {}
-) {
-  if (!PROJECT_ID) {
-    throw new Error("Missing GOOGLE_CLOUD_PROJECT environment variable");
-  }
-
-  const vertexAI = new VertexAI({
-    project: PROJECT_ID,
-    location: LOCATION,
-  });
-
-  const model = vertexAI.getGenerativeModel({
-    model: MODEL_NAME,
-    systemInstruction: {
-      role: "system",
-      parts: [{ text: buildSystemInstruction(branding) }],
-    },
-    generationConfig: {
-      maxOutputTokens: 2048,
-      temperature: 0.7,
-      topP: 0.9,
-    },
-  });
-
-  const result = await model.generateContent({
-    contents: [
-      {
-        role: "user",
-        parts: [{ text: compiledPrompt }],
-      },
-    ],
-  });
-
-  const response = result.response;
-  const text = response?.candidates?.[0]?.content?.parts
-    ?.map((part) => part.text || "")
-    .join("")
-    .trim();
-
-  if (!text) {
-    throw new Error("Vertex returned empty output");
-  }
-
-  return text;
-}
-
 function createApp({
   missionControlRepository = new InMemoryMissionControlRepository(),
   branding = brandingConfig,
+  scriptGenerator = generateScriptWithVertex,
+  logger = console,
 } = {}) {
   const resolvedBranding = BrandingConfigSchema.parse(branding);
   const app = express();
@@ -139,14 +52,14 @@ function createApp({
   );
 
   app.post("/generate-script", requireAdmin, async (req, res) => {
-    try {
-      const {
-        execution_id,
-        user_id,
-        project_id,
-        compiled_prompt
-      } = req.body;
+    const {
+      execution_id,
+      user_id,
+      project_id,
+      compiled_prompt
+    } = req.body;
 
+    try {
       if (!execution_id || !user_id || !project_id || !compiled_prompt) {
         return res.status(400).json({
           status: "failed",
@@ -155,18 +68,45 @@ function createApp({
         });
       }
 
-      const text = await generateScriptWithVertex(compiled_prompt, {
+      const generation = await scriptGenerator(compiled_prompt, {
         branding: resolvedBranding,
+      });
+
+      logger.info?.("generation completed", {
+        execution_id,
+        ...generation.metadata,
       });
 
       return res.json({
         status: "completed",
         execution_id,
-        script_body: text
+        script_body: generation.text
       });
 
     } catch (err) {
-      console.error("generate-script error:", err);
+      if (err instanceof GenerationIncompleteError) {
+        logger.warn?.("generation incomplete", {
+          execution_id,
+          ...err.metadata,
+          missing_sections: err.details.missing_sections,
+          retryable: err.details.retryable,
+        });
+
+        return res.status(502).json({
+          status: "failed",
+          error: {
+            code: GENERATION_INCOMPLETE_CODE,
+            message: err.message,
+            details: err.details,
+          },
+          script_body: ""
+        });
+      }
+
+      logger.error?.("generate-script error", {
+        name: err?.name || "Error",
+        code: err?.code || null,
+      });
 
       return res.status(500).json({
         status: "failed",
@@ -216,5 +156,6 @@ if (require.main === module) {
 module.exports = {
   app,
   createApp,
+  generateScriptWithVertex,
   requireAdmin,
 };

--- a/src/generation.js
+++ b/src/generation.js
@@ -1,0 +1,272 @@
+const { VertexAI } = require("@google-cloud/vertexai");
+
+const PROVIDER = "vertex-ai";
+const DEFAULT_LOCATION = "europe-west1";
+const DEFAULT_MODEL_NAME = "gemini-2.5-flash";
+const GENERATION_INCOMPLETE_CODE = "GENERATION_INCOMPLETE";
+const GENERATION_INCOMPLETE_MESSAGE =
+  "The model response ended before all required sections were completed";
+
+const GENERATION_CONFIG = Object.freeze({
+  maxOutputTokens: 4096,
+  temperature: 0.7,
+  topP: 0.9,
+  candidateCount: 1,
+});
+
+const REQUIRED_SECTIONS = Object.freeze([
+  "Hook",
+  "Concept",
+  "Script",
+  "CTA",
+  "Caption",
+  "Hashtags",
+  "Filming instructions",
+]);
+
+const NON_RETRYABLE_REASONS = new Set([
+  "SAFETY",
+  "RECITATION",
+  "BLOCKLIST",
+  "PROHIBITED_CONTENT",
+  "SPII",
+]);
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^()|[\]\\{}$]/g, "\\$&");
+}
+
+const SECTION_LABEL_PATTERN = new RegExp(
+  "^[ \\t]*(" +
+    REQUIRED_SECTIONS.map(escapeRegExp).join("|") +
+    ")(?:[ \\t]*\\([^\\r\\n]*\\))?[ \\t]*(?::[ \\t]*(.*))?$",
+  "gim"
+);
+
+class GenerationIncompleteError extends Error {
+  constructor({ finishReason = null, missingSections = [], retryable, metadata }) {
+    super(GENERATION_INCOMPLETE_MESSAGE);
+    this.name = "GenerationIncompleteError";
+    this.code = GENERATION_INCOMPLETE_CODE;
+    this.details = {
+      finish_reason: finishReason,
+      missing_sections: [...missingSections],
+      retryable,
+    };
+    this.metadata = metadata;
+  }
+}
+
+function buildSystemInstruction(branding) {
+  return [
+    "You are " + branding.appName + " Phase 1 script generation engine.",
+    "",
+    "You MUST return a COMPLETE structured output.",
+    "",
+    "STRICT RULES:",
+    "- Do NOT stop early",
+    "- ALL sections must be included",
+    "- If any section is missing, the response is invalid",
+    "",
+    "Return ONLY plain text. No JSON. No markdown.",
+    "",
+    "FOR SHORT-FORM VIDEO OUTPUT:",
+    "You MUST include ALL sections below:",
+    "",
+    "Hook (1 sentence)",
+    "Concept (1-2 sentences)",
+    "Script (MAX 120 words)",
+    "CTA (1 line)",
+    "Caption (MAX 2 lines)",
+    "Hashtags (MAX 8 hashtags)",
+    "Filming instructions (bullet points, MAX 6 bullets)",
+    "",
+    "Each section must be clearly labeled.",
+    "",
+    "Keep everything concise and complete.",
+    "",
+    "Do not exceed limits.",
+    "Do not truncate sections.",
+  ].join("\n");
+}
+
+function assembleCandidateText(candidate) {
+  const parts = candidate?.content?.parts;
+  if (!Array.isArray(parts)) {
+    return "";
+  }
+
+  return parts
+    .map((part) => (typeof part?.text === "string" ? part.text : ""))
+    .join("")
+    .trim();
+}
+
+function findMissingSections(text) {
+  if (!text) {
+    return [...REQUIRED_SECTIONS];
+  }
+
+  const matches = [];
+  SECTION_LABEL_PATTERN.lastIndex = 0;
+
+  for (const match of text.matchAll(SECTION_LABEL_PATTERN)) {
+    const section = REQUIRED_SECTIONS.find(
+      (required) => required.toLowerCase() === match[1].toLowerCase()
+    );
+    matches.push({
+      section,
+      index: match.index,
+      end: match.index + match[0].length,
+      inlineContent: match[2] || "",
+    });
+  }
+
+  return REQUIRED_SECTIONS.filter((section) => {
+    const matchIndex = matches.findIndex((match) => match.section === section);
+    if (matchIndex === -1) {
+      return true;
+    }
+
+    const match = matches[matchIndex];
+    const nextMatch = matches.find((candidate) => candidate.index > match.index);
+    const followingContent = text.slice(
+      match.end,
+      nextMatch ? nextMatch.index : text.length
+    );
+
+    return !(match.inlineContent + "\n" + followingContent).trim();
+  });
+}
+
+function safeTokenCount(value) {
+  return Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function normalizeCompletionMetadata(response, candidate, model) {
+  const usage = response?.usageMetadata || {};
+
+  return {
+    provider: PROVIDER,
+    model,
+    finish_reason:
+      typeof candidate?.finishReason === "string"
+        ? candidate.finishReason
+        : null,
+    prompt_block_reason:
+      typeof response?.promptFeedback?.blockReason === "string"
+        ? response.promptFeedback.blockReason
+        : null,
+    prompt_token_count: safeTokenCount(usage.promptTokenCount),
+    output_token_count: safeTokenCount(usage.candidatesTokenCount),
+    total_token_count: safeTokenCount(usage.totalTokenCount),
+    required_sections_complete: false,
+    incomplete_reason: null,
+  };
+}
+
+function incompleteReason({ finishReason, text, missingSections }) {
+  if (finishReason === "MAX_TOKENS") {
+    return "TOKEN_EXHAUSTION";
+  }
+  if (!text) {
+    return "EMPTY_OUTPUT";
+  }
+  if (finishReason && finishReason !== "STOP") {
+    return "PROVIDER_STOP";
+  }
+  if (missingSections.length > 0) {
+    return "MISSING_SECTIONS";
+  }
+  return null;
+}
+
+function isRetryable({ finishReason, promptBlockReason }) {
+  return !(
+    NON_RETRYABLE_REASONS.has(finishReason) ||
+    NON_RETRYABLE_REASONS.has(promptBlockReason)
+  );
+}
+
+function validateGenerationResponse(response, { model = DEFAULT_MODEL_NAME } = {}) {
+  const candidate = response?.candidates?.[0];
+  const text = assembleCandidateText(candidate);
+  const missingSections = findMissingSections(text);
+  const metadata = normalizeCompletionMetadata(response, candidate, model);
+  const reason = incompleteReason({
+    finishReason: metadata.finish_reason,
+    text,
+    missingSections,
+  });
+
+  metadata.incomplete_reason = reason;
+  metadata.required_sections_complete = missingSections.length === 0;
+
+  if (reason) {
+    throw new GenerationIncompleteError({
+      finishReason: metadata.finish_reason,
+      missingSections,
+      retryable: isRetryable({
+        finishReason: metadata.finish_reason,
+        promptBlockReason: metadata.prompt_block_reason,
+      }),
+      metadata,
+    });
+  }
+
+  return { text, metadata };
+}
+
+async function generateScriptWithVertex(
+  compiledPrompt,
+  {
+    branding,
+    projectId =
+      process.env.GOOGLE_CLOUD_PROJECT ||
+      process.env.GCLOUD_PROJECT ||
+      process.env.GCP_PROJECT,
+    location = process.env.VERTEX_LOCATION || DEFAULT_LOCATION,
+    modelName = process.env.VERTEX_MODEL || DEFAULT_MODEL_NAME,
+    VertexAIClient = VertexAI,
+  } = {}
+) {
+  if (!projectId) {
+    throw new Error("Missing GOOGLE_CLOUD_PROJECT environment variable");
+  }
+
+  const vertexAI = new VertexAIClient({ project: projectId, location });
+  const model = vertexAI.getGenerativeModel({
+    model: modelName,
+    systemInstruction: {
+      role: "system",
+      parts: [{ text: buildSystemInstruction(branding) }],
+    },
+    generationConfig: GENERATION_CONFIG,
+  });
+
+  const result = await model.generateContent({
+    contents: [
+      {
+        role: "user",
+        parts: [{ text: compiledPrompt }],
+      },
+    ],
+  });
+
+  return validateGenerationResponse(result.response, { model: modelName });
+}
+
+module.exports = {
+  DEFAULT_LOCATION,
+  DEFAULT_MODEL_NAME,
+  GENERATION_CONFIG,
+  GENERATION_INCOMPLETE_CODE,
+  GENERATION_INCOMPLETE_MESSAGE,
+  GenerationIncompleteError,
+  REQUIRED_SECTIONS,
+  assembleCandidateText,
+  buildSystemInstruction,
+  findMissingSections,
+  generateScriptWithVertex,
+  validateGenerationResponse,
+};

--- a/test/generation.test.js
+++ b/test/generation.test.js
@@ -1,0 +1,321 @@
+const assert = require("node:assert/strict");
+const { beforeEach, describe, it } = require("node:test");
+const request = require("supertest");
+const { brandingConfig } = require("../src/config/branding");
+const {
+  GENERATION_CONFIG,
+  GENERATION_INCOMPLETE_MESSAGE,
+  GenerationIncompleteError,
+  REQUIRED_SECTIONS,
+  generateScriptWithVertex,
+  validateGenerationResponse,
+} = require("../src/generation");
+const { createApp } = require("../index");
+
+const ADMIN_KEY = "generation-completion-test-key";
+
+const COMPLETE_OUTPUT = [
+  "Hook: Stop scrolling and make planning work for you.",
+  "Concept: Show a simple plan becoming a finished post.",
+  "Script: Start with one clear goal, choose the next action, and publish consistently.",
+  "CTA: Try the planning workflow today.",
+  "Caption: A practical plan turns ideas into progress.",
+  "Hashtags: #Planning #Content #SmallBusiness",
+  "Filming instructions:",
+  "- Open on a close-up of the written plan.",
+].join("\n");
+
+const silentLogger = {
+  info() {},
+  warn() {},
+  error() {},
+};
+
+function providerResponse({
+  text = COMPLETE_OUTPUT,
+  parts,
+  finishReason = "STOP",
+  usageMetadata = {
+    promptTokenCount: 800,
+    candidatesTokenCount: 220,
+    totalTokenCount: 1020,
+  },
+} = {}) {
+  return {
+    candidates: [
+      {
+        index: 0,
+        finishReason,
+        content: {
+          role: "model",
+          parts: parts || [{ text }],
+        },
+      },
+    ],
+    usageMetadata,
+  };
+}
+
+function validRequest(compiledPrompt = "Create a concise video script") {
+  return {
+    execution_id: "execution_001",
+    user_id: "user_001",
+    project_id: "project_001",
+    compiled_prompt: compiledPrompt,
+  };
+}
+
+function admin(client) {
+  return client.set("x-admin-key", ADMIN_KEY);
+}
+
+beforeEach(() => {
+  process.env.ADMIN_KEY = ADMIN_KEY;
+});
+
+describe("generation response completion validation", () => {
+  it("accepts a complete response and normalises safe completion metadata", () => {
+    const result = validateGenerationResponse(providerResponse(), {
+      model: "gemini-test",
+    });
+
+    assert.equal(result.text, COMPLETE_OUTPUT);
+    assert.deepEqual(result.metadata, {
+      provider: "vertex-ai",
+      model: "gemini-test",
+      finish_reason: "STOP",
+      prompt_block_reason: null,
+      prompt_token_count: 800,
+      output_token_count: 220,
+      total_token_count: 1020,
+      required_sections_complete: true,
+      incomplete_reason: null,
+    });
+  });
+
+  it("rejects a max-token stop even when every required section is present", () => {
+    assert.throws(
+      () =>
+        validateGenerationResponse(
+          providerResponse({ finishReason: "MAX_TOKENS" })
+        ),
+      (error) => {
+        assert.ok(error instanceof GenerationIncompleteError);
+        assert.deepEqual(error.details, {
+          finish_reason: "MAX_TOKENS",
+          missing_sections: [],
+          retryable: true,
+        });
+        assert.equal(error.metadata.incomplete_reason, "TOKEN_EXHAUSTION");
+        return true;
+      }
+    );
+  });
+
+  it("rejects output that is missing required sections", () => {
+    const partial = [
+      "Hook: Make planning simpler.",
+      "Concept: Demonstrate one useful workflow.",
+      "Script: We connect planning",
+    ].join("\n");
+
+    assert.throws(
+      () => validateGenerationResponse(providerResponse({ text: partial })),
+      (error) => {
+        assert.deepEqual(error.details.missing_sections, [
+          "CTA",
+          "Caption",
+          "Hashtags",
+          "Filming instructions",
+        ]);
+        assert.equal(error.metadata.incomplete_reason, "MISSING_SECTIONS");
+        return true;
+      }
+    );
+  });
+
+  it("rejects an empty candidate list and empty candidate text", async (t) => {
+    await t.test("empty candidate list", () => {
+      assert.throws(
+        () => validateGenerationResponse({ candidates: [] }),
+        (error) => {
+          assert.equal(error.details.finish_reason, null);
+          assert.deepEqual(error.details.missing_sections, REQUIRED_SECTIONS);
+          assert.equal(error.metadata.incomplete_reason, "EMPTY_OUTPUT");
+          return true;
+        }
+      );
+    });
+
+    await t.test("empty candidate text", () => {
+      assert.throws(
+        () => validateGenerationResponse(providerResponse({ text: "" })),
+        (error) => {
+          assert.deepEqual(error.details.missing_sections, REQUIRED_SECTIONS);
+          assert.equal(error.metadata.incomplete_reason, "EMPTY_OUTPUT");
+          return true;
+        }
+      );
+    });
+  });
+
+  it("assembles every text part in the selected candidate", () => {
+    const splitAt = COMPLETE_OUTPUT.indexOf("Script:") + 12;
+    const result = validateGenerationResponse(
+      providerResponse({
+        parts: [
+          { text: COMPLETE_OUTPUT.slice(0, splitAt) },
+          { text: COMPLETE_OUTPUT.slice(splitAt) },
+        ],
+      })
+    );
+
+    assert.equal(result.text, COMPLETE_OUTPUT);
+  });
+});
+
+describe("Vertex generation configuration", () => {
+  it("uses the bounded generation settings and validates the mocked response", async () => {
+    let clientOptions;
+    let modelOptions;
+    let requestBody;
+
+    class FakeVertexAI {
+      constructor(options) {
+        clientOptions = options;
+      }
+
+      getGenerativeModel(options) {
+        modelOptions = options;
+        return {
+          async generateContent(body) {
+            requestBody = body;
+            return { response: providerResponse() };
+          },
+        };
+      }
+    }
+
+    const result = await generateScriptWithVertex("enriched prompt", {
+      branding: brandingConfig,
+      projectId: "test-project",
+      location: "europe-west1",
+      modelName: "gemini-test",
+      VertexAIClient: FakeVertexAI,
+    });
+
+    assert.deepEqual(clientOptions, {
+      project: "test-project",
+      location: "europe-west1",
+    });
+    assert.deepEqual(modelOptions.generationConfig, GENERATION_CONFIG);
+    assert.equal(modelOptions.model, "gemini-test");
+    assert.match(
+      modelOptions.systemInstruction.parts[0].text,
+      /You MUST return a COMPLETE structured output/
+    );
+    assert.deepEqual(requestBody, {
+      contents: [
+        {
+          role: "user",
+          parts: [{ text: "enriched prompt" }],
+        },
+      ],
+    });
+    assert.equal(result.text, COMPLETE_OUTPUT);
+  });
+});
+
+describe("generate-script completion contract", () => {
+  it("preserves authentication and validation before invoking the provider", async () => {
+    let calls = 0;
+    const app = createApp({
+      scriptGenerator: async () => {
+        calls += 1;
+        throw new Error("provider should not be called");
+      },
+      logger: silentLogger,
+    });
+
+    const unauthorised = await request(app)
+      .post("/generate-script")
+      .send(validRequest());
+    assert.equal(unauthorised.status, 403);
+    assert.deepEqual(unauthorised.body, { error: "Forbidden" });
+
+    const invalid = await admin(
+      request(app).post("/generate-script").send({})
+    );
+    assert.equal(invalid.status, 400);
+    assert.deepEqual(invalid.body, {
+      status: "failed",
+      error: "Missing required fields",
+      script_body: "",
+    });
+    assert.equal(calls, 0);
+  });
+
+  it("handles a long enriched prompt with a deterministic mocked output", async () => {
+    const longPrompt = "Detailed audience and business context. ".repeat(500);
+    let receivedPrompt;
+    const app = createApp({
+      scriptGenerator: async (compiledPrompt) => {
+        receivedPrompt = compiledPrompt;
+        return validateGenerationResponse(providerResponse());
+      },
+      logger: silentLogger,
+    });
+
+    const response = await admin(
+      request(app).post("/generate-script").send(validRequest(longPrompt))
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(receivedPrompt, longPrompt);
+    assert.deepEqual(response.body, {
+      status: "completed",
+      execution_id: "execution_001",
+      script_body: COMPLETE_OUTPUT,
+    });
+  });
+
+  it("returns the stable incomplete error and never returns partial text as success", async () => {
+    const partial = [
+      "Hook: Make planning simpler.",
+      "Concept: Demonstrate one useful workflow.",
+      "Script: We connect planning",
+    ].join("\n");
+    const app = createApp({
+      scriptGenerator: async () =>
+        validateGenerationResponse(
+          providerResponse({ text: partial, finishReason: "MAX_TOKENS" })
+        ),
+      logger: silentLogger,
+    });
+
+    const response = await admin(
+      request(app).post("/generate-script").send(validRequest())
+    );
+
+    assert.equal(response.status, 502);
+    assert.deepEqual(response.body, {
+      status: "failed",
+      error: {
+        code: "GENERATION_INCOMPLETE",
+        message: GENERATION_INCOMPLETE_MESSAGE,
+        details: {
+          finish_reason: "MAX_TOKENS",
+          missing_sections: [
+            "CTA",
+            "Caption",
+            "Hashtags",
+            "Filming instructions",
+          ],
+          retryable: true,
+        },
+      },
+      script_body: "",
+    });
+    assert.doesNotMatch(JSON.stringify(response.body), /We connect planning/);
+  });
+});


### PR DESCRIPTION
Closes #22.

## Root cause

The application treated any non-empty candidate text as a completed generation. Although `@google-cloud/vertexai` 1.12.0 exposes `finishReason`, prompt feedback, and prompt/output/total token usage, the endpoint discarded those fields and performed no required-section validation.

The incident's provider-side stop reason cannot be recovered because the old implementation did not record completion metadata. The configured 2,048-token output cap was a possible termination mechanism, but it is not asserted as the historical cause. The response extractor already joined every text part in candidate 0, and no API serialization clipping was present.

## Changes

- set an explicit single-candidate, bounded 4,096-token generation configuration;
- assemble every text part in the selected candidate;
- normalize safe finish, block, and usage metadata for logs;
- reject max-token stops, empty output, non-`STOP` finish reasons, and missing/empty required sections;
- return a stable HTTP 502 `GENERATION_INCOMPLETE` response without partial text;
- preserve the successful response, authentication, validation, and generic failure contracts;
- add no automatic retries;
- document the completion contract.

## Validation

- Node 22.23.2 / npm 10.9.8
- `npm ci --no-audit --no-fund`
- `npm test`: 42 passed, 0 failed
- JavaScript syntax checks: passed
- `git diff --check`: passed
- all provider tests are mocked; no live Vertex calls
- production Cloud Run health checked read-only before changes; no deployment or cloud mutation
- [CI run #24](https://github.com/shirrie01/bizgenie-api/actions/runs/31062092081): passed on exact head `12aea8740d07d7d047ef1a82228af895411a7410`
  - Node 22 tests and syntax: passed
  - Docker build, Node 22 verification, and route-contract smoke tests: passed
  - Google Buildpack build, Node 22 verification, and route-contract smoke tests: passed