### PR TITLE
BG-AUTH-002A — Customer identity and tenant authorization foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ The tests do not call Vertex AI and do not require Google Cloud credentials.
 The authenticated routes require the `x-admin-key` header to exactly match the
 `ADMIN_KEY` environment variable.
 
+## Customer identity and authorization foundation
+
+BG-AUTH-002A adds the provider-neutral customer actor, tenant membership,
+project ownership, and project-to-Brand-Brain authorization contract under
+`src/authorization/`. It does not verify customer tokens or change route
+authentication; existing routes continue to use `ADMIN_KEY` until the bounded
+BG-AUTH-002B enforcement task.
+
+The version-controlled migration creates `customer_profiles`, `tenants`,
+`tenant_memberships`, and `projects`, anchors profiles to `auth.users.id`, makes
+project tenant ownership immutable, and adds the relational Brand Brain project
+foreign key. The complete security, rollout, backfill, and rollback contract is
+documented in `docs/security/IDENTITY_AUTHORIZATION_FOUNDATION.md`.
+
 ## Brand Brain context foundation
 
 Brand Brain is the persistent brand-intelligence layer of the future Company

--- a/docs/security/IDENTITY_AUTHORIZATION_FOUNDATION.md
+++ b/docs/security/IDENTITY_AUTHORIZATION_FOUNDATION.md
@@ -1,0 +1,92 @@
+# Customer identity and authorization foundation
+
+BG-AUTH-002A establishes the durable ownership graph without activating customer
+token verification or changing any route authentication:
+
+```text
+auth.users.id
+  -> customer_profiles.auth_user_id
+  -> tenant_memberships.auth_user_id
+  -> tenants.tenant_id
+  -> projects.tenant_id
+  -> brand_brains.project_id
+```
+
+## Principals and trust boundaries
+
+- A customer actor is created only from a verified Supabase Auth UUID. A body,
+  query, or route `user_id` is never identity evidence.
+- A service actor has a distinct `service_id` and explicit scopes. This
+  foundation defines the principal shape only; BG-AUTH-002C will define and
+  enforce the credential and generation-job boundary.
+- An administrator remains authenticated by the existing `ADMIN_KEY` and
+  `x-admin-key` middleware. Customer actors and service actors do not inherit
+  administrator authority.
+
+`src/authorization/` is provider-neutral. Token verification in BG-AUTH-002B
+must pass a verified UUID into `createCustomerActorFromVerifiedIdentity` and
+then call `AuthorizationService`; it must not pass the request's `user_id`.
+
+## Authorization contract
+
+The service fails closed and resolves each link independently:
+
+1. Validate a trusted actor.
+2. Resolve the customer profile by the verified Auth UUID.
+3. Resolve membership in the requested tenant and check the minimal role
+   policy (`owner` or `member`) for the requested action.
+4. Resolve the requested project and compare its immutable `tenant_id`.
+5. Resolve a Brand Brain by the existing `(project_id, brand_id)` pair.
+
+Every client-supplied identifier is a requested resource only. A missing
+resource, non-membership, cross-tenant project, disallowed role, and
+project/brand mismatch all return the same `RESOURCE_NOT_AVAILABLE` denial so
+the contract does not disclose cross-tenant existence.
+
+The database enables RLS and installs read policies as defense in depth, but
+keeps `anon` and `authenticated` table privileges revoked in this task. No
+route may rely on RLS alone: the server database role can own tables or bypass
+RLS, so server-side authorization remains mandatory.
+
+## Migration and rollout
+
+The migration is version-controlled at
+`supabase/migrations/20260818010000_create_customer_tenant_authorization_foundation.sql`.
+It was not applied to any database by this task.
+
+Before a future authorized application:
+
+1. Back up the target and verify point-in-time recovery.
+2. Inventory existing `brand_brains.project_id` values.
+3. Create reviewed customer profile, tenant, membership, and project rows for
+   each known owner. Do not invent owners for orphaned projects.
+4. Apply the migration in a staging branch/database first.
+5. Confirm new Brand Brain writes require a real project.
+6. After every existing Brand Brain has a project, run
+   `alter table public.brand_brains validate constraint brand_brains_project_id_fkey;`.
+7. Run Supabase security and performance advisors, then the two-tenant
+   acceptance suite before production rollout.
+
+The Brand Brain foreign key is created `not valid`: it protects new writes
+immediately while allowing existing rows to be mapped deliberately before the
+constraint is validated.
+
+Rollback should be forward-fix first. If application code must be rolled back,
+remove only the new Brand Brain foreign key initially:
+
+```sql
+alter table public.brand_brains
+  drop constraint if exists brand_brains_project_id_fkey;
+```
+
+Keep the ownership tables and data during investigation. Dropping them is a
+destructive operation and must happen only after a verified backup, an empty
+dependency check, and separate authorization.
+
+## Forward ownership references
+
+Future subscription and credit-account rows should reference `tenant_id`.
+Credit reservations and generation requests should reference both `tenant_id`
+and `project_id`; generated assets should also retain the originating
+generation request and project. Those systems are intentionally not created by
+BG-AUTH-002A.

