### PR TITLE
BG-CORE-001B: add durable Brand Brain persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ npm ci
 Start the API:
 
 ```bash
-ADMIN_KEY=replace-with-a-local-secret \
-GOOGLE_CLOUD_PROJECT=your-project-id \
+# After setting ADMIN_KEY, BRAND_BRAIN_DATABASE_URL, and GOOGLE_CLOUD_PROJECT:
 npm start
 ```
 
@@ -47,15 +46,22 @@ compilation, and protected administration endpoints.
 The implementation is isolated under `src/brand-brain/`:
 
 - `schema.js` defines the strict, bounded V1 record and administration input.
-- `repository.js` defines `getByBrandId`, `getByProjectAndBrand`, and `upsert`.
+- `repository.js` defines `getByBrandId`, `getByProjectAndBrand`, and `upsert`,
+  plus the isolated in-memory implementation used by unit tests.
+- `postgresRepository.js` implements the production contract with a bounded
+  PostgreSQL pool and validates stored rows against the locked V1 schema.
 - `contextResolver.js` enforces project ownership and approved status.
 - `contextCompiler.js` produces deterministic prompt-ready context.
 - `router.js` exposes the smallest protected testability surface.
 - `index.js` is the domain's public module boundary.
 
-The default repository is process-local and in-memory. It stores defensive
-copies and can be replaced by a permanent repository later without changing the
-prompt compiler. No database or persistence-provider dependency is introduced.
+The `node index.js` production entry point always builds the PostgreSQL
+repository from environment configuration and verifies connectivity before it
+starts listening. Missing, malformed, or unreachable database configuration
+fails startup; production never silently falls back to process memory. Tests
+and embedded callers may explicitly inject `InMemoryBrandBrainRepository` into
+`createApp`. The resolver and Prompt Compiler only use the repository contract
+and contain no PostgreSQL-specific logic.
 
 ### V1 record
 
@@ -169,6 +175,105 @@ only `approved` records resolve. Generation success/error logs contain safe
 execution and provider metadata only; prompts and Brand Brain content are not
 written to generic logs.
 
+The security boundary has three deliberate layers:
+
+1. PostgreSQL stores `project_id`, makes `brand_id` globally unique, prevents
+   updates to project ownership and creation time with a trigger, enables RLS,
+   and revokes table access from Supabase `anon` and `authenticated` roles. No
+   client RLS policy is created because this service does not use Supabase Auth
+   and the table is not exposed to clients. The server-only database role owns
+   or bypasses RLS as expected for a direct backend connection.
+2. Repository generation reads use `WHERE project_id = $1 AND brand_id = $2`.
+   The atomic upsert only updates a conflict when the existing `project_id`
+   matches; otherwise it returns `BRAND_PROJECT_CONFLICT`.
+3. The context resolver repeats the ownership boundary through that scoped
+   method and only compiles records whose status is `approved`. Draft and
+   archived records never enter generation context.
+
+### Durable PostgreSQL persistence
+
+The canonical schema is created by
+`supabase/migrations/20260808170000_create_brand_brains.sql`. It creates one
+`public.brand_brains` row per globally stable `brand_id` with `project_id`,
+`name`, JSONB columns for the six bounded V1 sections, and typed `version`,
+`status`, `created_at`, and `updated_at` metadata. Database checks cover
+identifier formats, core bounds, status, version, and JSON object shape; the
+application performs the complete locked Zod validation on write and read. The
+composite `(project_id, brand_id)` index supports tenant-scoped lookup.
+
+Apply the migration through the version-controlled Supabase workflow, never as
+a dashboard-only change:
+
+```bash
+supabase link --project-ref your-project-reference
+supabase db push --linked
+```
+
+Run the optional real-database persistence test only against a disposable,
+migrated database. The default CI suite does not require a database secret:
+
+After setting `BRAND_BRAIN_TEST_DATABASE_URL`, run:
+
+```bash
+npm run test:brand-brain:integration
+```
+
+For Cloud Run, `BRAND_BRAIN_DATABASE_URL` should be the server-side Supabase
+Supavisor **session-mode** PostgreSQL connection string with TLS enabled. Cloud
+Run instances are long-lived application servers rather than per-query edge
+functions, so session mode plus one process-wide `pg.Pool` is appropriate. The
+pool defaults to five connections per instance, a five-second connection
+timeout, and a 30-second idle timeout. This bounds per-instance connections
+while allowing reuse across requests and avoids ORM or PostgREST complexity.
+Account for `Cloud Run maximum instances × pool maximum` when sizing the
+Supabase database and pooler.
+
+### Persistence failure behaviour
+
+Startup validates both configuration and connectivity before opening the HTTP
+listener. Database errors are converted to
+`BRAND_BRAIN_PERSISTENCE_UNAVAILABLE` without returning raw provider messages,
+connection details, credentials, or stored Brand Brain content. Administration
+requests return the structured error with HTTP 503.
+
+Generation deliberately fails closed with the same safe 503 when a caller
+explicitly supplies `brand_id` and its lookup fails. It does not call Vertex AI
+or pretend Brand Brain was applied. This favours correct, governed output over
+availability. An absent `brand_id` performs no lookup and retains the previous
+generation behaviour; a successful lookup for an unknown ID still retains the
+existing no-context behaviour.
+
+### Operations, backup, and production verification
+
+Supabase/PostgreSQL operators remain responsible for backups, point-in-time
+recovery configuration, retention, restore testing, database capacity, and
+credential rotation. This repository does not create an application-level
+backup channel.
+
+After merge, use this production verification procedure (it is a runbook, not
+an instruction to deploy from this change):
+
+1. Apply `supabase/migrations/20260808170000_create_brand_brains.sql` with
+   `supabase db push --linked` and record the migration result.
+2. Configure the required server-side environment/secret names listed below;
+   do not expose the database value to a client.
+3. Deploy the normal Cloud Run release.
+4. Send an authenticated `PUT /_admin/brand-brains/:brand_id` for an approved,
+   non-production test brand owned by test Project A.
+5. Send authenticated `GET /_admin/brand-brains/:brand_id` and compare the
+   returned identity, status, version, and project to the PUT response.
+6. Call `POST /generate-script` with the matching `project_id` and `brand_id`.
+7. Confirm the generated result reflects a distinctive approved test-brand
+   instruction without exposing the full prompt in logs.
+8. Deploy a no-code Cloud Run revision, or otherwise direct traffic to a newly
+   started instance after the original instance is stopped.
+9. Repeat the authenticated GET for the same `brand_id`.
+10. Confirm the same record is returned, proving survival across process
+    replacement.
+11. Attempt to PUT the same `brand_id` with test Project B and confirm
+    `BRAND_PROJECT_CONFLICT`; then generate as Project B and confirm no Project
+    A Brand Brain content is injected.
+
 ### Explicit future extension points
 
 The repository interface is the persistence seam. The resolver/compiler can
