### PR TITLE
BG-OUT-001: Add modular prompt compiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,12 @@ function createApp({
       execution_id,
       user_id,
       project_id,
-      compiled_prompt
+      compiled_prompt,
+      platform,
+      script_type,
+      audience,
+      intent_stage,
+      voice_style
     } = req.body;
 
     try {
@@ -70,6 +75,13 @@ function createApp({
 
       const generation = await scriptGenerator(compiled_prompt, {
         branding: resolvedBranding,
+        promptOptions: {
+          platform,
+          scriptType: script_type,
+          audience,
+          intent: intent_stage,
+          voice: voice_style,
+        },
       });
 
       logger.info?.("generation completed", {

--- a/src/generation.js
+++ b/src/generation.js
@@ -1,4 +1,5 @@
 const { VertexAI } = require("@google-cloud/vertexai");
+const { buildSystemRole, compilePrompt } = require("./prompts/compiler");
 
 const PROVIDER = "vertex-ai";
 const DEFAULT_LOCATION = "europe-west1";
@@ -58,36 +59,7 @@ class GenerationIncompleteError extends Error {
 }
 
 function buildSystemInstruction(branding) {
-  return [
-    "You are " + branding.appName + " Phase 1 script generation engine.",
-    "",
-    "You MUST return a COMPLETE structured output.",
-    "",
-    "STRICT RULES:",
-    "- Do NOT stop early",
-    "- ALL sections must be included",
-    "- If any section is missing, the response is invalid",
-    "",
-    "Return ONLY plain text. No JSON. No markdown.",
-    "",
-    "FOR SHORT-FORM VIDEO OUTPUT:",
-    "You MUST include ALL sections below:",
-    "",
-    "Hook (1 sentence)",
-    "Concept (1-2 sentences)",
-    "Script (MAX 120 words)",
-    "CTA (1 line)",
-    "Caption (MAX 2 lines)",
-    "Hashtags (MAX 8 hashtags)",
-    "Filming instructions (bullet points, MAX 6 bullets)",
-    "",
-    "Each section must be clearly labeled.",
-    "",
-    "Keep everything concise and complete.",
-    "",
-    "Do not exceed limits.",
-    "Do not truncate sections.",
-  ].join("\n");
+  return buildSystemRole(branding.appName);
 }
 
 function assembleCandidateText(candidate) {
@@ -218,9 +190,10 @@ function validateGenerationResponse(response, { model = DEFAULT_MODEL_NAME } = {
 }
 
 async function generateScriptWithVertex(
-  compiledPrompt,
+  userContext,
   {
     branding,
+    promptOptions = {},
     projectId =
       process.env.GOOGLE_CLOUD_PROJECT ||
       process.env.GCLOUD_PROJECT ||
@@ -235,6 +208,11 @@ async function generateScriptWithVertex(
   }
 
   const vertexAI = new VertexAIClient({ project: projectId, location });
+  const compiledPrompt = compilePrompt({
+    ...promptOptions,
+    appName: branding.appName,
+    userContext,
+  });
   const model = vertexAI.getGenerativeModel({
     model: modelName,
     systemInstruction: {

--- a/src/prompts/audiences/b2b.js
+++ b/src/prompts/audiences/b2b.js
@@ -1,0 +1,4 @@
+module.exports = Object.freeze([
+  "Address a professional audience in terms of its work, constraints, and desired business outcome.",
+  "Prioritise useful specificity, credibility, and the cost of leaving the problem unresolved.",
+]);

--- a/src/prompts/audiences/consumer.js
+++ b/src/prompts/audiences/consumer.js
@@ -1,0 +1,4 @@
+module.exports = Object.freeze([
+  "Address an individual in plain, relatable language.",
+  "Emphasise the practical or emotional benefit in everyday life without overstating it.",
+]);

--- a/src/prompts/compiler.js
+++ b/src/prompts/compiler.js
@@ -1,0 +1,94 @@
+const instagram = require("./platforms/instagram");
+const linkedin = require("./platforms/linkedin");
+const tiktok = require("./platforms/tiktok");
+const problemSolution = require("./scriptTypes/problemSolution");
+const comparison = require("./scriptTypes/comparison");
+const ugc = require("./scriptTypes/ugc");
+const b2b = require("./audiences/b2b");
+const consumer = require("./audiences/consumer");
+const professional = require("./voices/professional");
+const bold = require("./voices/bold");
+const friendly = require("./voices/friendly");
+const cold = require("./intent/cold");
+const awareness = require("./intent/awareness");
+const customer = require("./intent/customer");
+const loyalty = require("./intent/loyalty");
+const qualityRules = require("./quality/qualityRules");
+const outputContract = require("./quality/outputContract");
+
+const PLATFORM_RULES = Object.freeze({ instagram, linkedin, tiktok });
+const SCRIPT_TYPE_RULES = Object.freeze({
+  problemsolution: problemSolution,
+  comparison,
+  ugc,
+});
+const AUDIENCE_RULES = Object.freeze({ b2b, consumer });
+const VOICE_RULES = Object.freeze({ professional, bold, friendly });
+const INTENT_RULES = Object.freeze({ cold, awareness, customer, loyalty });
+
+const BRAND_CONTEXT_PLACEHOLDER = Object.freeze([
+  "Brand context is not available in this version.",
+  "This section is the documented injection point for future Brand Brain context.",
+]);
+
+function normaliseOption(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  return value.trim().toLowerCase().replace(/[\s_-]+/g, "") || null;
+}
+
+function selectRules(options, value) {
+  const key = normaliseOption(value);
+  return key ? options[key] : undefined;
+}
+
+function section(label, content) {
+  return ["[" + label + "]", ...content].join("\n");
+}
+
+function buildSystemRole(appName = "BizGenie") {
+  return "You are " + appName + " Phase 1 script generation engine.";
+}
+
+function selectedSection(label, options, value) {
+  const rules = selectRules(options, value);
+  return rules ? section(label, rules) : null;
+}
+
+function compilePrompt({
+  appName = "BizGenie",
+  platform,
+  scriptType,
+  audience,
+  intent,
+  voice,
+  userContext = "",
+} = {}) {
+  const sections = [
+    section("SYSTEM ROLE", [
+      buildSystemRole(appName),
+    ]),
+    selectedSection("PLATFORM RULES", PLATFORM_RULES, platform),
+    selectedSection("SCRIPT TYPE RULES", SCRIPT_TYPE_RULES, scriptType),
+    selectedSection("AUDIENCE RULES", AUDIENCE_RULES, audience),
+    selectedSection("INTENT RULES", INTENT_RULES, intent),
+    selectedSection("VOICE RULES", VOICE_RULES, voice),
+    // Placeholder only: Brand Brain lookup and injection are intentionally out of scope.
+    section("BRAND CONTEXT", BRAND_CONTEXT_PLACEHOLDER),
+    section("USER CONTEXT", [
+      typeof userContext === "string" ? userContext : "",
+    ]),
+    section("QUALITY RULES", qualityRules),
+    section("OUTPUT CONTRACT", outputContract),
+  ];
+
+  return sections.filter(Boolean).join("\n\n");
+}
+
+module.exports = {
+  BRAND_CONTEXT_PLACEHOLDER,
+  buildSystemRole,
+  compilePrompt,
+};

--- a/src/prompts/intent/awareness.js
+++ b/src/prompts/intent/awareness.js
@@ -1,0 +1,4 @@
+module.exports = Object.freeze([
+  "Optimise for recognition, understanding, and recall rather than an immediate sale.",
+  "Deliver one memorable idea that gives the viewer a reason to notice the brand again.",
+]);

--- a/src/prompts/intent/cold.js
+++ b/src/prompts/intent/cold.js
@@ -1,0 +1,4 @@
+module.exports = Object.freeze([
+  "Assume the viewer has no prior relationship with the brand.",
+  "Earn attention by making relevance clear quickly and use a low-friction next step.",
+]);

--- a/src/prompts/intent/customer.js
+++ b/src/prompts/intent/customer.js
@@ -1,0 +1,4 @@
+module.exports = Object.freeze([
+  "Speak to an existing customer who already understands the core offer.",
+  "Help them realise more value through a relevant use, feature, or next action.",
+]);

--- a/src/prompts/intent/loyalty.js
+++ b/src/prompts/intent/loyalty.js
@@ -1,0 +1,4 @@
+module.exports = Object.freeze([
+  "Reinforce the relationship with an existing, engaged customer.",
+  "Show appreciation and create a genuine reason for repeat use, advocacy, or community participation.",
+]);

--- a/src/prompts/platforms/instagram.js
+++ b/src/prompts/platforms/instagram.js
@@ -1,0 +1,5 @@
+module.exports = Object.freeze([
+  "Optimise for an Instagram Reels viewing experience.",
+  "Open with a visually clear, scroll-stopping hook in the first moments.",
+  "Keep the language concise and make the idea worth saving or sharing.",
+]);

--- a/src/prompts/platforms/linkedin.js
+++ b/src/prompts/platforms/linkedin.js
@@ -1,0 +1,5 @@
+module.exports = Object.freeze([
+  "Optimise for a LinkedIn feed viewing experience.",
+  "Make the professional or business relevance clear immediately.",
+  "Prefer credible, substantive language and avoid empty engagement bait.",
+]);

--- a/src/prompts/platforms/tiktok.js
+++ b/src/prompts/platforms/tiktok.js
@@ -1,0 +1,5 @@
+module.exports = Object.freeze([
+  "Optimise for a native TikTok viewing experience.",
+  "Hook the viewer immediately with conversational spoken language and quick visual movement.",
+  "Do not depend on a specific trend, sound, or effect to make the script work.",
+]);

--- a/src/prompts/quality/outputContract.js
+++ b/src/prompts/quality/outputContract.js
@@ -1,0 +1,11 @@
+module.exports = Object.freeze([
+  "Return only plain text. Do not return JSON or markdown.",
+  "Include every section below with its label:",
+  "Hook (1 sentence)",
+  "Concept (1-2 sentences)",
+  "Script (MAX 120 words)",
+  "CTA (1 line)",
+  "Caption (MAX 2 lines)",
+  "Hashtags (MAX 8 hashtags)",
+  "Filming instructions (bullet points, MAX 6 bullets)",
+]);

--- a/src/prompts/quality/qualityRules.js
+++ b/src/prompts/quality/qualityRules.js
@@ -1,0 +1,6 @@
+module.exports = Object.freeze([
+  "Return a complete response and do not stop early.",
+  "Include every required section; a missing or empty section makes the response invalid.",
+  "Keep every section concise and complete.",
+  "Do not exceed the stated limits or truncate a section.",
+]);

--- a/src/prompts/scriptTypes/comparison.js
+++ b/src/prompts/scriptTypes/comparison.js
@@ -1,0 +1,4 @@
+module.exports = Object.freeze([
+  "Compare the alternatives on clear, relevant criteria.",
+  "Keep the contrast fair and specific, then make the useful takeaway obvious.",
+]);

--- a/src/prompts/scriptTypes/problemSolution.js
+++ b/src/prompts/scriptTypes/problemSolution.js
@@ -1,0 +1,4 @@
+module.exports = Object.freeze([
+  "Establish one recognisable problem before introducing the solution.",
+  "Connect the solution directly to the problem and show the practical change it creates.",
+]);

--- a/src/prompts/scriptTypes/ugc.js
+++ b/src/prompts/scriptTypes/ugc.js
@@ -1,0 +1,4 @@
+module.exports = Object.freeze([
+  "Write in a natural first-person creator style.",
+  "Use believable observations and concrete experience rather than polished advertising claims.",
+]);

--- a/src/prompts/voices/bold.js
+++ b/src/prompts/voices/bold.js
@@ -1,0 +1,4 @@
+module.exports = Object.freeze([
+  "Use a decisive, energetic, and direct voice.",
+  "Make strong points without hype, aggression, or unsupported claims.",
+]);

--- a/src/prompts/voices/friendly.js
+++ b/src/prompts/voices/friendly.js
@@ -1,0 +1,4 @@
+module.exports = Object.freeze([
+  "Use a warm, approachable, and conversational voice.",
+  "Sound helpful and human without becoming vague or overly casual.",
+]);

--- a/src/prompts/voices/professional.js
+++ b/src/prompts/voices/professional.js
@@ -1,0 +1,4 @@
+module.exports = Object.freeze([
+  "Use a polished, confident, and precise voice.",
+  "Stay accessible and avoid unnecessary jargon or stiffness.",
+]);

--- a/test/generation.test.js
+++ b/test/generation.test.js
@@ -284,6 +284,71 @@ describe("generate-script completion contract", () => {
     });
   });
 
+  it("wires structured request selections through the real prompt compiler", async () => {
+    let requestBody;
+
+    class FakeVertexAI {
+      getGenerativeModel() {
+        return {
+          async generateContent(body) {
+            requestBody = body;
+            return { response: providerResponse() };
+          },
+        };
+      }
+    }
+
+    const app = createApp({
+      scriptGenerator: (userContext, options) =>
+        generateScriptWithVertex(userContext, {
+          ...options,
+          projectId: "test-project",
+          modelName: "gemini-test",
+          VertexAIClient: FakeVertexAI,
+        }),
+      logger: silentLogger,
+    });
+    const userContext = "Explain how a planning workflow saves time.";
+
+    const response = await admin(
+      request(app)
+        .post("/generate-script")
+        .send({
+          ...validRequest(userContext),
+          platform: "LinkedIn",
+          script_type: "Problem Solution",
+          audience: "B2B",
+          intent_stage: "Cold",
+          voice_style: "Professional",
+        })
+    );
+
+    assert.equal(response.status, 200);
+    const finalPrompt = requestBody.contents[0].parts[0].text;
+    assert.match(
+      finalPrompt,
+      /\[PLATFORM RULES\]\nOptimise for a LinkedIn feed viewing experience\./
+    );
+    assert.match(
+      finalPrompt,
+      /\[SCRIPT TYPE RULES\]\nEstablish one recognisable problem before introducing the solution\./
+    );
+    assert.match(
+      finalPrompt,
+      /\[AUDIENCE RULES\]\nAddress a professional audience in terms of its work, constraints, and desired business outcome\./
+    );
+    assert.match(
+      finalPrompt,
+      /\[INTENT RULES\]\nAssume the viewer has no prior relationship with the brand\./
+    );
+    assert.match(
+      finalPrompt,
+      /\[VOICE RULES\]\nUse a polished, confident, and precise voice\./
+    );
+    assert.match(finalPrompt, /\[USER CONTEXT\]/);
+    assert.match(finalPrompt, new RegExp(userContext.replaceAll(".", "\\.")));
+  });
+
   it("returns the stable incomplete error and never returns partial text as success", async () => {
     const partial = [
       "Hook: Make planning simpler.",

--- a/test/generation.test.js
+++ b/test/generation.test.js
@@ -2,6 +2,7 @@ const assert = require("node:assert/strict");
 const { beforeEach, describe, it } = require("node:test");
 const request = require("supertest");
 const { brandingConfig } = require("../src/config/branding");
+const { compilePrompt } = require("../src/prompts/compiler");
 const {
   GENERATION_CONFIG,
   GENERATION_INCOMPLETE_MESSAGE,
@@ -210,15 +211,19 @@ describe("Vertex generation configuration", () => {
     });
     assert.deepEqual(modelOptions.generationConfig, GENERATION_CONFIG);
     assert.equal(modelOptions.model, "gemini-test");
-    assert.match(
+    assert.equal(
       modelOptions.systemInstruction.parts[0].text,
-      /You MUST return a COMPLETE structured output/
+      "You are BizGenie Phase 1 script generation engine."
     );
+    const expectedPrompt = compilePrompt({
+      appName: brandingConfig.appName,
+      userContext: "enriched prompt",
+    });
     assert.deepEqual(requestBody, {
       contents: [
         {
           role: "user",
-          parts: [{ text: "enriched prompt" }],
+          parts: [{ text: expectedPrompt }],
         },
       ],
     });

--- a/test/prompts.test.js
+++ b/test/prompts.test.js
@@ -1,0 +1,115 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+const {
+  BRAND_CONTEXT_PLACEHOLDER,
+  compilePrompt,
+} = require("../src/prompts/compiler");
+
+const ALL_OPTIONS = Object.freeze({
+  appName: "BizGenie",
+  platform: "instagram",
+  scriptType: "problemSolution",
+  audience: "b2b",
+  intent: "cold",
+  voice: "professional",
+  userContext: "Explain how a planning workflow saves time.",
+});
+
+function position(prompt, label) {
+  const index = prompt.indexOf("[" + label + "]");
+  assert.notEqual(index, -1, label + " should be present");
+  return index;
+}
+
+describe("prompt compiler", () => {
+  it("assembles sections in the required order", () => {
+    const prompt = compilePrompt(ALL_OPTIONS);
+    const labels = [
+      "SYSTEM ROLE",
+      "PLATFORM RULES",
+      "SCRIPT TYPE RULES",
+      "AUDIENCE RULES",
+      "INTENT RULES",
+      "VOICE RULES",
+      "BRAND CONTEXT",
+      "USER CONTEXT",
+      "QUALITY RULES",
+      "OUTPUT CONTRACT",
+    ];
+
+    const positions = labels.map((label) => position(prompt, label));
+    assert.deepEqual(positions, [...positions].sort((a, b) => a - b));
+  });
+
+  it("selects every supported platform", () => {
+    assert.match(compilePrompt({ platform: "instagram" }), /Instagram Reels/);
+    assert.match(compilePrompt({ platform: "LinkedIn" }), /LinkedIn feed/);
+    assert.match(compilePrompt({ platform: "tiktok" }), /native TikTok/);
+  });
+
+  it("selects every supported script type", () => {
+    assert.match(
+      compilePrompt({ scriptType: "problem_solution" }),
+      /recognisable problem/
+    );
+    assert.match(compilePrompt({ scriptType: "comparison" }), /alternatives/);
+    assert.match(compilePrompt({ scriptType: "ugc" }), /first-person creator/);
+  });
+
+  it("selects every supported audience", () => {
+    assert.match(compilePrompt({ audience: "B2B" }), /business outcome/);
+    assert.match(compilePrompt({ audience: "consumer" }), /individual/);
+  });
+
+  it("selects every supported voice", () => {
+    assert.match(compilePrompt({ voice: "professional" }), /polished/);
+    assert.match(compilePrompt({ voice: "bold" }), /decisive/);
+    assert.match(compilePrompt({ voice: "friendly" }), /warm/);
+  });
+
+  it("selects every supported intent", () => {
+    assert.match(compilePrompt({ intent: "cold" }), /no prior relationship/);
+    assert.match(compilePrompt({ intent: "awareness" }), /recognition/);
+    assert.match(compilePrompt({ intent: "customer" }), /existing customer/);
+    assert.match(compilePrompt({ intent: "loyalty" }), /engaged customer/);
+  });
+
+  it("omits unselected optional rule sections", () => {
+    const prompt = compilePrompt({ userContext: "Keep this context." });
+
+    assert.doesNotMatch(prompt, /\[PLATFORM RULES\]/);
+    assert.doesNotMatch(prompt, /\[SCRIPT TYPE RULES\]/);
+    assert.doesNotMatch(prompt, /\[AUDIENCE RULES\]/);
+    assert.doesNotMatch(prompt, /\[INTENT RULES\]/);
+    assert.doesNotMatch(prompt, /\[VOICE RULES\]/);
+    assert.match(prompt, /Keep this context\./);
+  });
+
+  it("ignores unknown option values without injecting unsupported rules", () => {
+    const prompt = compilePrompt({
+      platform: "unknown-platform",
+      scriptType: "unknown-script",
+      audience: "unknown-audience",
+      intent: "unknown-intent",
+      voice: "unknown-voice",
+    });
+
+    assert.doesNotMatch(prompt, /\[PLATFORM RULES\]/);
+    assert.doesNotMatch(prompt, /\[SCRIPT TYPE RULES\]/);
+    assert.doesNotMatch(prompt, /\[AUDIENCE RULES\]/);
+    assert.doesNotMatch(prompt, /\[INTENT RULES\]/);
+    assert.doesNotMatch(prompt, /\[VOICE RULES\]/);
+    assert.doesNotMatch(prompt, /unknown-/);
+  });
+
+  it("keeps Brand Brain as a documented placeholder only", () => {
+    const prompt = compilePrompt(ALL_OPTIONS);
+    for (const line of BRAND_CONTEXT_PLACEHOLDER) {
+      assert.match(prompt, new RegExp(line.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    }
+  });
+
+  it("returns byte-for-byte deterministic output", () => {
+    assert.equal(compilePrompt(ALL_OPTIONS), compilePrompt({ ...ALL_OPTIONS }));
+  });
+});


### PR DESCRIPTION
## What changed

- added a deterministic, modular prompt compiler under `src/prompts/`
- added rules for the currently supported platforms, script types, audiences, intents, and voices
- separated quality rules and the existing plain-text output contract
- added a documented Brand Brain placeholder without implementing brand context
- routed the existing Vertex generation flow through the compiler without changing the API request or response contracts

## Why

The generation prompt was assembled as one hard-coded instruction block. Modular sections make prompt quality easier to test, maintain, and extend while preserving the current API surface and completion validation.

## Impact

The endpoint, authentication, billing boundaries, provider, generation settings, and response handling remain unchanged. Prompt composition is now deterministic and internally extensible. Make, Glide, Google Sheets, environment configuration, and deployment are untouched.

## Validation

- focused prompt compiler tests: 10 passed
- complete test suite: 52 passed
- compiler selection, order, missing/unknown values, determinism, Brand Brain placeholder, and generation-flow regression covered