--- a/src/authorization/errors.js
+++ b/src/authorization/errors.js
@@ -1,0 +1,22 @@
+class AuthenticationRequiredError extends Error {
+  constructor() {
+    super("A verified customer identity is required");
+    this.name = "AuthenticationRequiredError";
+    this.status = 401;
+    this.code = "AUTHENTICATION_REQUIRED";
+  }
+}
+
+class AuthorizationDeniedError extends Error {
+  constructor() {
+    super("The requested resource is not available");
+    this.name = "AuthorizationDeniedError";
+    this.status = 404;
+    this.code = "RESOURCE_NOT_AVAILABLE";
+  }
+}
+
+module.exports = {
+  AuthenticationRequiredError,
+  AuthorizationDeniedError,
+};

--- a/src/authorization/index.js
+++ b/src/authorization/index.js
@@ -1,0 +1,15 @@
+const errors = require("./errors");
+const policy = require("./policy");
+const repositories = require("./repository");
+const schemas = require("./schema");
+const { PostgresAuthorizationRepository } = require("./postgresRepository");
+const { AuthorizationService } = require("./service");
+
+module.exports = {
+  AuthorizationService,
+  PostgresAuthorizationRepository,
+  ...errors,
+  ...policy,
+  ...repositories,
+  ...schemas,
+};

--- a/src/authorization/policy.js
+++ b/src/authorization/policy.js
@@ -1,0 +1,29 @@
+const AUTHORIZATION_ACTIONS = Object.freeze([
+  "tenant:read",
+  "tenant:manage",
+  "project:read",
+  "project:write",
+  "brand:read",
+  "brand:write",
+  "generation:create",
+]);
+
+const ROLE_ACTIONS = Object.freeze({
+  owner: new Set(AUTHORIZATION_ACTIONS),
+  member: new Set([
+    "tenant:read",
+    "project:read",
+    "brand:read",
+    "generation:create",
+  ]),
+});
+
+function roleAllows(role, action) {
+  return ROLE_ACTIONS[role]?.has(action) === true;
+}
+
+module.exports = {
+  AUTHORIZATION_ACTIONS,
+  ROLE_ACTIONS,
+  roleAllows,
+};

--- a/src/authorization/postgresRepository.js
+++ b/src/authorization/postgresRepository.js
@@ -1,0 +1,67 @@
+const { AuthorizationRepository } = require("./repository");
+
+class PostgresAuthorizationRepository extends AuthorizationRepository {
+  constructor({ pool }) {
+    super();
+    if (!pool || typeof pool.query !== "function") {
+      throw new TypeError("A PostgreSQL connection pool is required");
+    }
+    this.pool = pool;
+  }
+
+  async getCustomerProfileByAuthUserId(authUserId) {
+    const result = await this.pool.query(
+      `SELECT auth_user_id, display_name, created_at, updated_at
+         FROM public.customer_profiles
+        WHERE auth_user_id = $1`,
+      [authUserId]
+    );
+    return result.rows[0] || null;
+  }
+
+  async getTenantById(tenantId) {
+    const result = await this.pool.query(
+      `SELECT tenant_id, name, created_by, created_at, updated_at
+         FROM public.tenants
+        WHERE tenant_id = $1`,
+      [tenantId]
+    );
+    return result.rows[0] || null;
+  }
+
+  async getTenantMembership(tenantId, authUserId) {
+    const result = await this.pool.query(
+      `SELECT tenant_id, auth_user_id, role, created_at, updated_at
+         FROM public.tenant_memberships
+        WHERE tenant_id = $1
+          AND auth_user_id = $2`,
+      [tenantId, authUserId]
+    );
+    return result.rows[0] || null;
+  }
+
+  async getProjectById(projectId) {
+    const result = await this.pool.query(
+      `SELECT project_id, tenant_id, name, created_at, updated_at
+         FROM public.projects
+        WHERE project_id = $1`,
+      [projectId]
+    );
+    return result.rows[0] || null;
+  }
+
+  async getBrandByProjectAndBrand(projectId, brandId) {
+    const result = await this.pool.query(
+      `SELECT brand_id, project_id, name, status
+         FROM public.brand_brains
+        WHERE project_id = $1
+          AND brand_id = $2`,
+      [projectId, brandId]
+    );
+    return result.rows[0] || null;
+  }
+}
+
+module.exports = {
+  PostgresAuthorizationRepository,
+};