@@ -176,12 +281,13 @@ later accept richer relevance signals or retrieval results without changing
 the Prompt Compiler contract. New Company Brain domains can remain separate
 context providers and be composed at the same controlled injection boundary.
 
-This foundation does **not** implement permanent production persistence, Brand
-Brain onboarding UI, the Genie interview, voice onboarding, automatic website
-ingestion, social ingestion, document ingestion, vector/semantic retrieval,
-Product Brain, Customer Brain, Campaign Brain, Learning Brain, Trend
-Intelligence, Opportunity Engine, or automated performance learning. Those
-remain separately reviewed roadmap components.
+This persistence layer does **not** implement vector retrieval, pgvector
+indexes, embeddings, document ingestion, website ingestion, Brand Brain
+onboarding UI, the Genie interview, Product Brain, Customer Brain, Campaign
+Brain, Competitor Brain, Learning Brain, Trend Intelligence, social ingestion,
+Opportunity Engine, or automated performance learning. A future pgvector or
+semantic retrieval repository can be composed behind the existing repository
+and resolver boundary without changing the Prompt Compiler contract.
 
 ## Mission Control foundation
 
@@ -306,6 +412,16 @@ field types fail fast rather than silently applying partial branding.
 ## Environment variables
 
 - `ADMIN_KEY` — required for all administration and script-generation routes.
+- `BRAND_BRAIN_DATABASE_URL` — required server-only Supabase/PostgreSQL
+  session-pooler connection string used by production startup.
+- `BRAND_BRAIN_DB_POOL_MAX` — optional bounded connections per Cloud Run
+  instance; defaults to `5`.
+- `BRAND_BRAIN_DB_CONNECTION_TIMEOUT_MS` — optional connection acquisition
+  timeout; defaults to `5000`.
+- `BRAND_BRAIN_DB_IDLE_TIMEOUT_MS` — optional idle connection timeout;
+  defaults to `30000`.
+- `BRAND_BRAIN_TEST_DATABASE_URL` — optional and only used by the manually
+  invoked disposable-database integration test.
 - `BRANDING_CONFIG_JSON` — optional validated partial override for the central branding configuration.
 - `GOOGLE_CLOUD_PROJECT`, `GCLOUD_PROJECT`, or `GCP_PROJECT` — Google Cloud
   project used by the existing script generator.
@@ -313,8 +429,8 @@ field types fail fast rather than silently applying partial branding.
 - `VERTEX_MODEL` — optional; defaults to `gemini-2.5-flash`.
 - `PORT` — optional; defaults to `8080`.
 
-Mission Control introduces no new environment variables. Its repository is
-process-local and is reset whenever the process restarts.
+Mission Control introduces no new environment variables. Its repository
+remains process-local and is reset whenever the process restarts.
 
 ## Generation completion protection
 

--- a/index.js
+++ b/index.js
@@ -8,9 +8,13 @@ console.log(`🚀 ${brandingConfig.marketingStrings.apiBooting}`);
 const express = require("express");
 const {
   InMemoryBrandBrainRepository,
+  createPostgresBrandBrainRepositoryFromEnv,
   createBrandBrainRouter,
   resolveBrandBrainContext,
 } = require("./src/brand-brain");
+const {
+  BrandBrainPersistenceError,
+} = require("./src/brand-brain/errors");
 const {
   InMemoryMissionControlRepository,
   createMissionControlRouter,
@@ -86,7 +90,7 @@ function createApp({
         });
       }
 
