### PR TITLE
BG-CORE-001A: Brand Brain context foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,154 @@ The tests do not call Vertex AI and do not require Google Cloud credentials.
 The authenticated routes require the `x-admin-key` header to exactly match the
 `ADMIN_KEY` environment variable.
 
+## Brand Brain context foundation
+
+Brand Brain is the persistent brand-intelligence layer of the future Company
+Brain. It acts as a digital employee handbook for approved identity, voice,
+audience, commercial, competitor, and selectively relevant visual context. The
+V1 foundation is deliberately small: it provides strict records, a replaceable
+repository contract, deterministic tenancy-aware resolution, bounded prompt
+compilation, and protected administration endpoints.
+
+The implementation is isolated under `src/brand-brain/`:
+
+- `schema.js` defines the strict, bounded V1 record and administration input.
+- `repository.js` defines `getByBrandId`, `getByProjectAndBrand`, and `upsert`.
+- `contextResolver.js` enforces project ownership and approved status.
+- `contextCompiler.js` produces deterministic prompt-ready context.
+- `router.js` exposes the smallest protected testability surface.
+- `index.js` is the domain's public module boundary.
+
+The default repository is process-local and in-memory. It stores defensive
+copies and can be replaced by a permanent repository later without changing the
+prompt compiler. No database or persistence-provider dependency is introduced.
+
+### V1 record
+
+Stored Brand Brains have this shape. `brand_id`, `project_id`, `name`, and all
+four metadata fields are required in the stored record; every domain section
+and each field within it is optional, so partial Brand Brains are valid.
+
+```yaml
+brand_id: string
+project_id: string
+name: string
+identity:
+  description: string
+  mission: string
+  vision: string
+  values: string[]
+  positioning: string
+voice:
+  tone: string
+  writing_style: string
+  personality: string
+  preferred_terms: string[]
+  prohibited_terms: string[]
+audience:
+  summary: string
+  pain_points: string[]
+  goals: string[]
+  objections: string[]
+  buying_triggers: string[]
+commercial:
+  differentiators: string[]
+  primary_cta: string
+  approved_claims: string[]
+  prohibited_claims: string[]
+competitors:
+  names: string[]
+  notes: string
+visual:
+  colours: string[]
+  fonts: string[]
+  photography_style: string
+metadata:
+  version: positive integer
+  status: draft | approved | archived
+  created_at: ISO 8601 timestamp
+  updated_at: ISO 8601 timestamp
+```
+
+Identifiers are limited to 128 characters and a safe identifier character set;
+names to 200 characters; prose fields to 2,000 characters; general lists to 20
+items of 300 characters; and approved/prohibited claim and prohibited-term
+lists to 12 items of 200 characters. Objects are strict and unknown fields,
+wrong structures, invalid timestamps, unsupported statuses, and oversized
+values are rejected rather than coerced into another shape.
+
+### Administration
+
+Both administration endpoints reuse the existing `x-admin-key` middleware:
+
+- `PUT /_admin/brand-brains/:brand_id` creates or replaces a Brand Brain.
+- `GET /_admin/brand-brains/:brand_id` retrieves a Brand Brain.
+
+Mutation is not publicly exposed. The route identifier is authoritative and
+any supplied body `brand_id` must match it. On first upsert, metadata defaults
+to version `1`, status `approved`, and server timestamps; supplied valid
+metadata may override those defaults. Upserting an existing `brand_id` for
+another `project_id` returns `BRAND_PROJECT_CONFLICT` and cannot transfer
+ownership implicitly. Missing records return `BRAND_BRAIN_NOT_FOUND`.
+Validation failures use the existing stable `VALIDATION_ERROR` response shape.
+
+### Generation and resolution
+
+`POST /generate-script` now accepts optional `brand_id`. No existing caller has
+to provide it.
+
+- With no `brand_id`, the existing prompt and generation behaviour are
+  preserved, including the documented Brand Context placeholder.
+- With an unknown `brand_id`, generation continues with that same fallback.
+- With an approved record belonging to the request's `project_id`, compiled
+  Brand Brain context replaces the placeholder.
+- With a project mismatch, draft record, or archived record, no Brand Brain
+  content is injected and generation continues with the fallback.
+
+The assembly order remains System role, Platform, Script type, Audience,
+Intent, Voice, Brand Brain, User context, Quality rules, and Output contract.
+Brand Brain supplements rather than replaces the existing structured modules
+or the caller's `compiled_prompt`.
+
+### Context budget and relevance
+
+Compiled Brand Brain context has an 8,000-character maximum. Empty sections and
+metadata are omitted. Sections are selected deterministically in this priority
+order: identity/positioning, voice, audience, differentiators, claims,
+preferred CTA, competitors, then visual context. Visual context is considered
+only for Instagram, TikTok, or UGC generation.
+
+When the complete context would exceed the budget, lower-priority sections are
+dropped whole; content is never cut mid-value. Brand name, prohibited terms,
+and prohibited claims are reserved before optional content, so governance
+language is never shortened in a way that changes its meaning. Schema bounds
+ensure that reserved governance content fits the configured default budget.
+This is deterministic section selection, not semantic or vector retrieval.
+
+### Security and tenancy
+
+Generation lookup always uses the `(project_id, brand_id)` pair. A `brand_id`
+match alone is insufficient, so one project's context cannot enter another
+project's prompt. Unknown identifiers return no data. Repository values are
+defensively copied, project ownership cannot be reassigned through upsert, and
+only `approved` records resolve. Generation success/error logs contain safe
+execution and provider metadata only; prompts and Brand Brain content are not
+written to generic logs.
+
+### Explicit future extension points
+
+The repository interface is the persistence seam. The resolver/compiler can
+later accept richer relevance signals or retrieval results without changing
+the Prompt Compiler contract. New Company Brain domains can remain separate
+context providers and be composed at the same controlled injection boundary.
+
+This foundation does **not** implement permanent production persistence, Brand
+Brain onboarding UI, the Genie interview, voice onboarding, automatic website
+ingestion, social ingestion, document ingestion, vector/semantic retrieval,
+Product Brain, Customer Brain, Campaign Brain, Learning Brain, Trend
+Intelligence, Opportunity Engine, or automated performance learning. Those
+remain separately reviewed roadmap components.
+
 ## Mission Control foundation
 
 Mission Control is an internal, in-memory foundation for reviews and Red Team

--- a/index.js
+++ b/index.js
@@ -7,6 +7,11 @@ console.log(`🚀 ${brandingConfig.marketingStrings.apiBooting}`);
 
 const express = require("express");
 const {
+  InMemoryBrandBrainRepository,
+  createBrandBrainRouter,
+  resolveBrandBrainContext,
+} = require("./src/brand-brain");
+const {
   InMemoryMissionControlRepository,
   createMissionControlRouter,
 } = require("./src/mission-control");