--- a/src/authorization/repository.js
+++ b/src/authorization/repository.js
@@ -1,0 +1,89 @@
+class AuthorizationRepository {
+  getCustomerProfileByAuthUserId(_authUserId) {
+    throw new Error(
+      "AuthorizationRepository.getCustomerProfileByAuthUserId is not implemented"
+    );
+  }
+
+  getTenantById(_tenantId) {
+    throw new Error("AuthorizationRepository.getTenantById is not implemented");
+  }
+
+  getTenantMembership(_tenantId, _authUserId) {
+    throw new Error(
+      "AuthorizationRepository.getTenantMembership is not implemented"
+    );
+  }
+
+  getProjectById(_projectId) {
+    throw new Error("AuthorizationRepository.getProjectById is not implemented");
+  }
+
+  getBrandByProjectAndBrand(_projectId, _brandId) {
+    throw new Error(
+      "AuthorizationRepository.getBrandByProjectAndBrand is not implemented"
+    );
+  }
+}
+
+function clone(value) {
+  return value ? structuredClone(value) : null;
+}
+
+class InMemoryAuthorizationRepository extends AuthorizationRepository {
+  constructor({
+    customerProfiles = [],
+    tenants = [],
+    memberships = [],
+    projects = [],
+    brands = [],
+  } = {}) {
+    super();
+    this.customerProfiles = new Map(
+      customerProfiles.map((profile) => [profile.auth_user_id, clone(profile)])
+    );
+    this.tenants = new Map(
+      tenants.map((tenant) => [tenant.tenant_id, clone(tenant)])
+    );
+    this.memberships = new Map(
+      memberships.map((membership) => [
+        `${membership.tenant_id}\u0000${membership.auth_user_id}`,
+        clone(membership),
+      ])
+    );
+    this.projects = new Map(
+      projects.map((project) => [project.project_id, clone(project)])
+    );
+    this.brands = new Map(
+      brands.map((brand) => [
+        `${brand.project_id}\u0000${brand.brand_id}`,
+        clone(brand),
+      ])
+    );
+  }
+
+  getCustomerProfileByAuthUserId(authUserId) {
+    return clone(this.customerProfiles.get(authUserId));
+  }
+
+  getTenantById(tenantId) {
+    return clone(this.tenants.get(tenantId));
+  }
+
+  getTenantMembership(tenantId, authUserId) {
+    return clone(this.memberships.get(`${tenantId}\u0000${authUserId}`));
+  }
+
+  getProjectById(projectId) {
+    return clone(this.projects.get(projectId));
+  }
+
+  getBrandByProjectAndBrand(projectId, brandId) {
+    return clone(this.brands.get(`${projectId}\u0000${brandId}`));
+  }
+}
+
+module.exports = {
+  AuthorizationRepository,
+  InMemoryAuthorizationRepository,
+};

--- a/src/authorization/schema.js
+++ b/src/authorization/schema.js
@@ -1,0 +1,59 @@
+const { z } = require("zod");
+const { AuthenticationRequiredError } = require("./errors");
+
+const IDENTIFIER_MAX_LENGTH = 128;
+const identifier = z
+  .string()
+  .trim()
+  .min(1)
+  .max(IDENTIFIER_MAX_LENGTH)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/, "Invalid identifier");
+
+const CustomerActorSchema = z
+  .object({
+    kind: z.literal("customer"),
+    auth_user_id: z.uuid(),
+  })
+  .strict();
+
+const ServiceActorSchema = z
+  .object({
+    kind: z.literal("service"),
+    service_id: identifier,
+    scopes: z.array(identifier).max(20),
+  })
+  .strict();
+
+const AdministratorActorSchema = z
+  .object({
+    kind: z.literal("administrator"),
+  })
+  .strict();
+
+const ActorSchema = z.discriminatedUnion("kind", [
+  CustomerActorSchema,
+  ServiceActorSchema,
+  AdministratorActorSchema,
+]);
+
+function createCustomerActorFromVerifiedIdentity({ verifiedAuthUserId } = {}) {
+  const parsed = CustomerActorSchema.safeParse({
+    kind: "customer",
+    auth_user_id: verifiedAuthUserId,
+  });
+
+  if (!parsed.success) {
+    throw new AuthenticationRequiredError();
+  }
+
+  return Object.freeze(parsed.data);
+}
+
+module.exports = {
+  ActorSchema,
+  AdministratorActorSchema,
+  CustomerActorSchema,
+  IDENTIFIER_MAX_LENGTH,
+  ServiceActorSchema,
+  createCustomerActorFromVerifiedIdentity,
+};