-      const brandContext = resolveBrandBrainContext({
+      const brandContext = await resolveBrandBrainContext({
         repository: brandBrainRepository,
         projectId: project_id,
         brandId: brand_id,
@@ -123,6 +127,23 @@ function createApp({
       });
 
     } catch (err) {
+      if (err instanceof BrandBrainPersistenceError) {
+        logger.error?.("brand brain persistence unavailable", {
+          execution_id,
+          name: err.name,
+          code: err.code,
+        });
+
+        return res.status(err.status).json({
+          status: "failed",
+          error: {
+            code: err.code,
+            message: err.message,
+          },
+          script_body: ""
+        });
+      }
+
       if (err instanceof GenerationIncompleteError) {
         logger.warn?.("generation incomplete", {
           execution_id,
@@ -184,18 +205,44 @@ function createApp({
   return app;
 }
 
-const app = createApp();
-
 const port = process.env.PORT || 8080;
+
+async function createProductionApp({ env = process.env, logger = console } = {}) {
+  const brandBrainRepository = createPostgresBrandBrainRepositoryFromEnv({
+    env,
+  });
+  await brandBrainRepository.initialize();
+  return {
+    app: createApp({ brandBrainRepository, logger }),
+    brandBrainRepository,
+  };
+}
+
+async function startServer({ env = process.env, logger = console } = {}) {
+  const production = await createProductionApp({ env, logger });
+  const server = production.app.listen(env.PORT || port, () => {
+    logger.log?.("Listening on", env.PORT || port);
+  });
+  return { ...production, server };
+}
+
+const app = require.main === module ? null : createApp();
+
 if (require.main === module) {
-  app.listen(port, () => {
-    console.log("Listening on", port);
+  startServer().catch((error) => {
+    console.error("Startup failed", {
+      name: error?.name || "Error",
+      code: error?.code || "STARTUP_ERROR",
+    });
+    process.exitCode = 1;
   });
 }
 
 module.exports = {
   app,
   createApp,
+  createProductionApp,
   generateScriptWithVertex,
   requireAdmin,
+  startServer,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,16 +7,17 @@
     "": {
       "name": "bizgenie-api",
       "version": "1.0.0",
-      "engines": {
-        "node": "22.x"
-      },
       "dependencies": {
         "@google-cloud/vertexai": "^1.0.0",
         "express": "^4.19.2",
+        "pg": "^8.22.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
         "supertest": "^7.2.2"
+      },
+      "engines": {
+        "node": "22.x"
       }
     },
     "node_modules/@google-cloud/vertexai": {
@@ -1234,6 +1235,135 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.6.5",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
@@ -1468,6 +1598,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1687,6 +1826,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "node --test"
+    "test": "node --test",
+    "test:brand-brain:integration": "node --test scripts/brand-brain-postgres-integration.js"
   },
   "dependencies": {
     "@google-cloud/vertexai": "^1.0.0",
     "express": "^4.19.2",
+    "pg": "^8.22.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/scripts/brand-brain-postgres-integration.js
+++ b/scripts/brand-brain-postgres-integration.js
@@ -1,0 +1,56 @@
+const assert = require("node:assert/strict");
+const { randomUUID } = require("node:crypto");
+const { after, test } = require("node:test");
+const { Pool } = require("pg");
+const {
+  PostgresBrandBrainRepository,
+} = require("../src/brand-brain");
+
+const connectionString = process.env.BRAND_BRAIN_TEST_DATABASE_URL;
+if (!connectionString) {
+  throw new Error(
+    "BRAND_BRAIN_TEST_DATABASE_URL is required for the optional integration test"
+  );
+}
+
+const pool = new Pool({
+  connectionString,
+  max: 2,
+  connectionTimeoutMillis: 5000,
+  idleTimeoutMillis: 1000,
+});
+const repository = new PostgresBrandBrainRepository({ pool });
+const suffix = randomUUID().replaceAll("-", "");
+const brandId = `integration_brand_${suffix}`;
+const projectId = `integration_project_${suffix}`;
+
+after(async () => {
+  await pool.query("DELETE FROM public.brand_brains WHERE brand_id = $1", [
+    brandId,
+  ]);
+  await pool.end();
+});
+
+test("persists across real Postgres repository instances", async () => {
+  const value = {
+    brand_id: brandId,
+    project_id: projectId,
+    name: "Brand Brain integration test",
+    metadata: {
+      version: 1,
+      status: "approved",
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    },
+  };
+
+  await repository.initialize();
+  await repository.upsert(value);
+
+  const recreated = new PostgresBrandBrainRepository({ pool });
+  assert.deepEqual(await recreated.getByProjectAndBrand(projectId, brandId), value);
+  assert.equal(
+    await recreated.getByProjectAndBrand(`other_${projectId}`, brandId),
+    null
+  );
+});

--- a/scripts/smoke-container.sh
+++ b/scripts/smoke-container.sh
@@ -5,6 +5,9 @@ image="${1:?image name is required}"
 container_name="${2:?container name is required}"
 : "${ADMIN_KEY:?ADMIN_KEY must be set to a disposable local value}"
 response_dir="$(mktemp -d)"
+database_container="${container_name}-postgres"
+network_name="${container_name}-network"
+database_password="$(openssl rand -hex 24)"
 
 cleanup() {
   exit_code=$?
@@ -12,17 +15,60 @@ cleanup() {
     docker logs "$container_name" 2>&1 || true
   fi
   docker rm --force "$container_name" >/dev/null 2>&1 || true
+  docker rm --force "$database_container" >/dev/null 2>&1 || true
+  docker network rm "$network_name" >/dev/null 2>&1 || true
   rm -rf "$response_dir"
   trap - EXIT
   exit "$exit_code"
 }
 trap cleanup EXIT
 
+docker network create "$network_name" >/dev/null
+docker run --detach \
+  --name "$database_container" \
+  --network "$network_name" \
+  --env POSTGRES_PASSWORD="$database_password" \
+  postgres:16-alpine >/dev/null
+
+database_ready=false
+for _ in {1..30}; do
+  if docker exec "$database_container" pg_isready --username postgres \
+    >/dev/null 2>&1; then
+    database_ready=true
+    break
+  fi
+  sleep 1
+done
+if [[ "$database_ready" != "true" ]]; then
+  echo "Disposable PostgreSQL did not become ready" >&2
+  exit 1
+fi
+
+migration_applied=false
+for _ in {1..30}; do
+  if docker exec --interactive "$database_container" \
+    psql --username postgres --dbname postgres \
+    < supabase/migrations/20260808170000_create_brand_brains.sql \
+    >/dev/null 2>&1; then
+    migration_applied=true
+    break
+  fi
+  sleep 1
+done
+if [[ "$migration_applied" != "true" ]]; then
+  echo "Brand Brain migration could not be applied to disposable PostgreSQL" >&2
+  exit 1
+fi
+
+database_url="postgresql://postgres:${database_password}@${database_container}:5432/postgres"
+
 docker run --detach \
   --name "$container_name" \
+  --network "$network_name" \
   -p 127.0.0.1::8080 \
   --env PORT=8080 \
   --env ADMIN_KEY \
+  --env BRAND_BRAIN_DATABASE_URL="$database_url" \
   "$image" >/dev/null
 
 host_binding="$(docker port "$container_name" 8080/tcp)"

--- a/src/brand-brain/contextResolver.js
+++ b/src/brand-brain/contextResolver.js
@@ -1,6 +1,6 @@
 const { compileBrandContext } = require("./contextCompiler");
 
-function resolveBrandBrainContext({
+async function resolveBrandBrainContext({
   repository,
   projectId,
   brandId,
@@ -16,7 +16,7 @@ function resolveBrandBrainContext({
     return "";
   }
 
-  const record = repository.getByProjectAndBrand(projectId, brandId);
+  const record = await repository.getByProjectAndBrand(projectId, brandId);
   if (!record || record.metadata.status !== "approved") {
     return "";
   }

--- a/src/brand-brain/errors.js
+++ b/src/brand-brain/errors.js
@@ -30,6 +30,24 @@ class BrandBrainOwnershipError extends BrandBrainError {
   }
 }
 
+class BrandBrainPersistenceError extends BrandBrainError {
+  constructor() {
+    super(
+      503,
+      "BRAND_BRAIN_PERSISTENCE_UNAVAILABLE",
+      "Brand Brain persistence is temporarily unavailable"
+    );
+  }
+}
+
+class BrandBrainConfigurationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "BrandBrainConfigurationError";
+    this.code = "BRAND_BRAIN_CONFIGURATION_ERROR";
+  }
+}
+
 function formatZodIssues(issues) {
   return issues.map((issue) => ({
     path: issue.path.join("."),
@@ -62,6 +80,8 @@ module.exports = {
   BrandBrainError,
   BrandBrainNotFoundError,
   BrandBrainOwnershipError,
+  BrandBrainPersistenceError,
+  BrandBrainConfigurationError,
   BrandBrainValidationError,
   formatZodIssues,
   sendBrandBrainError,

--- a/src/brand-brain/index.js
+++ b/src/brand-brain/index.js
@@ -8,14 +8,20 @@ const {
   InMemoryBrandBrainRepository,
 } = require("./repository");
 const { createBrandBrainRouter } = require("./router");
+const {
+  PostgresBrandBrainRepository,
+  createPostgresBrandBrainRepositoryFromEnv,
+} = require("./postgresRepository");
 const schemas = require("./schema");
 
 module.exports = {
   BrandBrainRepository,
   DEFAULT_BRAND_CONTEXT_MAX_CHARS,
   InMemoryBrandBrainRepository,
+  PostgresBrandBrainRepository,
   compileBrandContext,
   createBrandBrainRouter,
+  createPostgresBrandBrainRepositoryFromEnv,
   resolveBrandBrainContext,
   ...schemas,
 };

--- a/src/brand-brain/postgresRepository.js
+++ b/src/brand-brain/postgresRepository.js
@@ -1,0 +1,256 @@
+const { Pool } = require("pg");
+const { BrandBrainSchema } = require("./schema");
+const { BrandBrainRepository } = require("./repository");
+const {
+  BrandBrainConfigurationError,
+  BrandBrainOwnershipError,
+  BrandBrainPersistenceError,
+} = require("./errors");
+
+const DEFAULT_POOL_MAX = 5;
+const DEFAULT_CONNECTION_TIMEOUT_MS = 5000;
+const DEFAULT_IDLE_TIMEOUT_MS = 30000;
+
+const SELECT_COLUMNS = [
+  "brand_id",
+  "project_id",
+  "name",
+  "identity",
+  "voice",
+  "audience",
+  "commercial",
+  "competitors",
+  "visual",
+  "version",
+  "status",
+  "created_at",
+  "updated_at",
+].join(", ");
+
+function safePositiveInteger(value, defaultValue, name) {
+  if (value === undefined || value === "") {
+    return defaultValue;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new BrandBrainConfigurationError(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function validateConnectionString(value) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new BrandBrainConfigurationError(
+      "BRAND_BRAIN_DATABASE_URL is required"
+    );
+  }
+
+  try {
+    const parsed = new URL(value);
+    if (!["postgres:", "postgresql:"].includes(parsed.protocol)) {
+      throw new Error("invalid protocol");
+    }
+  } catch {
+    throw new BrandBrainConfigurationError(
+      "BRAND_BRAIN_DATABASE_URL must be a valid PostgreSQL connection string"
+    );
+  }
+
+  return value;
+}
+
+function mapRow(row) {
+  if (!row) {
+    return null;
+  }
+
+  const candidate = {
+    brand_id: row.brand_id,
+    project_id: row.project_id,
+    name: row.name,
+    metadata: {
+      version: row.version,
+      status: row.status,
+      created_at: new Date(row.created_at).toISOString(),
+      updated_at: new Date(row.updated_at).toISOString(),
+    },
+  };
+
+  for (const section of [
+    "identity",
+    "voice",
+    "audience",
+    "commercial",
+    "competitors",
+    "visual",
+  ]) {
+    if (row[section] !== null && row[section] !== undefined) {
+      candidate[section] = row[section];
+    }
+  }
+
+  const parsed = BrandBrainSchema.safeParse(candidate);
+  if (!parsed.success) {
+    throw new BrandBrainPersistenceError();
+  }
+  return structuredClone(parsed.data);
+}
+
+class PostgresBrandBrainRepository extends BrandBrainRepository {
+  constructor({ pool }) {
+    super();
+    if (!pool || typeof pool.query !== "function") {
+      throw new BrandBrainConfigurationError(
+        "A PostgreSQL connection pool is required"
+      );
+    }
+    this.pool = pool;
+  }
+
+  async initialize() {
+    try {
+      await this.pool.query(
+        "SELECT brand_id FROM public.brand_brains LIMIT 0"
+      );
+    } catch {
+      throw new BrandBrainPersistenceError();
+    }
+  }
+
+  async close() {
+    if (typeof this.pool.end === "function") {
+      await this.pool.end();
+    }
+  }
+
+  async getByBrandId(brandId) {
+    try {
+      const result = await this.pool.query(
+        `SELECT ${SELECT_COLUMNS}
+           FROM public.brand_brains
+          WHERE brand_id = $1`,
+        [brandId]
+      );
+      return mapRow(result.rows[0]);
+    } catch (error) {
+      if (error instanceof BrandBrainPersistenceError) {
+        throw error;
+      }
+      throw new BrandBrainPersistenceError();
+    }
+  }
+
+  async getByProjectAndBrand(projectId, brandId) {
+    try {
+      const result = await this.pool.query(
+        `SELECT ${SELECT_COLUMNS}
+           FROM public.brand_brains
+          WHERE project_id = $1
+            AND brand_id = $2`,
+        [projectId, brandId]
+      );
+      return mapRow(result.rows[0]);
+    } catch (error) {
+      if (error instanceof BrandBrainPersistenceError) {
+        throw error;
+      }
+      throw new BrandBrainPersistenceError();
+    }
+  }
+
+  async upsert(record) {
+    const values = [
+      record.brand_id,
+      record.project_id,
+      record.name,
+      record.identity ?? null,
+      record.voice ?? null,
+      record.audience ?? null,
+      record.commercial ?? null,
+      record.competitors ?? null,
+      record.visual ?? null,
+      record.metadata.version,
+      record.metadata.status,
+      record.metadata.created_at,
+      record.metadata.updated_at,
+    ];
+
+    try {
+      const result = await this.pool.query(
+        `INSERT INTO public.brand_brains (
+           brand_id, project_id, name, identity, voice, audience, commercial,
+           competitors, visual, version, status, created_at, updated_at
+         ) VALUES (
+           $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
+         )
+         ON CONFLICT (brand_id) DO UPDATE SET
+           name = EXCLUDED.name,
+           identity = EXCLUDED.identity,
+           voice = EXCLUDED.voice,
+           audience = EXCLUDED.audience,
+           commercial = EXCLUDED.commercial,
+           competitors = EXCLUDED.competitors,
+           visual = EXCLUDED.visual,
+           version = EXCLUDED.version,
+           status = EXCLUDED.status,
+           updated_at = EXCLUDED.updated_at
+         WHERE public.brand_brains.project_id = EXCLUDED.project_id
+         RETURNING ${SELECT_COLUMNS}`,
+        values
+      );
+
+      if (result.rowCount === 0) {
+        throw new BrandBrainOwnershipError(record.brand_id);
+      }
+      return mapRow(result.rows[0]);
+    } catch (error) {
+      if (
+        error instanceof BrandBrainOwnershipError ||
+        error instanceof BrandBrainPersistenceError
+      ) {
+        throw error;
+      }
+      throw new BrandBrainPersistenceError();
+    }
+  }
+}
+
+function createPostgresBrandBrainRepositoryFromEnv({
+  env = process.env,
+  PoolClass = Pool,
+} = {}) {
+  const connectionString = validateConnectionString(
+    env.BRAND_BRAIN_DATABASE_URL
+  );
+  const pool = new PoolClass({
+    connectionString,
+    max: safePositiveInteger(
+      env.BRAND_BRAIN_DB_POOL_MAX,
+      DEFAULT_POOL_MAX,
+      "BRAND_BRAIN_DB_POOL_MAX"
+    ),
+    connectionTimeoutMillis: safePositiveInteger(
+      env.BRAND_BRAIN_DB_CONNECTION_TIMEOUT_MS,
+      DEFAULT_CONNECTION_TIMEOUT_MS,
+      "BRAND_BRAIN_DB_CONNECTION_TIMEOUT_MS"
+    ),
+    idleTimeoutMillis: safePositiveInteger(
+      env.BRAND_BRAIN_DB_IDLE_TIMEOUT_MS,
+      DEFAULT_IDLE_TIMEOUT_MS,
+      "BRAND_BRAIN_DB_IDLE_TIMEOUT_MS"
+    ),
+    allowExitOnIdle: false,
+  });
+
+  return new PostgresBrandBrainRepository({ pool });
+}
+
+module.exports = {
+  DEFAULT_CONNECTION_TIMEOUT_MS,
+  DEFAULT_IDLE_TIMEOUT_MS,
+  DEFAULT_POOL_MAX,
+  PostgresBrandBrainRepository,
+  createPostgresBrandBrainRepositoryFromEnv,
+  mapRow,
+};

--- a/src/brand-brain/router.js
+++ b/src/brand-brain/router.js
@@ -22,7 +22,7 @@ function createBrandBrainRouter({ repository, now = () => new Date() }) {
 
   const router = express.Router();
 
-  router.put("/:brandId", (req, res, next) => {
+  router.put("/:brandId", async (req, res, next) => {
     try {
       const input = parse(UpsertBrandBrainSchema, req.body);
       if (input.brand_id && input.brand_id !== req.params.brandId) {
@@ -35,7 +35,7 @@ function createBrandBrainRouter({ repository, now = () => new Date() }) {
         ]);
       }
 
-      const existing = repository.getByBrandId(req.params.brandId);
+      const existing = await repository.getByBrandId(req.params.brandId);
       const timestamp = now().toISOString();
       const record = parse(BrandBrainSchema, {
         ...input,
@@ -52,15 +52,15 @@ function createBrandBrainRouter({ repository, now = () => new Date() }) {
         },
       });
 
-      return res.json({ brand_brain: repository.upsert(record) });
+      return res.json({ brand_brain: await repository.upsert(record) });
     } catch (error) {
       return next(error);
     }
   });
 
-  router.get("/:brandId", (req, res, next) => {
+  router.get("/:brandId", async (req, res, next) => {
     try {
-      const record = repository.getByBrandId(req.params.brandId);
+      const record = await repository.getByBrandId(req.params.brandId);
       if (!record) {
         throw new BrandBrainNotFoundError(req.params.brandId);
       }

--- a/supabase/migrations/20260808170000_create_brand_brains.sql
+++ b/supabase/migrations/20260808170000_create_brand_brains.sql
@@ -1,0 +1,88 @@
+create table if not exists public.brand_brains (
+  brand_id text primary key,
+  project_id text not null,
+  name text not null,
+  identity jsonb,
+  voice jsonb,
+  audience jsonb,
+  commercial jsonb,
+  competitors jsonb,
+  visual jsonb,
+  version integer not null,
+  status text not null,
+  created_at timestamptz not null,
+  updated_at timestamptz not null,
+  constraint brand_brains_brand_id_format check (
+    length(brand_id) between 1 and 128
+    and brand_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]*$'
+  ),
+  constraint brand_brains_project_id_format check (
+    length(project_id) between 1 and 128
+    and project_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]*$'
+  ),
+  constraint brand_brains_name_length check (length(name) between 1 and 200),
+  constraint brand_brains_version_positive check (version between 1 and 1000000),
+  constraint brand_brains_status_allowed check (
+    status in ('draft', 'approved', 'archived')
+  ),
+  constraint brand_brains_identity_object check (
+    identity is null or jsonb_typeof(identity) = 'object'
+  ),
+  constraint brand_brains_voice_object check (
+    voice is null or jsonb_typeof(voice) = 'object'
+  ),
+  constraint brand_brains_audience_object check (
+    audience is null or jsonb_typeof(audience) = 'object'
+  ),
+  constraint brand_brains_commercial_object check (
+    commercial is null or jsonb_typeof(commercial) = 'object'
+  ),
+  constraint brand_brains_competitors_object check (
+    competitors is null or jsonb_typeof(competitors) = 'object'
+  ),
+  constraint brand_brains_visual_object check (
+    visual is null or jsonb_typeof(visual) = 'object'
+  )
+);
+
+create index if not exists brand_brains_project_brand_idx
+  on public.brand_brains (project_id, brand_id);
+
+create or replace function public.protect_brand_brain_ownership()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if new.project_id is distinct from old.project_id then
+    raise exception 'brand brain project ownership is immutable'
+      using errcode = '23514';
+  end if;
+  if new.created_at is distinct from old.created_at then
+    raise exception 'brand brain creation timestamp is immutable'
+      using errcode = '23514';
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists protect_brand_brain_ownership on public.brand_brains;
+create trigger protect_brand_brain_ownership
+before update on public.brand_brains
+for each row execute function public.protect_brand_brain_ownership();
+
+alter table public.brand_brains enable row level security;
+
+do $$
+begin
+  if exists (select 1 from pg_roles where rolname = 'anon') then
+    revoke all on table public.brand_brains from anon;
+  end if;
+  if exists (select 1 from pg_roles where rolname = 'authenticated') then
+    revoke all on table public.brand_brains from authenticated;
+  end if;
+end;
+$$;
+
+comment on table public.brand_brains is
+  'Server-only canonical V1 Brand Brain records; access is mediated by bizgenie-api.';

--- a/test/brand-brain-admin.test.js
+++ b/test/brand-brain-admin.test.js
@@ -1,7 +1,9 @@
 const assert = require("node:assert/strict");
 const { beforeEach, describe, it } = require("node:test");
 const request = require("supertest");
+const { PostgresBrandBrainRepository } = require("../src/brand-brain");
 const { createApp } = require("../index");
+const { FakeBrandBrainPool } = require("./helpers/fake-brand-brain-pool");
 
 const ADMIN_KEY = "brand-brain-admin-test-key";
 
@@ -60,6 +62,48 @@ describe("Brand Brain administration", () => {
     );
     assert.equal(fetched.status, 200);
     assert.deepEqual(fetched.body, created.body);
+  });
+
+  it("authorises persistent upsert and retrieval through the Postgres repository", async () => {
+    const repository = new PostgresBrandBrainRepository({
+      pool: new FakeBrandBrainPool(),
+    });
+    const app = createApp({ brandBrainRepository: repository });
+
+    const created = await admin(
+      request(app)
+        .put("/_admin/brand-brains/brand_persistent")
+        .send(validInput())
+    );
+    const fetched = await admin(
+      request(app).get("/_admin/brand-brains/brand_persistent")
+    );
+
+    assert.equal(created.status, 200);
+    assert.equal(fetched.status, 200);
+    assert.deepEqual(fetched.body, created.body);
+  });
+
+  it("returns a safe structured error when persistent retrieval fails", async () => {
+    const repository = new PostgresBrandBrainRepository({
+      pool: new FakeBrandBrainPool({
+        failure: new Error("private provider diagnostic details"),
+      }),
+    });
+    const response = await admin(
+      request(createApp({ brandBrainRepository: repository })).get(
+        "/_admin/brand-brains/brand_001"
+      )
+    );
+
+    assert.equal(response.status, 503);
+    assert.deepEqual(response.body, {
+      error: {
+        code: "BRAND_BRAIN_PERSISTENCE_UNAVAILABLE",
+        message: "Brand Brain persistence is temporarily unavailable",
+      },
+    });
+    assert.doesNotMatch(JSON.stringify(response.body), /private|provider|diagnostic/);
   });
 
   it("rejects malformed records with structured validation details", async () => {

--- a/test/brand-brain-context.test.js
+++ b/test/brand-brain-context.test.js
@@ -110,15 +110,15 @@ describe("Brand Brain context compiler", () => {
 });
 
 describe("Brand Brain context resolver", () => {
-  it("returns no context for absent or unknown brand IDs", () => {
+  it("returns no context for absent or unknown brand IDs", async () => {
     const repository = new InMemoryBrandBrainRepository();
     repository.upsert(record());
     assert.equal(
-      resolveBrandBrainContext({ repository, projectId: "project_001" }),
+      await resolveBrandBrainContext({ repository, projectId: "project_001" }),
       ""
     );
     assert.equal(
-      resolveBrandBrainContext({
+      await resolveBrandBrainContext({
         repository,
         projectId: "project_001",
         brandId: "brand_missing",
@@ -127,11 +127,11 @@ describe("Brand Brain context resolver", () => {
     );
   });
 
-  it("resolves approved context only for the owning project", () => {
+  it("resolves approved context only for the owning project", async () => {
     const repository = new InMemoryBrandBrainRepository();
     repository.upsert(record());
     assert.match(
-      resolveBrandBrainContext({
+      await resolveBrandBrainContext({
         repository,
         projectId: "project_001",
         brandId: "brand_001",
@@ -139,7 +139,7 @@ describe("Brand Brain context resolver", () => {
       /\[BRAND BRAIN\]/
     );
     assert.equal(
-      resolveBrandBrainContext({
+      await resolveBrandBrainContext({
         repository,
         projectId: "project_002",
         brandId: "brand_001",
@@ -148,14 +148,14 @@ describe("Brand Brain context resolver", () => {
     );
   });
 
-  it("does not resolve draft or archived records", () => {
+  it("does not resolve draft or archived records", async () => {
     for (const status of ["draft", "archived"]) {
       const repository = new InMemoryBrandBrainRepository();
       repository.upsert(
         record({ metadata: { ...record().metadata, status } })
       );
       assert.equal(
-        resolveBrandBrainContext({
+        await resolveBrandBrainContext({
           repository,
           projectId: "project_001",
           brandId: "brand_001",

--- a/test/brand-brain-generation.test.js
+++ b/test/brand-brain-generation.test.js
@@ -3,9 +3,11 @@ const { beforeEach, describe, it } = require("node:test");
 const request = require("supertest");
 const {
   InMemoryBrandBrainRepository,
+  PostgresBrandBrainRepository,
 } = require("../src/brand-brain");
 const { generateScriptWithVertex } = require("../src/generation");
 const { createApp } = require("../index");
+const { FakeBrandBrainPool } = require("./helpers/fake-brand-brain-pool");
 
 const ADMIN_KEY = "brand-brain-generation-test-key";
 const COMPLETE_OUTPUT = [
@@ -178,6 +180,52 @@ describe("Brand Brain generation integration", () => {
     assert.match(capture.value, /Explain how a planning workflow saves time\./);
   });
 
+  it("does not query unavailable persistence when brand_id is absent", async () => {
+    const repository = new PostgresBrandBrainRepository({
+      pool: new FakeBrandBrainPool({
+        failure: new Error("database should not be queried"),
+      }),
+    });
+    const capture = {};
+    const response = await admin(
+      request(
+        appWithCapturedPrompt(repository, capture, {
+          info() {},
+          warn() {},
+          error() {},
+        })
+      )
+        .post("/generate-script")
+        .send(validRequest())
+    );
+
+    assert.equal(response.status, 200);
+    assert.doesNotMatch(capture.value, /\[BRAND BRAIN\]/);
+  });
+
+  it("injects approved context through the production repository path", async () => {
+    const repository = new PostgresBrandBrainRepository({
+      pool: new FakeBrandBrainPool(),
+    });
+    await repository.upsert(record());
+    const capture = {};
+    const response = await admin(
+      request(
+        appWithCapturedPrompt(repository, capture, {
+          info() {},
+          warn() {},
+          error() {},
+        })
+      )
+        .post("/generate-script")
+        .send(validRequest({ brand_id: "brand_001" }))
+    );
+
+    assert.equal(response.status, 200);
+    assert.match(capture.value, /\[BRAND BRAIN\]/);
+    assert.match(capture.value, /Sensitive Brand Name/);
+  });
+
   it("does not inject a Brand Brain across project boundaries", async () => {
     const repository = new InMemoryBrandBrainRepository();
     repository.upsert(record());
@@ -245,5 +293,38 @@ describe("Brand Brain generation integration", () => {
     assert.doesNotMatch(logs, /confidential market position/);
     assert.doesNotMatch(logs, /magic button|Guaranteed revenue/);
     assert.doesNotMatch(logs, /Explain how a planning workflow saves time/);
+  });
+
+  it("fails closed with a safe response when an explicit lookup fails", async () => {
+    const repository = new PostgresBrandBrainRepository({
+      pool: new FakeBrandBrainPool({
+        failure: new Error("private provider diagnostic details"),
+      }),
+    });
+    let generated = false;
+    const response = await admin(
+      request(
+        createApp({
+          brandBrainRepository: repository,
+          scriptGenerator: async () => {
+            generated = true;
+            throw new Error("should not run");
+          },
+          logger: { info() {}, warn() {}, error() {} },
+        })
+      )
+        .post("/generate-script")
+        .send(validRequest({ brand_id: "brand_001" }))
+    );
+
+    assert.equal(response.status, 503);
+    assert.equal(response.body.status, "failed");
+    assert.equal(
+      response.body.error.code,
+      "BRAND_BRAIN_PERSISTENCE_UNAVAILABLE"
+    );
+    assert.equal(response.body.script_body, "");
+    assert.equal(generated, false);
+    assert.doesNotMatch(JSON.stringify(response.body), /private|provider|diagnostic/);
   });
 });

--- a/test/brand-brain-postgres-repository.test.js
+++ b/test/brand-brain-postgres-repository.test.js
@@ -1,0 +1,197 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+const {
+  PostgresBrandBrainRepository,
+  createPostgresBrandBrainRepositoryFromEnv,
+} = require("../src/brand-brain");
+const {
+  BrandBrainConfigurationError,
+  BrandBrainOwnershipError,
+  BrandBrainPersistenceError,
+} = require("../src/brand-brain/errors");
+const { FakeBrandBrainPool } = require("./helpers/fake-brand-brain-pool");
+
+function record(overrides = {}) {
+  return {
+    brand_id: "brand_001",
+    project_id: "project_001",
+    name: "BizGenie",
+    identity: { positioning: "An AI Brand Operating System." },
+    metadata: {
+      version: 1,
+      status: "approved",
+      created_at: "2026-08-08T09:00:00.000Z",
+      updated_at: "2026-08-08T09:00:00.000Z",
+    },
+    ...overrides,
+  };
+}
+
+describe("PostgresBrandBrainRepository", () => {
+  it("inserts, retrieves, updates, and returns defensive copies", async () => {
+    const repository = new PostgresBrandBrainRepository({
+      pool: new FakeBrandBrainPool(),
+    });
+    const inserted = await repository.upsert(record());
+    inserted.name = "Mutated response";
+
+    const updated = record({
+      name: "BizGenie Updated",
+      metadata: {
+        ...record().metadata,
+        updated_at: "2026-08-08T10:00:00.000Z",
+      },
+    });
+    await repository.upsert(updated);
+    updated.name = "Mutated input";
+
+    assert.equal((await repository.getByBrandId("brand_001")).name, "BizGenie Updated");
+    assert.equal(
+      (await repository.getByBrandId("brand_001")).metadata.created_at,
+      "2026-08-08T09:00:00.000Z"
+    );
+  });
+
+  it("returns null for unknown brands and project mismatches", async () => {
+    const pool = new FakeBrandBrainPool();
+    const repository = new PostgresBrandBrainRepository({ pool });
+    await repository.upsert(record());
+
+    assert.equal(await repository.getByBrandId("brand_missing"), null);
+    assert.equal(
+      await repository.getByProjectAndBrand("project_002", "brand_001"),
+      null
+    );
+    assert.equal(
+      (await repository.getByProjectAndBrand("project_001", "brand_001")).name,
+      "BizGenie"
+    );
+    const scopedQuery = pool.queries.find(({ text }) =>
+      text.includes("WHERE project_id = $1")
+    );
+    assert.deepEqual(scopedQuery.values, ["project_002", "brand_001"]);
+  });
+
+  it("preserves status values and rejects ownership reassignment atomically", async () => {
+    const repository = new PostgresBrandBrainRepository({
+      pool: new FakeBrandBrainPool(),
+    });
+    for (const status of ["approved", "draft", "archived"]) {
+      const value = record({
+        brand_id: `brand_${status}`,
+        metadata: { ...record().metadata, status },
+      });
+      assert.equal((await repository.upsert(value)).metadata.status, status);
+    }
+
+    await repository.upsert(record());
+    await assert.rejects(
+      repository.upsert(record({ project_id: "project_002" })),
+      BrandBrainOwnershipError
+    );
+  });
+
+  it("rejects malformed stored data without returning content", async () => {
+    const records = new Map([
+      [
+        "brand_001",
+        {
+          brand_id: "brand_001",
+          project_id: "project_001",
+          name: "Malformed",
+          identity: ["not-an-object"],
+          version: 1,
+          status: "approved",
+          created_at: "2026-08-08T09:00:00.000Z",
+          updated_at: "2026-08-08T09:00:00.000Z",
+        },
+      ],
+    ]);
+    const repository = new PostgresBrandBrainRepository({
+      pool: new FakeBrandBrainPool({ records }),
+    });
+
+    await assert.rejects(
+      repository.getByProjectAndBrand("project_001", "brand_001"),
+      (error) =>
+        error instanceof BrandBrainPersistenceError &&
+        !JSON.stringify(error).includes("Malformed")
+    );
+  });
+
+  it("sanitises database and initialization failures", async () => {
+    const repository = new PostgresBrandBrainRepository({
+      pool: new FakeBrandBrainPool({
+        failure: new Error("private provider diagnostic details"),
+      }),
+    });
+    for (const operation of [
+      () => repository.initialize(),
+      () => repository.getByBrandId("brand_001"),
+      () => repository.getByProjectAndBrand("project_001", "brand_001"),
+      () => repository.upsert(record()),
+    ]) {
+      await assert.rejects(operation(), (error) => {
+        assert.ok(error instanceof BrandBrainPersistenceError);
+        assert.doesNotMatch(error.message, /private|provider|diagnostic/);
+        return true;
+      });
+    }
+  });
+
+  it("persists across repository instance recreation with a shared database", async () => {
+    const records = new Map();
+    const writer = new PostgresBrandBrainRepository({
+      pool: new FakeBrandBrainPool({ records }),
+    });
+    await writer.upsert(record());
+
+    const reader = new PostgresBrandBrainRepository({
+      pool: new FakeBrandBrainPool({ records }),
+    });
+    assert.deepEqual(await reader.getByBrandId("brand_001"), record());
+  });
+});
+
+describe("Postgres Brand Brain configuration", () => {
+  it("fails deterministically for missing and malformed configuration", () => {
+    for (const env of [
+      {},
+      { BRAND_BRAIN_DATABASE_URL: "https://not-postgres.example" },
+      {
+        BRAND_BRAIN_DATABASE_URL: "postgresql://example.invalid/database",
+        BRAND_BRAIN_DB_POOL_MAX: "unbounded",
+      },
+    ]) {
+      assert.throws(
+        () => createPostgresBrandBrainRepositoryFromEnv({ env }),
+        BrandBrainConfigurationError
+      );
+    }
+  });
+
+  it("creates one bounded pool from environment configuration", () => {
+    let config;
+    class CapturingPool extends FakeBrandBrainPool {
+      constructor(value) {
+        super();
+        config = value;
+      }
+    }
+
+    const repository = createPostgresBrandBrainRepositoryFromEnv({
+      env: {
+        BRAND_BRAIN_DATABASE_URL: "postgresql://example.invalid/database",
+        BRAND_BRAIN_DB_POOL_MAX: "4",
+        BRAND_BRAIN_DB_CONNECTION_TIMEOUT_MS: "6000",
+        BRAND_BRAIN_DB_IDLE_TIMEOUT_MS: "45000",
+      },
+      PoolClass: CapturingPool,
+    });
+
+    assert.ok(repository instanceof PostgresBrandBrainRepository);
+    assert.equal(config.max, 4);
+    assert.equal(config.connectionTimeoutMillis, 6000);
+    assert.equal(config.idleTimeoutMillis, 45000);
+  });
+});

--- a/test/helpers/fake-brand-brain-pool.js
+++ b/test/helpers/fake-brand-brain-pool.js
@@ -1,0 +1,75 @@
+function clone(value) {
+  return value === undefined ? undefined : structuredClone(value);
+}
+
+class FakeBrandBrainPool {
+  constructor({ records = new Map(), failure = null } = {}) {
+    this.records = records;
+    this.failure = failure;
+    this.queries = [];
+    this.ended = false;
+  }
+
+  async query(text, values = []) {
+    this.queries.push({ text, values: clone(values) });
+    if (this.failure) {
+      throw this.failure;
+    }
+    if (text.includes("LIMIT 0")) {
+      return { rowCount: 0, rows: [] };
+    }
+
+    if (text.includes("INSERT INTO public.brand_brains")) {
+      const [
+        brand_id,
+        project_id,
+        name,
+        identity,
+        voice,
+        audience,
+        commercial,
+        competitors,
+        visual,
+        version,
+        status,
+        created_at,
+        updated_at,
+      ] = values;
+      const existing = this.records.get(brand_id);
+      if (existing && existing.project_id !== project_id) {
+        return { rowCount: 0, rows: [] };
+      }
+      const row = {
+        brand_id,
+        project_id,
+        name,
+        identity,
+        voice,
+        audience,
+        commercial,
+        competitors,
+        visual,
+        version,
+        status,
+        created_at: existing?.created_at ?? created_at,
+        updated_at,
+      };
+      this.records.set(brand_id, clone(row));
+      return { rowCount: 1, rows: [clone(row)] };
+    }
+
+    const projectScoped = text.includes("WHERE project_id = $1");
+    const brandId = projectScoped ? values[1] : values[0];
+    const row = this.records.get(brandId);
+    if (!row || (projectScoped && row.project_id !== values[0])) {
+      return { rowCount: 0, rows: [] };
+    }
+    return { rowCount: 1, rows: [clone(row)] };
+  }
+
+  async end() {
+    this.ended = true;
+  }
+}
+
+module.exports = { FakeBrandBrainPool };


### PR DESCRIPTION
## Summary

- replace production Brand Brain process memory with a pooled PostgreSQL repository while retaining the in-memory implementation for isolated tests
- add the version-controlled Supabase migration at `supabase/migrations/20260808170000_create_brand_brains.sql`
- make Brand Brain lookup/admin paths async without coupling the resolver or Prompt Compiler to PostgreSQL
- enforce project-scoped generation reads and atomic ownership-preserving upserts
- fail production startup on missing, malformed, unreachable, or unmigrated database configuration
- fail explicit Brand Brain generation lookups closed with a safe structured 503
- document migration, tenancy boundaries, backup responsibility, connection sizing, non-goals, and the post-merge verification runbook

## Persistence and security

Cloud Run uses one bounded `pg.Pool` per process against a server-side Supabase Supavisor session-mode connection. The database stores one canonical row per globally stable `brand_id`, persists `project_id`, enables RLS, revokes client roles, and prevents ownership/creation-time reassignment. The repository uses `(project_id, brand_id)` for generation lookup; the resolver still requires an approved record.

No frontend Supabase auth change, client table exposure, deployment, migration execution, or production state change is included.

## Validation

- untouched baseline: 82 tests passed
- final local suite: 96 tests passed
- `npm ci --no-audit --no-fund`
- JavaScript syntax checks for `index.js`, `src/`, `test/`, and `scripts/`
- `git diff --check`
- optional real Postgres integration path added without requiring CI secrets
- exact-head GitHub Actions run 34: Node 22 tests/syntax passed
- exact-head GitHub Actions run 34: Docker and Google Buildpack build/runtime/migrated-Postgres smoke checks passed