@@ -29,6 +34,7 @@ function requireAdmin(req, res, next) {
 
 function createApp({
   missionControlRepository = new InMemoryMissionControlRepository(),
+  brandBrainRepository = new InMemoryBrandBrainRepository(),
   branding = brandingConfig,
   scriptGenerator = generateScriptWithVertex,
   logger = console,
@@ -51,6 +57,12 @@ function createApp({
     createMissionControlRouter({ repository: missionControlRepository })
   );
 
+  app.use(
+    "/_admin/brand-brains",
+    requireAdmin,
+    createBrandBrainRouter({ repository: brandBrainRepository })
+  );
+
   app.post("/generate-script", requireAdmin, async (req, res) => {
     const {
       execution_id,
@@ -61,7 +73,8 @@ function createApp({
       script_type,
       audience,
       intent_stage,
-      voice_style
+      voice_style,
+      brand_id,
     } = req.body;
 
     try {
@@ -73,6 +86,19 @@ function createApp({
         });
       }
 
+      const brandContext = resolveBrandBrainContext({
+        repository: brandBrainRepository,
+        projectId: project_id,
+        brandId: brand_id,
+        generationContext: {
+          platform,
+          scriptType: script_type,
+          audience,
+          intent: intent_stage,
+          voice: voice_style,
+        },
+      });
+
       const generation = await scriptGenerator(compiled_prompt, {
         branding: resolvedBranding,
         promptOptions: {
@@ -81,6 +107,7 @@ function createApp({
           audience,
           intent: intent_stage,
           voice: voice_style,
+          brandContext,
         },
       });
 
@@ -130,7 +157,8 @@ function createApp({
 
   app.use((error, req, res, next) => {
     if (
-      req.path.startsWith("/_admin/mission-control") &&
+      (req.path.startsWith("/_admin/mission-control") ||
+        req.path.startsWith("/_admin/brand-brains")) &&
       error instanceof SyntaxError &&
       error.status === 400 &&
       Object.hasOwn(error, "body")

--- a/src/brand-brain/contextCompiler.js
+++ b/src/brand-brain/contextCompiler.js
@@ -1,0 +1,152 @@
+const DEFAULT_BRAND_CONTEXT_MAX_CHARS = 8000;
+
+function hasText(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
+function line(label, value, { priority, order, required = false } = {}) {
+  if (!hasText(value)) {
+    return null;
+  }
+  return { text: `${label}:\n${value}`, priority, order, required };
+}
+
+function listLine(label, values, options) {
+  if (!Array.isArray(values) || values.length === 0) {
+    return null;
+  }
+  return line(label, values.map((value) => `- ${value}`).join("\n"), options);
+}
+
+function visualContextIsUseful(generationContext = {}) {
+  const platform = String(generationContext.platform || "").toLowerCase();
+  const scriptType = String(
+    generationContext.scriptType || generationContext.script_type || ""
+  ).toLowerCase();
+  return ["instagram", "tiktok"].includes(platform) || scriptType === "ugc";
+}
+
+function candidateSections(record, generationContext) {
+  const identity = record.identity || {};
+  const voice = record.voice || {};
+  const audience = record.audience || {};
+  const commercial = record.commercial || {};
+  const competitors = record.competitors || {};
+  const visual = record.visual || {};
+
+  const sections = [
+    line("Brand", record.name, { priority: 1, order: 1, required: true }),
+    line("Description", identity.description, { priority: 1, order: 2 }),
+    line("Mission", identity.mission, { priority: 1, order: 3 }),
+    line("Vision", identity.vision, { priority: 1, order: 4 }),
+    listLine("Values", identity.values, { priority: 1, order: 5 }),
+    line("Positioning", identity.positioning, { priority: 1, order: 6 }),
+    line("Tone", voice.tone, { priority: 2, order: 7 }),
+    line("Writing style", voice.writing_style, { priority: 2, order: 8 }),
+    line("Personality", voice.personality, { priority: 2, order: 9 }),
+    listLine("Preferred terms", voice.preferred_terms, {
+      priority: 2,
+      order: 10,
+    }),
+    listLine("Do not say", voice.prohibited_terms, {
+      priority: 2,
+      order: 11,
+      required: true,
+    }),
+    line("Audience", audience.summary, { priority: 3, order: 12 }),
+    listLine("Audience pain points", audience.pain_points, {
+      priority: 3,
+      order: 13,
+    }),
+    listLine("Audience goals", audience.goals, { priority: 3, order: 14 }),
+    listLine("Audience objections", audience.objections, {
+      priority: 3,
+      order: 15,
+    }),
+    listLine("Buying triggers", audience.buying_triggers, {
+      priority: 3,
+      order: 16,
+    }),
+    listLine("Differentiators", commercial.differentiators, {
+      priority: 4,
+      order: 17,
+    }),
+    listLine("Approved claims", commercial.approved_claims, {
+      priority: 5,
+      order: 18,
+    }),
+    listLine("Prohibited claims", commercial.prohibited_claims, {
+      priority: 5,
+      order: 19,
+      required: true,
+    }),
+    line("CTA preference", commercial.primary_cta, {
+      priority: 6,
+      order: 20,
+    }),
+    listLine("Competitors", competitors.names, { priority: 7, order: 21 }),
+    line("Competitor notes", competitors.notes, { priority: 7, order: 22 }),
+  ].filter(Boolean);
+
+  if (visualContextIsUseful(generationContext)) {
+    sections.push(
+      ...[
+        listLine("Brand colours", visual.colours, { priority: 8, order: 23 }),
+        listLine("Brand fonts", visual.fonts, { priority: 8, order: 24 }),
+        line("Photography style", visual.photography_style, {
+          priority: 8,
+          order: 25,
+        }),
+      ].filter(Boolean)
+    );
+  }
+
+  return sections;
+}
+
+function outputLength(sections) {
+  return ["[BRAND BRAIN]", ...sections.map(({ text }) => text)].join("\n\n")
+    .length;
+}
+
+function compileBrandContext(
+  record,
+  {
+    maxChars = DEFAULT_BRAND_CONTEXT_MAX_CHARS,
+    generationContext = {},
+  } = {}
+) {
+  if (!record) {
+    return "";
+  }
+
+  const candidates = candidateSections(record, generationContext);
+  const selected = candidates.filter(({ required }) => required);
+
+  for (const candidate of [...candidates]
+    .filter(({ required }) => !required)
+    .sort((a, b) => a.priority - b.priority || a.order - b.order)) {
+    if (outputLength([...selected, candidate]) <= maxChars) {
+      selected.push(candidate);
+    }
+  }
+
+  const ordered = selected.sort((a, b) => a.order - b.order);
+  const output = ["[BRAND BRAIN]", ...ordered.map(({ text }) => text)].join(
+    "\n\n"
+  );
+
+  if (output.length > maxChars) {
+    throw new RangeError(
+      "Brand Brain context budget is too small for required governance content"
+    );
+  }
+
+  return output;
+}
+
+module.exports = {
+  DEFAULT_BRAND_CONTEXT_MAX_CHARS,
+  compileBrandContext,
+  visualContextIsUseful,
+};

--- a/src/brand-brain/contextResolver.js
+++ b/src/brand-brain/contextResolver.js
@@ -1,0 +1,29 @@
+const { compileBrandContext } = require("./contextCompiler");
+
+function resolveBrandBrainContext({
+  repository,
+  projectId,
+  brandId,
+  generationContext = {},
+  maxChars,
+}) {
+  if (
+    !repository ||
+    typeof projectId !== "string" ||
+    typeof brandId !== "string" ||
+    !brandId.trim()
+  ) {
+    return "";
+  }
+
+  const record = repository.getByProjectAndBrand(projectId, brandId);
+  if (!record || record.metadata.status !== "approved") {
+    return "";
+  }
+
+  return compileBrandContext(record, { generationContext, maxChars });
+}
+
+module.exports = {
+  resolveBrandBrainContext,
+};

--- a/src/brand-brain/errors.js
+++ b/src/brand-brain/errors.js
@@ -1,0 +1,68 @@
+class BrandBrainError extends Error {
+  constructor(status, code, message, details) {
+    super(message);
+    this.name = this.constructor.name;
+    this.status = status;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+class BrandBrainValidationError extends BrandBrainError {
+  constructor(details) {
+    super(400, "VALIDATION_ERROR", "Request validation failed", details);
+  }
+}
+
+class BrandBrainNotFoundError extends BrandBrainError {
+  constructor(brandId) {
+    super(404, "BRAND_BRAIN_NOT_FOUND", `Brand Brain '${brandId}' was not found`);
+  }
+}
+
+class BrandBrainOwnershipError extends BrandBrainError {
+  constructor(brandId) {
+    super(
+      409,
+      "BRAND_PROJECT_CONFLICT",
+      `Brand Brain '${brandId}' belongs to a different project`
+    );
+  }
+}
+
+function formatZodIssues(issues) {
+  return issues.map((issue) => ({
+    path: issue.path.join("."),
+    code: issue.code,
+    message: issue.message,
+  }));
+}
+
+function sendBrandBrainError(error, res) {
+  if (!(error instanceof BrandBrainError)) {
+    return false;
+  }
+
+  const body = {
+    error: {
+      code: error.code,
+      message: error.message,
+    },
+  };
+
+  if (error.details) {
+    body.error.details = error.details;
+  }
+
+  res.status(error.status).json(body);
+  return true;
+}
+
+module.exports = {
+  BrandBrainError,
+  BrandBrainNotFoundError,
+  BrandBrainOwnershipError,
+  BrandBrainValidationError,
+  formatZodIssues,
+  sendBrandBrainError,
+};

--- a/src/brand-brain/index.js
+++ b/src/brand-brain/index.js
@@ -1,0 +1,21 @@
+const {
+  DEFAULT_BRAND_CONTEXT_MAX_CHARS,
+  compileBrandContext,
+} = require("./contextCompiler");
+const { resolveBrandBrainContext } = require("./contextResolver");
+const {
+  BrandBrainRepository,
+  InMemoryBrandBrainRepository,
+} = require("./repository");
+const { createBrandBrainRouter } = require("./router");
+const schemas = require("./schema");
+
+module.exports = {
+  BrandBrainRepository,
+  DEFAULT_BRAND_CONTEXT_MAX_CHARS,
+  InMemoryBrandBrainRepository,
+  compileBrandContext,
+  createBrandBrainRouter,
+  resolveBrandBrainContext,
+  ...schemas,
+};

--- a/src/brand-brain/repository.js
+++ b/src/brand-brain/repository.js
@@ -1,0 +1,53 @@
+const { BrandBrainOwnershipError } = require("./errors");
+
+class BrandBrainRepository {
+  getByBrandId(_brandId) {
+    throw new Error("BrandBrainRepository.getByBrandId is not implemented");
+  }
+
+  getByProjectAndBrand(_projectId, _brandId) {
+    throw new Error(
+      "BrandBrainRepository.getByProjectAndBrand is not implemented"
+    );
+  }
+
+  upsert(_record) {
+    throw new Error("BrandBrainRepository.upsert is not implemented");
+  }
+}
+
+class InMemoryBrandBrainRepository extends BrandBrainRepository {
+  constructor() {
+    super();
+    this.records = new Map();
+  }
+
+  getByBrandId(brandId) {
+    const record = this.records.get(brandId);
+    return record ? structuredClone(record) : null;
+  }
+
+  getByProjectAndBrand(projectId, brandId) {
+    const record = this.records.get(brandId);
+    if (!record || record.project_id !== projectId) {
+      return null;
+    }
+    return structuredClone(record);
+  }
+
+  upsert(record) {
+    const existing = this.records.get(record.brand_id);
+    if (existing && existing.project_id !== record.project_id) {
+      throw new BrandBrainOwnershipError(record.brand_id);
+    }
+
+    const stored = structuredClone(record);
+    this.records.set(stored.brand_id, stored);
+    return structuredClone(stored);
+  }
+}
+
+module.exports = {
+  BrandBrainRepository,
+  InMemoryBrandBrainRepository,
+};

--- a/src/brand-brain/router.js
+++ b/src/brand-brain/router.js
@@ -1,0 +1,85 @@
+const express = require("express");
+const { BrandBrainSchema, UpsertBrandBrainSchema } = require("./schema");
+const {
+  BrandBrainNotFoundError,
+  BrandBrainValidationError,
+  formatZodIssues,
+  sendBrandBrainError,
+} = require("./errors");
+
+function parse(schema, value) {
+  const result = schema.safeParse(value);
+  if (!result.success) {
+    throw new BrandBrainValidationError(formatZodIssues(result.error.issues));
+  }
+  return result.data;
+}
+
+function createBrandBrainRouter({ repository, now = () => new Date() }) {
+  if (!repository) {
+    throw new Error("A Brand Brain repository is required");
+  }
+
+  const router = express.Router();
+
+  router.put("/:brandId", (req, res, next) => {
+    try {
+      const input = parse(UpsertBrandBrainSchema, req.body);
+      if (input.brand_id && input.brand_id !== req.params.brandId) {
+        throw new BrandBrainValidationError([
+          {
+            path: "brand_id",
+            code: "custom",
+            message: "brand_id must match the brandId route parameter",
+          },
+        ]);
+      }
+
+      const existing = repository.getByBrandId(req.params.brandId);
+      const timestamp = now().toISOString();
+      const record = parse(BrandBrainSchema, {
+        ...input,
+        brand_id: req.params.brandId,
+        metadata: {
+          version: input.metadata?.version ?? existing?.metadata.version ?? 1,
+          status:
+            input.metadata?.status ?? existing?.metadata.status ?? "approved",
+          created_at:
+            existing?.metadata.created_at ??
+            input.metadata?.created_at ??
+            timestamp,
+          updated_at: input.metadata?.updated_at ?? timestamp,
+        },
+      });
+
+      return res.json({ brand_brain: repository.upsert(record) });
+    } catch (error) {
+      return next(error);
+    }
+  });
+
+  router.get("/:brandId", (req, res, next) => {
+    try {
+      const record = repository.getByBrandId(req.params.brandId);
+      if (!record) {
+        throw new BrandBrainNotFoundError(req.params.brandId);
+      }
+      return res.json({ brand_brain: record });
+    } catch (error) {
+      return next(error);
+    }
+  });
+
+  router.use((error, _req, res, next) => {
+    if (sendBrandBrainError(error, res)) {
+      return;
+    }
+    next(error);
+  });
+
+  return router;
+}
+
+module.exports = {
+  createBrandBrainRouter,
+};

--- a/src/brand-brain/schema.js
+++ b/src/brand-brain/schema.js
@@ -1,0 +1,134 @@
+const { z } = require("zod");
+
+const IDENTIFIER_MAX_LENGTH = 128;
+const NAME_MAX_LENGTH = 200;
+const PROSE_MAX_LENGTH = 2000;
+const LIST_ITEM_MAX_LENGTH = 300;
+const GOVERNANCE_ITEM_MAX_LENGTH = 200;
+const LIST_MAX_ITEMS = 20;
+const GOVERNANCE_MAX_ITEMS = 12;
+
+const identifier = z
+  .string()
+  .trim()
+  .min(1)
+  .max(IDENTIFIER_MAX_LENGTH)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/, "Invalid identifier");
+const name = z.string().trim().min(1).max(NAME_MAX_LENGTH);
+const prose = z.string().trim().min(1).max(PROSE_MAX_LENGTH);
+const listItem = z.string().trim().min(1).max(LIST_ITEM_MAX_LENGTH);
+const governanceItem = z
+  .string()
+  .trim()
+  .min(1)
+  .max(GOVERNANCE_ITEM_MAX_LENGTH);
+const list = z.array(listItem).max(LIST_MAX_ITEMS);
+const governanceList = z
+  .array(governanceItem)
+  .max(GOVERNANCE_MAX_ITEMS);
+const timestamp = z.string().datetime({ offset: true });
+
+const brandBrainStatuses = ["draft", "approved", "archived"];
+
+const IdentitySchema = z
+  .object({
+    description: prose.optional(),
+    mission: prose.optional(),
+    vision: prose.optional(),
+    values: list.optional(),
+    positioning: prose.optional(),
+  })
+  .strict();
+
+const VoiceSchema = z
+  .object({
+    tone: prose.optional(),
+    writing_style: prose.optional(),
+    personality: prose.optional(),
+    preferred_terms: list.optional(),
+    prohibited_terms: governanceList.optional(),
+  })
+  .strict();
+
+const AudienceSchema = z
+  .object({
+    summary: prose.optional(),
+    pain_points: list.optional(),
+    goals: list.optional(),
+    objections: list.optional(),
+    buying_triggers: list.optional(),
+  })
+  .strict();
+
+const CommercialSchema = z
+  .object({
+    differentiators: list.optional(),
+    primary_cta: prose.optional(),
+    approved_claims: governanceList.optional(),
+    prohibited_claims: governanceList.optional(),
+  })
+  .strict();
+
+const CompetitorsSchema = z
+  .object({
+    names: list.optional(),
+    notes: prose.optional(),
+  })
+  .strict();
+
+const VisualSchema = z
+  .object({
+    colours: list.optional(),
+    fonts: list.optional(),
+    photography_style: prose.optional(),
+  })
+  .strict();
+
+const MetadataSchema = z
+  .object({
+    version: z.number().int().positive().max(1_000_000),
+    status: z.enum(brandBrainStatuses),
+    created_at: timestamp,
+    updated_at: timestamp,
+  })
+  .strict();
+
+const BrandBrainSchema = z
+  .object({
+    brand_id: identifier,
+    project_id: identifier,
+    name,
+    identity: IdentitySchema.optional(),
+    voice: VoiceSchema.optional(),
+    audience: AudienceSchema.optional(),
+    commercial: CommercialSchema.optional(),
+    competitors: CompetitorsSchema.optional(),
+    visual: VisualSchema.optional(),
+    metadata: MetadataSchema,
+  })
+  .strict();
+
+const UpsertBrandBrainSchema = BrandBrainSchema.extend({
+  brand_id: identifier.optional(),
+  metadata: MetadataSchema.partial().strict().optional(),
+});
+
+module.exports = {
+  AudienceSchema,
+  BrandBrainSchema,
+  CommercialSchema,
+  CompetitorsSchema,
+  GOVERNANCE_ITEM_MAX_LENGTH,
+  GOVERNANCE_MAX_ITEMS,
+  IDENTIFIER_MAX_LENGTH,
+  IdentitySchema,
+  LIST_ITEM_MAX_LENGTH,
+  LIST_MAX_ITEMS,
+  MetadataSchema,
+  NAME_MAX_LENGTH,
+  PROSE_MAX_LENGTH,
+  UpsertBrandBrainSchema,
+  VisualSchema,
+  VoiceSchema,
+  brandBrainStatuses,
+};

--- a/src/prompts/compiler.js
+++ b/src/prompts/compiler.js
@@ -64,6 +64,7 @@ function compilePrompt({
   audience,
   intent,
   voice,
+  brandContext = "",
   userContext = "",
 } = {}) {
   const sections = [
@@ -75,8 +76,9 @@ function compilePrompt({
     selectedSection("AUDIENCE RULES", AUDIENCE_RULES, audience),
     selectedSection("INTENT RULES", INTENT_RULES, intent),
     selectedSection("VOICE RULES", VOICE_RULES, voice),
-    // Placeholder only: Brand Brain lookup and injection are intentionally out of scope.
-    section("BRAND CONTEXT", BRAND_CONTEXT_PLACEHOLDER),
+    typeof brandContext === "string" && brandContext
+      ? brandContext
+      : section("BRAND CONTEXT", BRAND_CONTEXT_PLACEHOLDER),
     section("USER CONTEXT", [
       typeof userContext === "string" ? userContext : "",
     ]),

--- a/test/brand-brain-admin.test.js
+++ b/test/brand-brain-admin.test.js
@@ -1,0 +1,135 @@
+const assert = require("node:assert/strict");
+const { beforeEach, describe, it } = require("node:test");
+const request = require("supertest");
+const { createApp } = require("../index");
+
+const ADMIN_KEY = "brand-brain-admin-test-key";
+
+function admin(client) {
+  return client.set("x-admin-key", ADMIN_KEY);
+}
+
+function validInput(overrides = {}) {
+  return {
+    project_id: "project_001",
+    name: "BizGenie",
+    identity: { positioning: "AI Brand Operating System." },
+    voice: { prohibited_terms: ["magic button"] },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  process.env.ADMIN_KEY = ADMIN_KEY;
+});
+
+describe("Brand Brain administration", () => {
+  it("rejects unauthorised upsert and retrieval", async () => {
+    const app = createApp();
+    const upsert = await request(app)
+      .put("/_admin/brand-brains/brand_001")
+      .send(validInput());
+    const get = await request(app).get("/_admin/brand-brains/brand_001");
+
+    assert.equal(upsert.status, 403);
+    assert.deepEqual(upsert.body, { error: "Forbidden" });
+    assert.equal(get.status, 403);
+    assert.deepEqual(get.body, { error: "Forbidden" });
+  });
+
+  it("authorises upsert and retrieval with server metadata defaults", async () => {
+    const app = createApp();
+    const created = await admin(
+      request(app)
+        .put("/_admin/brand-brains/brand_001")
+        .send(validInput())
+    );
+
+    assert.equal(created.status, 200);
+    assert.equal(created.body.brand_brain.brand_id, "brand_001");
+    assert.equal(created.body.brand_brain.project_id, "project_001");
+    assert.deepEqual(created.body.brand_brain.metadata, {
+      version: 1,
+      status: "approved",
+      created_at: created.body.brand_brain.metadata.created_at,
+      updated_at: created.body.brand_brain.metadata.updated_at,
+    });
+
+    const fetched = await admin(
+      request(app).get("/_admin/brand-brains/brand_001")
+    );
+    assert.equal(fetched.status, 200);
+    assert.deepEqual(fetched.body, created.body);
+  });
+
+  it("rejects malformed records with structured validation details", async () => {
+    const response = await admin(
+      request(createApp())
+        .put("/_admin/brand-brains/brand_001")
+        .send({ project_id: "bad project", voice: [] })
+    );
+
+    assert.equal(response.status, 400);
+    assert.equal(response.body.error.code, "VALIDATION_ERROR");
+    assert.equal(response.body.error.message, "Request validation failed");
+    assert.deepEqual(
+      response.body.error.details.map(({ path }) => path),
+      ["project_id", "name", "voice"]
+    );
+  });
+
+  it("rejects malformed JSON with the shared structured response", async () => {
+    const response = await admin(
+      request(createApp())
+        .put("/_admin/brand-brains/brand_001")
+        .set("content-type", "application/json")
+        .send('{"project_id":')
+    );
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(response.body, {
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Request validation failed",
+        details: [
+          {
+            path: "",
+            code: "invalid_json",
+            message: "Malformed JSON request body",
+          },
+        ],
+      },
+    });
+  });
+
+  it("rejects route/body identity mismatch and project reassignment", async () => {
+    const app = createApp();
+    const mismatch = await admin(
+      request(app)
+        .put("/_admin/brand-brains/brand_001")
+        .send(validInput({ brand_id: "brand_002" }))
+    );
+    assert.equal(mismatch.status, 400);
+
+    await admin(
+      request(app)
+        .put("/_admin/brand-brains/brand_001")
+        .send(validInput())
+    );
+    const reassignment = await admin(
+      request(app)
+        .put("/_admin/brand-brains/brand_001")
+        .send(validInput({ project_id: "project_002" }))
+    );
+    assert.equal(reassignment.status, 409);
+    assert.equal(reassignment.body.error.code, "BRAND_PROJECT_CONFLICT");
+  });
+
+  it("returns a structured 404 for an unknown Brand Brain", async () => {
+    const response = await admin(
+      request(createApp()).get("/_admin/brand-brains/brand_missing")
+    );
+    assert.equal(response.status, 404);
+    assert.equal(response.body.error.code, "BRAND_BRAIN_NOT_FOUND");
+  });
+});

--- a/test/brand-brain-context.test.js
+++ b/test/brand-brain-context.test.js
@@ -1,0 +1,167 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+const {
+  InMemoryBrandBrainRepository,
+  compileBrandContext,
+  resolveBrandBrainContext,
+} = require("../src/brand-brain");
+
+function record(overrides = {}) {
+  return {
+    brand_id: "brand_001",
+    project_id: "project_001",
+    name: "BizGenie",
+    identity: {
+      positioning: "AI Brand Operating System for ambitious businesses.",
+    },
+    voice: {
+      tone: "Confident, intelligent, and commercially sharp.",
+      preferred_terms: ["Brand Brain"],
+      prohibited_terms: ["magic button"],
+    },
+    audience: {
+      summary: "Founder-led ecommerce businesses.",
+      goals: ["Publish better content consistently"],
+    },
+    commercial: {
+      differentiators: ["Persistent approved context"],
+      primary_cta: "Build your Brand Brain.",
+      approved_claims: ["Uses approved brand context"],
+      prohibited_claims: ["Guaranteed revenue"],
+    },
+    competitors: {
+      names: ["Example competitor"],
+      notes: "Avoid unsupported comparisons.",
+    },
+    visual: {
+      colours: ["Midnight blue"],
+      photography_style: "Natural workplace photography.",
+    },
+    metadata: {
+      version: 1,
+      status: "approved",
+      created_at: "2026-08-08T09:00:00.000Z",
+      updated_at: "2026-08-08T09:00:00.000Z",
+    },
+    ...overrides,
+  };
+}
+
+function position(context, label) {
+  const index = context.indexOf(label);
+  assert.notEqual(index, -1, `${label} should be present`);
+  return index;
+}
+
+describe("Brand Brain context compiler", () => {
+  it("produces byte-for-byte deterministic output and omits metadata", () => {
+    const first = compileBrandContext(record());
+    const second = compileBrandContext(structuredClone(record()));
+    assert.equal(first, second);
+    assert.doesNotMatch(first, /created_at|updated_at|version/);
+  });
+
+  it("omits empty sections and preserves meaningful ordering", () => {
+    const context = compileBrandContext(
+      record({
+        identity: { positioning: "Clear positioning." },
+        voice: undefined,
+        audience: undefined,
+        commercial: undefined,
+        competitors: undefined,
+        visual: undefined,
+      })
+    );
+
+    assert.match(context, /^\[BRAND BRAIN\]/);
+    assert.ok(position(context, "Brand:") < position(context, "Positioning:"));
+    assert.doesNotMatch(context, /Tone:|Audience:|Approved claims:/);
+  });
+
+  it("keeps preferred, prohibited, approved, and prohibited claims distinct", () => {
+    const context = compileBrandContext(record());
+    const labels = [
+      "Preferred terms:",
+      "Do not say:",
+      "Approved claims:",
+      "Prohibited claims:",
+    ];
+    const positions = labels.map((label) => position(context, label));
+    assert.deepEqual(positions, [...positions].sort((a, b) => a - b));
+  });
+
+  it("stays within budget by dropping low-priority sections whole", () => {
+    const context = compileBrandContext(record(), { maxChars: 250 });
+    assert.ok(context.length <= 250);
+    assert.match(context, /Do not say:\n- magic button/);
+    assert.match(context, /Prohibited claims:\n- Guaranteed revenue/);
+    assert.doesNotMatch(context, /Competitor notes/);
+  });
+
+  it("includes visual context only for a relevant generation", () => {
+    assert.doesNotMatch(compileBrandContext(record()), /Brand colours/);
+    assert.match(
+      compileBrandContext(record(), {
+        generationContext: { platform: "instagram" },
+      }),
+      /Brand colours:\n- Midnight blue/
+    );
+  });
+});
+
+describe("Brand Brain context resolver", () => {
+  it("returns no context for absent or unknown brand IDs", () => {
+    const repository = new InMemoryBrandBrainRepository();
+    repository.upsert(record());
+    assert.equal(
+      resolveBrandBrainContext({ repository, projectId: "project_001" }),
+      ""
+    );
+    assert.equal(
+      resolveBrandBrainContext({
+        repository,
+        projectId: "project_001",
+        brandId: "brand_missing",
+      }),
+      ""
+    );
+  });
+
+  it("resolves approved context only for the owning project", () => {
+    const repository = new InMemoryBrandBrainRepository();
+    repository.upsert(record());
+    assert.match(
+      resolveBrandBrainContext({
+        repository,
+        projectId: "project_001",
+        brandId: "brand_001",
+      }),
+      /\[BRAND BRAIN\]/
+    );
+    assert.equal(
+      resolveBrandBrainContext({
+        repository,
+        projectId: "project_002",
+        brandId: "brand_001",
+      }),
+      ""
+    );
+  });
+
+  it("does not resolve draft or archived records", () => {
+    for (const status of ["draft", "archived"]) {
+      const repository = new InMemoryBrandBrainRepository();
+      repository.upsert(
+        record({ metadata: { ...record().metadata, status } })
+      );
+      assert.equal(
+        resolveBrandBrainContext({
+          repository,
+          projectId: "project_001",
+          brandId: "brand_001",
+        }),
+        ""
+      );
+    }
+  });
+});

--- a/test/brand-brain-generation.test.js
+++ b/test/brand-brain-generation.test.js
@@ -1,0 +1,249 @@
+const assert = require("node:assert/strict");
+const { beforeEach, describe, it } = require("node:test");
+const request = require("supertest");
+const {
+  InMemoryBrandBrainRepository,
+} = require("../src/brand-brain");
+const { generateScriptWithVertex } = require("../src/generation");
+const { createApp } = require("../index");
+
+const ADMIN_KEY = "brand-brain-generation-test-key";
+const COMPLETE_OUTPUT = [
+  "Hook: Stop scrolling and make planning work for you.",
+  "Concept: Show a simple plan becoming a finished post.",
+  "Script: Start with one clear goal, choose the next action, and publish consistently.",
+  "CTA: Try the planning workflow today.",
+  "Caption: A practical plan turns ideas into progress.",
+  "Hashtags: #Planning #Content #SmallBusiness",
+  "Filming instructions:",
+  "- Open on a close-up of the written plan.",
+].join("\n");
+
+function record() {
+  return {
+    brand_id: "brand_001",
+    project_id: "project_001",
+    name: "Sensitive Brand Name",
+    identity: {
+      positioning: "A confidential market position.",
+    },
+    voice: {
+      tone: "Confident and precise.",
+      prohibited_terms: ["magic button"],
+    },
+    commercial: {
+      prohibited_claims: ["Guaranteed revenue"],
+    },
+    metadata: {
+      version: 1,
+      status: "approved",
+      created_at: "2026-08-08T09:00:00.000Z",
+      updated_at: "2026-08-08T09:00:00.000Z",
+    },
+  };
+}
+
+function validRequest(overrides = {}) {
+  return {
+    execution_id: "execution_001",
+    user_id: "user_001",
+    project_id: "project_001",
+    compiled_prompt: "Explain how a planning workflow saves time.",
+    ...overrides,
+  };
+}
+
+function providerResponse() {
+  return {
+    candidates: [
+      {
+        finishReason: "STOP",
+        content: { parts: [{ text: COMPLETE_OUTPUT }] },
+      },
+    ],
+  };
+}
+
+function appWithCapturedPrompt(repository, capture, logger) {
+  class FakeVertexAI {
+    getGenerativeModel() {
+      return {
+        async generateContent(body) {
+          capture.value = body.contents[0].parts[0].text;
+          return { response: providerResponse() };
+        },
+      };
+    }
+  }
+
+  return createApp({
+    brandBrainRepository: repository,
+    scriptGenerator: (userContext, options) =>
+      generateScriptWithVertex(userContext, {
+        ...options,
+        projectId: "test-project",
+        modelName: "gemini-test",
+        VertexAIClient: FakeVertexAI,
+      }),
+    logger,
+  });
+}
+
+function admin(client) {
+  return client.set("x-admin-key", ADMIN_KEY);
+}
+
+beforeEach(() => {
+  process.env.ADMIN_KEY = ADMIN_KEY;
+});
+
+describe("Brand Brain generation integration", () => {
+  it("preserves the existing prompt when brand_id is absent", async () => {
+    const capture = {};
+    const response = await admin(
+      request(
+        appWithCapturedPrompt(
+          new InMemoryBrandBrainRepository(),
+          capture,
+          { info() {}, warn() {}, error() {} }
+        )
+      )
+        .post("/generate-script")
+        .send(validRequest())
+    );
+
+    assert.equal(response.status, 200);
+    assert.match(capture.value, /\[BRAND CONTEXT\]/);
+    assert.doesNotMatch(capture.value, /\[BRAND BRAIN\]/);
+  });
+
+  it("preserves existing behaviour for an unknown brand_id", async () => {
+    const capture = {};
+    const response = await admin(
+      request(
+        appWithCapturedPrompt(
+          new InMemoryBrandBrainRepository(),
+          capture,
+          { info() {}, warn() {}, error() {} }
+        )
+      )
+        .post("/generate-script")
+        .send(validRequest({ brand_id: "brand_missing" }))
+    );
+
+    assert.equal(response.status, 200);
+    assert.match(capture.value, /\[BRAND CONTEXT\]/);
+    assert.doesNotMatch(capture.value, /Sensitive Brand Name/);
+  });
+
+  it("injects the owning approved brand alongside every structured module and user prompt", async () => {
+    const repository = new InMemoryBrandBrainRepository();
+    repository.upsert(record());
+    const capture = {};
+    const response = await admin(
+      request(
+        appWithCapturedPrompt(repository, capture, {
+          info() {},
+          warn() {},
+          error() {},
+        })
+      )
+        .post("/generate-script")
+        .send(
+          validRequest({
+            brand_id: "brand_001",
+            platform: "LinkedIn",
+            script_type: "Problem Solution",
+            audience: "B2B",
+            intent_stage: "Cold",
+            voice_style: "Professional",
+          })
+        )
+    );
+
+    assert.equal(response.status, 200);
+    const labels = [
+      "[PLATFORM RULES]",
+      "[SCRIPT TYPE RULES]",
+      "[AUDIENCE RULES]",
+      "[INTENT RULES]",
+      "[VOICE RULES]",
+      "[BRAND BRAIN]",
+      "[USER CONTEXT]",
+    ];
+    const positions = labels.map((label) => capture.value.indexOf(label));
+    assert.ok(positions.every((position) => position >= 0));
+    assert.deepEqual(positions, [...positions].sort((a, b) => a - b));
+    assert.match(capture.value, /Sensitive Brand Name/);
+    assert.match(capture.value, /Explain how a planning workflow saves time\./);
+  });
+
+  it("does not inject a Brand Brain across project boundaries", async () => {
+    const repository = new InMemoryBrandBrainRepository();
+    repository.upsert(record());
+    const capture = {};
+    const response = await admin(
+      request(
+        appWithCapturedPrompt(repository, capture, {
+          info() {},
+          warn() {},
+          error() {},
+        })
+      )
+        .post("/generate-script")
+        .send(
+          validRequest({
+            project_id: "project_002",
+            brand_id: "brand_001",
+          })
+        )
+    );
+
+    assert.equal(response.status, 200);
+    assert.doesNotMatch(capture.value, /Sensitive Brand Name/);
+    assert.doesNotMatch(capture.value, /confidential market position/);
+  });
+
+  it("does not write Brand Brain content to completion or error logs", async () => {
+    const repository = new InMemoryBrandBrainRepository();
+    repository.upsert(record());
+    const events = [];
+    const logger = {
+      info(message, details) {
+        events.push({ message, details });
+      },
+      warn(message, details) {
+        events.push({ message, details });
+      },
+      error(message, details) {
+        events.push({ message, details });
+      },
+    };
+    const capture = {};
+
+    await admin(
+      request(appWithCapturedPrompt(repository, capture, logger))
+        .post("/generate-script")
+        .send(validRequest({ brand_id: "brand_001" }))
+    );
+
+    const failingApp = createApp({
+      brandBrainRepository: repository,
+      scriptGenerator: async () => {
+        throw new Error("provider failure");
+      },
+      logger,
+    });
+    await admin(
+      request(failingApp)
+        .post("/generate-script")
+        .send(validRequest({ brand_id: "brand_001" }))
+    );
+
+    const logs = JSON.stringify(events);
+    assert.doesNotMatch(logs, /Sensitive Brand Name/);
+    assert.doesNotMatch(logs, /confidential market position/);
+    assert.doesNotMatch(logs, /magic button|Guaranteed revenue/);
+    assert.doesNotMatch(logs, /Explain how a planning workflow saves time/);
+  });
+});

--- a/test/brand-brain-repository.test.js
+++ b/test/brand-brain-repository.test.js
@@ -1,0 +1,65 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+const {
+  InMemoryBrandBrainRepository,
+} = require("../src/brand-brain");
+const {
+  BrandBrainOwnershipError,
+} = require("../src/brand-brain/errors");
+
+function record(overrides = {}) {
+  return {
+    brand_id: "brand_001",
+    project_id: "project_001",
+    name: "BizGenie",
+    metadata: {
+      version: 1,
+      status: "approved",
+      created_at: "2026-08-08T09:00:00.000Z",
+      updated_at: "2026-08-08T09:00:00.000Z",
+    },
+    ...overrides,
+  };
+}
+
+describe("InMemoryBrandBrainRepository", () => {
+  it("upserts and retrieves defensive copies", () => {
+    const repository = new InMemoryBrandBrainRepository();
+    const value = record();
+    const stored = repository.upsert(value);
+
+    value.name = "Mutated input";
+    stored.name = "Mutated output";
+    assert.equal(repository.getByBrandId("brand_001").name, "BizGenie");
+  });
+
+  it("updates an existing record for the same project", () => {
+    const repository = new InMemoryBrandBrainRepository();
+    repository.upsert(record());
+    repository.upsert(record({ name: "BizGenie Updated" }));
+    assert.equal(repository.getByBrandId("brand_001").name, "BizGenie Updated");
+  });
+
+  it("returns null for a missing record or project mismatch", () => {
+    const repository = new InMemoryBrandBrainRepository();
+    repository.upsert(record());
+    assert.equal(repository.getByBrandId("brand_missing"), null);
+    assert.equal(
+      repository.getByProjectAndBrand("project_002", "brand_001"),
+      null
+    );
+    assert.equal(
+      repository.getByProjectAndBrand("project_001", "brand_001").name,
+      "BizGenie"
+    );
+  });
+
+  it("rejects moving an existing brand to another project", () => {
+    const repository = new InMemoryBrandBrainRepository();
+    repository.upsert(record());
+    assert.throws(
+      () => repository.upsert(record({ project_id: "project_002" })),
+      BrandBrainOwnershipError
+    );
+  });
+});

--- a/test/brand-brain-schema.test.js
+++ b/test/brand-brain-schema.test.js
@@ -1,0 +1,134 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+const { BrandBrainSchema } = require("../src/brand-brain");
+
+const metadata = Object.freeze({
+  version: 1,
+  status: "approved",
+  created_at: "2026-08-08T09:00:00.000Z",
+  updated_at: "2026-08-08T09:00:00.000Z",
+});
+
+function partialBrand(overrides = {}) {
+  return {
+    brand_id: "brand_001",
+    project_id: "project_001",
+    name: "BizGenie",
+    metadata,
+    ...overrides,
+  };
+}
+
+describe("Brand Brain schema", () => {
+  it("accepts a valid partial Brand Brain", () => {
+    const value = partialBrand({
+      identity: { positioning: "An AI Brand Operating System." },
+    });
+    assert.deepEqual(BrandBrainSchema.parse(value), value);
+  });
+
+  it("accepts the complete V1 structure", () => {
+    const value = partialBrand({
+      identity: {
+        description: "Persistent brand intelligence for growing businesses.",
+        mission: "Make excellent brand execution accessible.",
+        vision: "Every growing company operates with a trusted Company Brain.",
+        values: ["Clarity", "Commercial usefulness"],
+        positioning: "AI Brand Operating System for ambitious businesses.",
+      },
+      voice: {
+        tone: "Confident and intelligent.",
+        writing_style: "Clear, concise British English.",
+        personality: "Commercially sharp and helpful.",
+        preferred_terms: ["Brand Brain"],
+        prohibited_terms: ["magic button"],
+      },
+      audience: {
+        summary: "Founder-led ecommerce businesses.",
+        pain_points: ["Inconsistent content"],
+        goals: ["Publish confidently"],
+        objections: ["AI sounds generic"],
+        buying_triggers: ["A launch deadline"],
+      },
+      commercial: {
+        differentiators: ["Persistent approved context"],
+        primary_cta: "Build your Brand Brain.",
+        approved_claims: ["Uses approved brand context"],
+        prohibited_claims: ["Guaranteed revenue"],
+      },
+      competitors: {
+        names: ["Example competitor"],
+        notes: "Do not make unsupported comparative claims.",
+      },
+      visual: {
+        colours: ["Midnight blue"],
+        fonts: ["Inter"],
+        photography_style: "Natural founder-led workplace photography.",
+      },
+    });
+
+    assert.deepEqual(BrandBrainSchema.parse(value), value);
+  });
+
+  it("rejects invalid identifiers and metadata", () => {
+    assert.equal(
+      BrandBrainSchema.safeParse(partialBrand({ brand_id: "bad id" })).success,
+      false
+    );
+    assert.equal(
+      BrandBrainSchema.safeParse(
+        partialBrand({ metadata: { ...metadata, version: 0 } })
+      ).success,
+      false
+    );
+    assert.equal(
+      BrandBrainSchema.safeParse(
+        partialBrand({ metadata: { ...metadata, status: "published" } })
+      ).success,
+      false
+    );
+  });
+
+  it("rejects invalid or unknown structures", () => {
+    assert.equal(
+      BrandBrainSchema.safeParse(partialBrand({ voice: [] })).success,
+      false
+    );
+    assert.equal(
+      BrandBrainSchema.safeParse(
+        partialBrand({ audience: { summary: ["not text"] } })
+      ).success,
+      false
+    );
+    assert.equal(
+      BrandBrainSchema.safeParse(partialBrand({ arbitrary: true })).success,
+      false
+    );
+  });
+
+  it("rejects oversized names, arrays, prose, and governance items", () => {
+    assert.equal(
+      BrandBrainSchema.safeParse(partialBrand({ name: "x".repeat(201) }))
+        .success,
+      false
+    );
+    assert.equal(
+      BrandBrainSchema.safeParse(
+        partialBrand({ identity: { description: "x".repeat(2001) } })
+      ).success,
+      false
+    );
+    assert.equal(
+      BrandBrainSchema.safeParse(
+        partialBrand({ identity: { values: Array(21).fill("value") } })
+      ).success,
+      false
+    );
+    assert.equal(
+      BrandBrainSchema.safeParse(
+        partialBrand({ voice: { prohibited_terms: ["x".repeat(201)] } })
+      ).success,
+      false
+    );
+  });
+});

--- a/test/prompts.test.js
+++ b/test/prompts.test.js
@@ -109,6 +109,24 @@ describe("prompt compiler", () => {
     }
   });
 
+  it("replaces the placeholder with resolved Brand Brain context", () => {
+    const brandContext = [
+      "[BRAND BRAIN]",
+      "",
+      "Brand:\nBizGenie",
+    ].join("\n");
+    const prompt = compilePrompt({ ...ALL_OPTIONS, brandContext });
+
+    assert.match(prompt, /\[BRAND BRAIN\]\n\nBrand:\nBizGenie/);
+    assert.doesNotMatch(prompt, /Brand context is not available/);
+    assert.ok(
+      position(prompt, "VOICE RULES") < position(prompt, "BRAND BRAIN")
+    );
+    assert.ok(
+      position(prompt, "BRAND BRAIN") < position(prompt, "USER CONTEXT")
+    );
+  });
+
   it("returns byte-for-byte deterministic output", () => {
     assert.equal(compilePrompt(ALL_OPTIONS), compilePrompt({ ...ALL_OPTIONS }));
   });


### PR DESCRIPTION
## Summary

- add a strict, bounded Brand Brain V1 schema and replaceable in-memory repository
- add tenancy-aware approved-context resolution and deterministic 8,000-character compilation
- wire optional `brand_id` into `POST /generate-script` without changing legacy requests
- add protected Brand Brain upsert/retrieval endpoints using the existing admin key
- document architecture, security guarantees, context-budget behavior, and explicit roadmap exclusions

## Security and compatibility

- generation resolves by both `project_id` and `brand_id`
- a stored brand cannot be reassigned to another project through upsert
- unknown, draft, archived, and cross-project brands fall back to existing behavior
- prompts and Brand Brain content are excluded from generic completion/error logs
- no database, persistence provider, deployment, billing, Make, Glide, or Sheets changes

## Validation

- baseline: 53/53 tests passing on `b06a478a7a5d38b669dcf72ced752ff1666148e7`
- `npm ci --no-audit --no-fund`
- `npm test`: 82/82 passing
- JavaScript syntax checks: passing
- `git diff --check`: passing

GitHub Actions must pass against the exact PR head before this draft is considered complete.