--- a/src/authorization/service.js
+++ b/src/authorization/service.js
@@ -1,0 +1,91 @@
+const { ActorSchema } = require("./schema");
+const { roleAllows } = require("./policy");
+const { AuthorizationDeniedError } = require("./errors");
+
+function deny() {
+  throw new AuthorizationDeniedError();
+}
+
+class AuthorizationService {
+  constructor({ repository }) {
+    if (!repository) {
+      throw new TypeError("An authorization repository is required");
+    }
+    this.repository = repository;
+  }
+
+  async authorizeTenant({ actor, tenantId, action }) {
+    const parsedActor = ActorSchema.safeParse(actor);
+    if (!parsedActor.success || parsedActor.data.kind !== "customer") {
+      return deny();
+    }
+
+    const authUserId = parsedActor.data.auth_user_id;
+    const [profile, tenant, membership] = await Promise.all([
+      this.repository.getCustomerProfileByAuthUserId(authUserId),
+      this.repository.getTenantById(tenantId),
+      this.repository.getTenantMembership(tenantId, authUserId),
+    ]);
+
+    if (!profile || !tenant || !membership || !roleAllows(membership.role, action)) {
+      return deny();
+    }
+
+    return Object.freeze({
+      actor: parsedActor.data,
+      tenant_id: tenantId,
+      membership_role: membership.role,
+      action,
+    });
+  }
+
+  async authorizeProject({ actor, tenantId, projectId, action }) {
+    const tenantAuthorization = await this.authorizeTenant({
+      actor,
+      tenantId,
+      action,
+    });
+    const project = await this.repository.getProjectById(projectId);
+
+    if (!project || project.tenant_id !== tenantId) {
+      return deny();
+    }
+
+    return Object.freeze({
+      ...tenantAuthorization,
+      project_id: projectId,
+    });
+  }
+
+  async authorizeProjectBrand({
+    actor,
+    tenantId,
+    projectId,
+    brandId,
+    action,
+  }) {
+    const projectAuthorization = await this.authorizeProject({
+      actor,
+      tenantId,
+      projectId,
+      action,
+    });
+    const brand = await this.repository.getBrandByProjectAndBrand(
+      projectId,
+      brandId
+    );
+
+    if (!brand) {
+      return deny();
+    }
+
+    return Object.freeze({
+      ...projectAuthorization,
+      brand_id: brandId,
+    });
+  }
+}
+
+module.exports = {
+  AuthorizationService,
+};

--- a/supabase/migrations/20260818010000_create_customer_tenant_authorization_foundation.sql
+++ b/supabase/migrations/20260818010000_create_customer_tenant_authorization_foundation.sql
@@ -1,0 +1,250 @@
+create table if not exists public.customer_profiles (
+  auth_user_id uuid primary key
+    references auth.users (id) on delete cascade,
+  display_name text,
+  created_at timestamptz not null default current_timestamp,
+  updated_at timestamptz not null default current_timestamp,
+  constraint customer_profiles_display_name_length check (
+    display_name is null or length(trim(display_name)) between 1 and 200
+  )
+);
+
+create table if not exists public.tenants (
+  tenant_id text primary key,
+  name text not null,
+  created_by uuid not null
+    references public.customer_profiles (auth_user_id) on delete restrict,
+  created_at timestamptz not null default current_timestamp,
+  updated_at timestamptz not null default current_timestamp,
+  constraint tenants_tenant_id_format check (
+    length(tenant_id) between 1 and 128
+    and tenant_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]*$'
+  ),
+  constraint tenants_name_length check (length(trim(name)) between 1 and 200)
+);
+
+create table if not exists public.tenant_memberships (
+  tenant_id text not null
+    references public.tenants (tenant_id) on delete cascade,
+  auth_user_id uuid not null
+    references public.customer_profiles (auth_user_id) on delete cascade,
+  role text not null,
+  created_at timestamptz not null default current_timestamp,
+  updated_at timestamptz not null default current_timestamp,
+  primary key (tenant_id, auth_user_id),
+  constraint tenant_memberships_role_allowed check (role in ('owner', 'member'))
+);
+
+create table if not exists public.projects (
+  project_id text primary key,
+  tenant_id text not null
+    references public.tenants (tenant_id) on delete restrict,
+  name text not null,
+  created_at timestamptz not null default current_timestamp,
+  updated_at timestamptz not null default current_timestamp,
+  constraint projects_project_id_format check (
+    length(project_id) between 1 and 128
+    and project_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]*$'
+  ),
+  constraint projects_name_length check (length(trim(name)) between 1 and 200)
+);
+
+create index if not exists tenants_created_by_idx
+  on public.tenants (created_by);
+create index if not exists tenant_memberships_auth_user_tenant_idx
+  on public.tenant_memberships (auth_user_id, tenant_id);
+create index if not exists projects_tenant_id_idx
+  on public.projects (tenant_id);
+
+create or replace function public.protect_customer_profile_identity()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if new.auth_user_id is distinct from old.auth_user_id then
+    raise exception 'customer profile auth identity is immutable'
+      using errcode = '23514';
+  end if;
+  if new.created_at is distinct from old.created_at then
+    raise exception 'customer profile creation timestamp is immutable'
+      using errcode = '23514';
+  end if;
+  return new;
+end;
+$$;
+
+create or replace function public.protect_tenant_identity()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if new.tenant_id is distinct from old.tenant_id then
+    raise exception 'tenant identity is immutable' using errcode = '23514';
+  end if;
+  if new.created_by is distinct from old.created_by then
+    raise exception 'tenant creator is immutable' using errcode = '23514';
+  end if;
+  if new.created_at is distinct from old.created_at then
+    raise exception 'tenant creation timestamp is immutable'
+      using errcode = '23514';
+  end if;
+  return new;
+end;
+$$;
+
+create or replace function public.protect_tenant_membership_identity()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if new.tenant_id is distinct from old.tenant_id
+    or new.auth_user_id is distinct from old.auth_user_id then
+    raise exception 'tenant membership identity is immutable'
+      using errcode = '23514';
+  end if;
+  if new.created_at is distinct from old.created_at then
+    raise exception 'tenant membership creation timestamp is immutable'
+      using errcode = '23514';
+  end if;
+  return new;
+end;
+$$;
+
+create or replace function public.protect_project_ownership()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if new.project_id is distinct from old.project_id then
+    raise exception 'project identity is immutable' using errcode = '23514';
+  end if;
+  if new.tenant_id is distinct from old.tenant_id then
+    raise exception 'project tenant ownership is immutable'
+      using errcode = '23514';
+  end if;
+  if new.created_at is distinct from old.created_at then
+    raise exception 'project creation timestamp is immutable'
+      using errcode = '23514';
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists protect_customer_profile_identity
+  on public.customer_profiles;
+create trigger protect_customer_profile_identity
+before update on public.customer_profiles
+for each row execute function public.protect_customer_profile_identity();
+
+drop trigger if exists protect_tenant_identity on public.tenants;
+create trigger protect_tenant_identity
+before update on public.tenants
+for each row execute function public.protect_tenant_identity();
+
+drop trigger if exists protect_tenant_membership_identity
+  on public.tenant_memberships;
+create trigger protect_tenant_membership_identity
+before update on public.tenant_memberships
+for each row execute function public.protect_tenant_membership_identity();
+
+drop trigger if exists protect_project_ownership on public.projects;
+create trigger protect_project_ownership
+before update on public.projects
+for each row execute function public.protect_project_ownership();
+
+do $$
+begin
+  if not exists (
+    select 1
+      from pg_constraint
+     where conname = 'brand_brains_project_id_fkey'
+       and conrelid = 'public.brand_brains'::regclass
+  ) then
+    alter table public.brand_brains
+      add constraint brand_brains_project_id_fkey
+      foreign key (project_id)
+      references public.projects (project_id)
+      on delete restrict
+      not valid;
+  end if;
+end;
+$$;
+
+alter table public.customer_profiles enable row level security;
+alter table public.tenants enable row level security;
+alter table public.tenant_memberships enable row level security;
+alter table public.projects enable row level security;
+
+drop policy if exists customer_profiles_select_own
+  on public.customer_profiles;
+create policy customer_profiles_select_own
+on public.customer_profiles
+for select
+to authenticated
+using ((select auth.uid()) = auth_user_id);
+
+drop policy if exists tenant_memberships_select_own
+  on public.tenant_memberships;
+create policy tenant_memberships_select_own
+on public.tenant_memberships
+for select
+to authenticated
+using ((select auth.uid()) = auth_user_id);
+
+drop policy if exists tenants_select_for_member on public.tenants;
+create policy tenants_select_for_member
+on public.tenants
+for select
+to authenticated
+using (
+  tenant_id in (
+    select membership.tenant_id
+      from public.tenant_memberships as membership
+     where membership.auth_user_id = (select auth.uid())
+  )
+);
+
+drop policy if exists projects_select_for_member on public.projects;
+create policy projects_select_for_member
+on public.projects
+for select
+to authenticated
+using (
+  tenant_id in (
+    select membership.tenant_id
+      from public.tenant_memberships as membership
+     where membership.auth_user_id = (select auth.uid())
+  )
+);
+
+do $$
+begin
+  if exists (select 1 from pg_roles where rolname = 'anon') then
+    revoke all on table public.customer_profiles from anon;
+    revoke all on table public.tenants from anon;
+    revoke all on table public.tenant_memberships from anon;
+    revoke all on table public.projects from anon;
+  end if;
+  if exists (select 1 from pg_roles where rolname = 'authenticated') then
+    revoke all on table public.customer_profiles from authenticated;
+    revoke all on table public.tenants from authenticated;
+    revoke all on table public.tenant_memberships from authenticated;
+    revoke all on table public.projects from authenticated;
+  end if;
+end;
+$$;
+
+comment on table public.customer_profiles is
+  'Customer profile anchored one-to-one to the immutable Supabase Auth user UUID.';
+comment on table public.tenants is
+  'Canonical commercial and customer isolation boundary.';
+comment on table public.tenant_memberships is
+  'Minimal owner/member relationship between Supabase identities and tenants.';
+comment on table public.projects is
+  'Tenant-owned project root for Brand Brain and future tenant-scoped resources.';
+comment on column public.projects.tenant_id is
+  'Immutable ownership reference for future subscriptions, credit accounts, generation requests, and generated assets.';

--- a/test/authorization-migration.test.js
+++ b/test/authorization-migration.test.js
@@ -1,0 +1,65 @@
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const { join } = require("node:path");
+const { describe, it } = require("node:test");
+
+const migration = readFileSync(
+  join(
+    __dirname,
+    "..",
+    "supabase",
+    "migrations",
+    "20260818010000_create_customer_tenant_authorization_foundation.sql"
+  ),
+  "utf8"
+).toLowerCase();
+
+describe("customer tenant ownership migration", () => {
+  it("anchors customer profiles to the auth.users primary key", () => {
+    assert.match(migration, /auth_user_id uuid primary key/);
+    assert.match(migration, /references auth\.users \(id\)/);
+  });
+
+  it("creates role-capable tenant membership with one row per user and tenant", () => {
+    assert.match(migration, /primary key \(tenant_id, auth_user_id\)/);
+    assert.match(migration, /role in \('owner', 'member'\)/);
+    assert.match(migration, /tenant_memberships_auth_user_tenant_idx/);
+  });
+
+  it("makes every project belong to exactly one tenant", () => {
+    assert.match(migration, /tenant_id text not null[\s\S]*references public\.tenants/);
+    assert.match(migration, /create table if not exists public\.projects/);
+    assert.match(migration, /project_id text primary key/);
+  });
+
+  it("prevents ordinary updates from transferring project ownership", () => {
+    assert.match(migration, /if new\.tenant_id is distinct from old\.tenant_id/);
+    assert.match(migration, /project tenant ownership is immutable/);
+    assert.match(migration, /before update on public\.projects/);
+  });
+
+  it("links Brand Brain to projects without bypassing deliberate legacy backfill", () => {
+    assert.match(migration, /brand_brains_project_id_fkey/);
+    assert.match(migration, /foreign key \(project_id\)/);
+    assert.match(migration, /references public\.projects \(project_id\)/);
+    assert.match(migration, /not valid/);
+  });
+
+  it("enables RLS while retaining server-only table privileges", () => {
+    for (const table of [
+      "customer_profiles",
+      "tenants",
+      "tenant_memberships",
+      "projects",
+    ]) {
+      assert.match(
+        migration,
+        new RegExp(`alter table public\\.${table} enable row level security`)
+      );
+      assert.match(
+        migration,
+        new RegExp(`revoke all on table public\\.${table} from authenticated`)
+      );
+    }
+  });
+});

--- a/test/authorization-postgres-repository.test.js
+++ b/test/authorization-postgres-repository.test.js
@@ -1,0 +1,68 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+
+const {
+  PostgresAuthorizationRepository,
+} = require("../src/authorization");
+
+class RecordingPool {
+  constructor(rows) {
+    this.rows = [...rows];
+    this.calls = [];
+  }
+
+  async query(text, values) {
+    this.calls.push({ text, values });
+    return { rows: [this.rows.shift()].filter(Boolean) };
+  }
+}
+
+describe("PostgresAuthorizationRepository", () => {
+  it("resolves every ownership link with parameterized scoped queries", async () => {
+    const authUserId = "11111111-1111-4111-8111-111111111111";
+    const pool = new RecordingPool([
+      { auth_user_id: authUserId },
+      { tenant_id: "tenant_a" },
+      { tenant_id: "tenant_a", auth_user_id: authUserId, role: "owner" },
+      { project_id: "project_a", tenant_id: "tenant_a" },
+      { brand_id: "brand_a", project_id: "project_a" },
+    ]);
+    const repository = new PostgresAuthorizationRepository({ pool });
+
+    assert.equal(
+      (await repository.getCustomerProfileByAuthUserId(authUserId)).auth_user_id,
+      authUserId
+    );
+    assert.equal((await repository.getTenantById("tenant_a")).tenant_id, "tenant_a");
+    assert.equal(
+      (await repository.getTenantMembership("tenant_a", authUserId)).role,
+      "owner"
+    );
+    assert.equal(
+      (await repository.getProjectById("project_a")).tenant_id,
+      "tenant_a"
+    );
+    assert.equal(
+      (
+        await repository.getBrandByProjectAndBrand("project_a", "brand_a")
+      ).brand_id,
+      "brand_a"
+    );
+
+    assert.deepEqual(pool.calls.map((call) => call.values), [
+      [authUserId],
+      ["tenant_a"],
+      ["tenant_a", authUserId],
+      ["project_a"],
+      ["project_a", "brand_a"],
+    ]);
+    assert.match(pool.calls[4].text, /where project_id = \$1\s+and brand_id = \$2/i);
+  });
+
+  it("returns null without leaking a missing row", async () => {
+    const repository = new PostgresAuthorizationRepository({
+      pool: new RecordingPool([]),
+    });
+    assert.equal(await repository.getProjectById("unknown"), null);
+  });
+});

--- a/test/authorization.test.js
+++ b/test/authorization.test.js
@@ -1,0 +1,162 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+
+const {
+  AuthenticationRequiredError,
+  AuthorizationDeniedError,
+  AuthorizationService,
+  InMemoryAuthorizationRepository,
+  createCustomerActorFromVerifiedIdentity,
+} = require("../src/authorization");
+
+const USER_A = "11111111-1111-4111-8111-111111111111";
+const USER_B = "22222222-2222-4222-8222-222222222222";
+
+function fixture() {
+  const repository = new InMemoryAuthorizationRepository({
+    customerProfiles: [
+      { auth_user_id: USER_A, display_name: "Customer A" },
+      { auth_user_id: USER_B, display_name: "Customer B" },
+    ],
+    tenants: [
+      { tenant_id: "tenant_a", name: "Tenant A", created_by: USER_A },
+      { tenant_id: "tenant_b", name: "Tenant B", created_by: USER_B },
+    ],
+    memberships: [
+      { tenant_id: "tenant_a", auth_user_id: USER_A, role: "owner" },
+      { tenant_id: "tenant_b", auth_user_id: USER_B, role: "owner" },
+    ],
+    projects: [
+      { project_id: "project_a", tenant_id: "tenant_a", name: "Project A" },
+      { project_id: "project_b", tenant_id: "tenant_b", name: "Project B" },
+    ],
+    brands: [
+      { brand_id: "brand_a", project_id: "project_a", name: "Brand A" },
+      { brand_id: "brand_b", project_id: "project_b", name: "Brand B" },
+    ],
+  });
+
+  return {
+    repository,
+    service: new AuthorizationService({ repository }),
+    actorA: createCustomerActorFromVerifiedIdentity({
+      verifiedAuthUserId: USER_A,
+    }),
+    actorB: createCustomerActorFromVerifiedIdentity({
+      verifiedAuthUserId: USER_B,
+    }),
+  };
+}
+
+describe("customer identity contract", () => {
+  it("anchors a customer actor to a verified Supabase Auth UUID", () => {
+    const actor = createCustomerActorFromVerifiedIdentity({
+      verifiedAuthUserId: USER_A,
+    });
+    assert.deepEqual(actor, { kind: "customer", auth_user_id: USER_A });
+    assert.equal(Object.isFrozen(actor), true);
+  });
+
+  it("does not allow a client-supplied user_id to establish identity", () => {
+    assert.throws(
+      () =>
+        createCustomerActorFromVerifiedIdentity({
+          requestBody: { user_id: USER_A },
+        }),
+      AuthenticationRequiredError
+    );
+  });
+});
+
+describe("tenant, project, and brand authorization", () => {
+  it("authorizes a member of the owning tenant for its project", async () => {
+    const { service, actorA } = fixture();
+    const result = await service.authorizeProject({
+      actor: actorA,
+      tenantId: "tenant_a",
+      projectId: "project_a",
+      action: "project:read",
+    });
+
+    assert.deepEqual(result, {
+      actor: actorA,
+      tenant_id: "tenant_a",
+      membership_role: "owner",
+      action: "project:read",
+      project_id: "project_a",
+    });
+  });
+
+  it("resolves the complete authenticated tenant/project/brand chain", async () => {
+    const { service, actorA } = fixture();
+    const result = await service.authorizeProjectBrand({
+      actor: actorA,
+      tenantId: "tenant_a",
+      projectId: "project_a",
+      brandId: "brand_a",
+      action: "brand:read",
+    });
+
+    assert.equal(result.actor.auth_user_id, USER_A);
+    assert.equal(result.tenant_id, "tenant_a");
+    assert.equal(result.project_id, "project_a");
+    assert.equal(result.brand_id, "brand_a");
+  });
+
+  it("does not authorize Tenant A for Tenant B's project", async () => {
+    const { service, actorA } = fixture();
+    await assert.rejects(
+      service.authorizeProject({
+        actor: actorA,
+        tenantId: "tenant_a",
+        projectId: "project_b",
+        action: "project:read",
+      }),
+      (error) =>
+        error instanceof AuthorizationDeniedError &&
+        error.code === "RESOURCE_NOT_AVAILABLE"
+    );
+  });
+
+  it("uses the same fail-closed denial for non-membership and unknown resources", async () => {
+    const { service, actorA } = fixture();
+    for (const request of [
+      {
+        actor: actorA,
+        tenantId: "tenant_b",
+        projectId: "project_b",
+        action: "project:read",
+      },
+      {
+        actor: actorA,
+        tenantId: "tenant_missing",
+        projectId: "project_missing",
+        action: "project:read",
+      },
+    ]) {
+      await assert.rejects(
+        service.authorizeProject(request),
+        (error) =>
+          error.status === 404 && error.code === "RESOURCE_NOT_AVAILABLE"
+      );
+    }
+  });
+
+  it("does not accept an administrator or service principal as customer membership", async () => {
+    const { service } = fixture();
+    for (const actor of [
+      { kind: "administrator" },
+      { kind: "service", service_id: "make", scopes: ["generation:execute"] },
+    ]) {
+      await assert.rejects(
+        service.authorizeProject({
+          actor,
+          tenantId: "tenant_a",
+          projectId: "project_a",
+          action: "project:read",
+        }),
+        AuthorizationDeniedError
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Publishes the independently reviewed BG-AUTH-002A customer identity, tenant ownership, and authorization foundation against current `main`.

## Baseline and review provenance

- Base: `d90ba9e3bcf4540ba8170e267e8b7d08833e632e`
- Independently reviewed current-main patch: `BG-AUTH-002A-current-main-d90ba9e.patch`
- Current-main reconciliation passed 141/141 tests on Node 22.23.2 before publication.
- Publication was recreated through the authenticated GitHub connector because the Codex sandbox did not have `gh` available.
- The published diff preserves the reviewed 13-file scope and line counts exactly.

## Architecture

- Anchors customer identity to a verified Supabase Auth UUID.
- Adds provider-neutral customer, service, and administrator principal types.
- Adds customer profile, tenant, tenant membership, and immutable tenant-owned project foundations.
- Adds project-to-Brand-Brain authorization linkage.
- Treats request `user_id` as untrusted input; it is not identity evidence.
- Fails closed with a non-enumerating `RESOURCE_NOT_AVAILABLE` authorization denial.
- Preserves existing `ADMIN_KEY` behavior and existing Brand Brain implementation.

## Database migration

Adds version-controlled migration:

`supabase/migrations/20260818010000_create_customer_tenant_authorization_foundation.sql`

The migration creates:

- `customer_profiles`
- `tenants`
- `tenant_memberships`
- `projects`
- staged `brand_brains.project_id -> projects.project_id` foreign key (`NOT VALID`)
- immutability triggers, indexes, RLS, and revoked client table privileges

**The migration has NOT been applied anywhere.** Production database state is unchanged. Staging/real-Postgres execution, Brand Brain ownership backfill, FK validation, security/performance advisor review, and the two-tenant DB acceptance suite remain separate gates.

## Scope boundaries

This PR does NOT:

- verify customer JWTs;
- activate customer route authentication;
- implement BG-AUTH-002B/002C/002D;
- apply any Supabase migration;
- create users;
- modify production configuration;
- modify BG-MEDIA-001 behavior;
- deploy anything;
- add secrets.

Production customer Auth remains OFF.

## Validation already completed before publication

- complete suite: 141/141 passed
- Image regression: 30/30 passed
- Text regression: 31/31 passed
- Brand Brain: 41/41 passed
- authorization tests: 9/9 passed
- migration contract tests: 6/6 passed
- JavaScript syntax: 70/70 passed
- `git diff --check`: passed

GitHub exact-head CI is required before merge.

## Next Auth task after merge

BG-AUTH-002B — Supabase customer token verification and customer-route enforcement.
