### PR TITLE
BG-MEDIA-002B — Provider-neutral Veo video generation foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ The tests do not call Vertex AI and do not require Google Cloud credentials.
 - `POST /generate-image` — provider-neutral authenticated image generation;
   production must inject the approved OpenAI adapter and durable media
   dependencies.
+- `POST /generate-video` — authenticated asynchronous video submission.
+- `GET /generate-video/:generationId` — reads current video generation state.
+- `POST /generate-video/:generationId/poll` — resumes an accepted operation.
 
 The authenticated routes require the `x-admin-key` header to exactly match the
 `ADMIN_KEY` environment variable.
@@ -450,6 +453,14 @@ Mission Control introduces no new environment variables. Its repository
 remains process-local and is reset whenever the process restarts.
 
 ## Generation completion protection
+
+The administration-only Video foundation and asynchronous contract are documented
+in [`docs/video-generation.md`](docs/video-generation.md). The production
+application factory does not configure or activate a video provider, durable asset
+store, or rights-aware reference loader. Video input/reference locations are
+resolved server-side from BizGenie asset identities; caller-supplied provider
+locations are never authoritative. Every Veo submission explicitly sends
+`generateAudio: false` and exposes no customer audio control.
 
 `POST /generate-script` requests one candidate with a bounded 4,096-token
 output budget. The service assembles every text part in that candidate, records

--- a/docs/video-generation.md
+++ b/docs/video-generation.md
@@ -1,0 +1,118 @@
+# BizGenie Video Generation v1.0
+
+## Status
+
+This is a provider-neutral, administration-only foundation. Production activation,
+credentials, deployment, customer JWT authentication, billing, and provider calls
+are intentionally absent.
+
+## Verified Google contract
+
+Verified against current official Google Cloud documentation on 2026-08-19:
+
+- Normal maps only to `veo-3.1-fast-generate-001`.
+- Premium maps only to `veo-3.1-generate-001`.
+- Both approved models are GA and available in `us-central1`.
+- Submission uses `:predictLongRunning`; polling uses
+  `:fetchPredictOperation` with the accepted full operation name.
+- Text-to-video, image-to-video, and asset-reference-to-video are supported.
+- Supported aspect ratios are `16:9` and `9:16`.
+- Supported durations are 4, 6, and 8 seconds; reference-image generations are
+  restricted to 8 seconds.
+- The implemented output is MP4 at the locked adapter resolution of 720p.
+- The shared `VideoGenerationModelParams` contract defaults `generateAudio` to
+  `true`, while current model documentation marks sound generation as unsupported
+  for both approved GA models. The adapter therefore sends `generateAudio: false`
+  explicitly on every submission and exposes no native-audio capability or
+  customer control over that provider parameter.
+
+Official sources:
+
+- https://cloud.google.com/vertex-ai/generative-ai/docs/models/veo/3-1-generate
+- https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/video/generate-videos-from-first-and-last-frames
+- https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/video/use-reference-images-to-guide-video-generation
+- https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/rest/Shared.Types/VideoGenerationModelInstance
+- https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/rest/Shared.Types/VideoGenerationModelParams
+
+## Provider boundary
+
+`VideoGenerationProvider` has two operations:
+
+- `submit(request)` performs exactly one billable submission and returns a
+  normalized provider identity, accepted operation ID, model evidence, and safe
+  diagnostic/cost-correlation metadata.
+- `poll(request)` resumes that known operation and returns `processing`,
+  `completed`, or `failed` in a normalized form.
+
+Google request bodies, endpoint names, full operation-name validation, REST
+polling, and response parsing are isolated in `googleVeoProvider.js`. Clients
+cannot choose a provider, model, resolution, seed, safety setting, arbitrary
+provider parameter, output bucket, or native-audio option.
+
+## State and retry contract
+
+```text
+queued -> submitted -> processing -> completed
+                    \-> failed
+queued ----------------> failed
+```
+
+`completed` requires a valid durable asset and approval state. `failed` never
+contains an asset. Completed and failed records are terminal and cannot be
+resurrected.
+
+Submission is never automatically retried. Once an operation is accepted, every
+later attempt polls the stored operation ID. Polling timeouts, transient polling
+failures, malformed polling responses, and asset-store failures leave the job in
+`processing`, so the same operation can be polled again without a second billable
+submission. A provider-declared terminal failure moves the record to `failed`.
+
+## Administration API
+
+All routes retain the existing `x-admin-key` middleware:
+
+- `POST /generate-video` validates, queues, and submits once; returns HTTP 202.
+- `GET /generate-video/:generationId` reads BizGenie's current state without
+  contacting Google.
+- `POST /generate-video/:generationId/poll` polls/resumes the accepted operation;
+  returns HTTP 202 while active and HTTP 200 when completed.
+
+Public responses contain BizGenie states, Normal/Premium quality, aspect ratio,
+duration, approval state, timestamps, and a normalized durable asset. They do not
+expose provider/model names, Google operation names, Google payloads, raw errors,
+credentials, output bucket configuration, or cost evidence.
+
+The request retains the existing ownership-readiness fields (`user_id`,
+`project_id`, optional `brand_id`, campaign and content lineage), but the admin
+key remains the only authentication boundary. Request `user_id` is metadata, not
+proof of identity. Customer-facing production activation remains blocked on the
+canonical tenant authorization work.
+
+## Durable asset boundary
+
+Video bytes are never stored in the application database. The service uses an
+injected asset store with the same `save()` shape already used by Image. It passes
+a provider output location plus lineage and expects normalized durable metadata
+back. No production asset store is configured by this task, so the default route
+fails closed before production use.
+
+Input and reference locations use a separate injected
+`VideoReferenceAssetLoader`. Public requests identify BizGenie assets by
+`asset_id`; any supplied `location`, MIME type, or dimensions are compatibility
+hints only and never reach the provider. Before submission, the service asks the
+loader to resolve each identity with the project, requested user metadata,
+generation lineage, usage, and required `video.generate.reference` right. The
+loader must derive authoritative tenant/project ownership and rights from
+server-side data, return a matching asset identity and approved `gs://` location,
+and must not treat request `user_id` as proof of identity. The resolved result is
+strictly validated before Veo receives it. The default unconfigured loader fails
+closed with `VIDEO_REFERENCE_ASSET_UNAVAILABLE`, and provider submission is not
+attempted.
+
+## Economic readiness
+
+Credit values do not exist in the provider adapter. Internal records preserve a
+client-supplied transaction correlation ID and safe provider operation/model
+evidence so later reservation, provider-cost confirmation, delivery, debit, and
+margin events can be connected without changing the provider boundary. These
+fields are deliberately omitted from public responses.

--- a/index.js
+++ b/index.js
@@ -26,6 +26,14 @@ const {
   createImageGenerationRouter,
 } = require("./src/image-generation");
 const {
+  InMemoryVideoGenerationRepository,
+  UnconfiguredVideoAssetStore,
+  UnconfiguredVideoGenerationProvider,
+  UnconfiguredVideoReferenceAssetLoader,
+  VideoGenerationService,
+  createVideoGenerationRouter,
+} = require("./src/video-generation");
+const {
   GENERATION_INCOMPLETE_CODE,
   GenerationIncompleteError,
   generateScriptWithVertex,
@@ -47,6 +55,10 @@ function createApp({
   brandBrainRepository = new InMemoryBrandBrainRepository(),
   imageGenerationRepository = new InMemoryImageGenerationRepository(),
   imageProvider = new UnconfiguredImageGenerationProvider(),
+  videoGenerationRepository = new InMemoryVideoGenerationRepository(),
+  videoProvider = new UnconfiguredVideoGenerationProvider(),
+  videoAssetStore = new UnconfiguredVideoAssetStore(),
+  videoReferenceAssetLoader = new UnconfiguredVideoReferenceAssetLoader(),
   branding = brandingConfig,
   scriptGenerator = generateScriptWithVertex,
   logger = console,
@@ -55,6 +67,13 @@ function createApp({
   const imageGenerationService = new ImageGenerationService({
     repository: imageGenerationRepository,
     provider: imageProvider,
+    brandBrainRepository,
+  });
+  const videoGenerationService = new VideoGenerationService({
+    repository: videoGenerationRepository,
+    provider: videoProvider,
+    assetStore: videoAssetStore,
+    referenceAssetLoader: videoReferenceAssetLoader,
     brandBrainRepository,
   });
   const app = express();
@@ -84,6 +103,12 @@ function createApp({
     "/generate-image",
     requireAdmin,
     createImageGenerationRouter({ service: imageGenerationService, logger })
+  );
+
+  app.use(
+    "/generate-video",
+    requireAdmin,
+    createVideoGenerationRouter({ service: videoGenerationService, logger })
   );
 
   app.post("/generate-script", requireAdmin, async (req, res) => {
@@ -199,7 +224,8 @@ function createApp({
     if (
       (req.path.startsWith("/_admin/mission-control") ||
         req.path.startsWith("/_admin/brand-brains") ||
-        req.path.startsWith("/generate-image")) &&
+        req.path.startsWith("/generate-image") ||
+        req.path.startsWith("/generate-video")) &&
       error instanceof SyntaxError &&
       error.status === 400 &&
       Object.hasOwn(error, "body")
@@ -219,6 +245,18 @@ function createApp({
             ],
           },
           media: null,
+        });
+      }
+
+      if (req.path.startsWith("/generate-video")) {
+        return res.status(400).json({
+          status: "failed",
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Request validation failed",
+            details: [{ path: "", code: "invalid_json", message: "Malformed JSON request body" }],
+          },
+          video: null,
         });
       }
 

--- a/src/brand-brain/contextCompiler.js
+++ b/src/brand-brain/contextCompiler.js
@@ -27,7 +27,7 @@ function visualContextIsUseful(generationContext = {}) {
     generationContext.scriptType || generationContext.script_type || ""
   ).toLowerCase();
   return (
-    mediaType === "image" ||
+    ["image", "video"].includes(mediaType) ||
     ["instagram", "tiktok"].includes(platform) ||
     scriptType === "ugc"
   );

--- a/src/video-generation/assetStore.js
+++ b/src/video-generation/assetStore.js
@@ -1,0 +1,15 @@
+const { VideoAssetPersistenceError } = require("./errors");
+
+class VideoAssetStore {
+  async save(_request) {
+    throw new Error("VideoAssetStore.save is not implemented");
+  }
+}
+
+class UnconfiguredVideoAssetStore extends VideoAssetStore {
+  async save() {
+    throw new VideoAssetPersistenceError();
+  }
+}
+
+module.exports = { VideoAssetStore, UnconfiguredVideoAssetStore };

--- a/src/video-generation/errors.js
+++ b/src/video-generation/errors.js
@@ -1,0 +1,126 @@
+class VideoGenerationError extends Error {
+  constructor(status, code, message, details) {
+    super(message);
+    this.name = this.constructor.name;
+    this.status = status;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+class VideoGenerationValidationError extends VideoGenerationError {
+  constructor(details) {
+    super(400, "VALIDATION_ERROR", "Request validation failed", details);
+  }
+}
+
+class VideoGenerationConflictError extends VideoGenerationError {
+  constructor(generationId) {
+    super(409, "VIDEO_GENERATION_EXISTS", `Video generation '${generationId}' already exists`);
+  }
+}
+
+class VideoGenerationNotFoundError extends VideoGenerationError {
+  constructor(generationId) {
+    super(404, "VIDEO_GENERATION_NOT_FOUND", `Video generation '${generationId}' was not found`);
+  }
+}
+
+class VideoProviderSelectionRequiredError extends VideoGenerationError {
+  constructor() {
+    super(503, "VIDEO_PROVIDER_SELECTION_REQUIRED", "No approved video rendering provider has been configured");
+  }
+}
+
+class VideoProviderUnavailableError extends VideoGenerationError {
+  constructor() {
+    super(503, "VIDEO_PROVIDER_UNAVAILABLE", "The video rendering provider is temporarily unavailable");
+  }
+}
+
+class VideoProviderRejectedError extends VideoGenerationError {
+  constructor() {
+    super(422, "VIDEO_PROVIDER_REJECTED", "The video rendering provider rejected the request");
+  }
+}
+
+class VideoProviderTimeoutError extends VideoGenerationError {
+  constructor() {
+    super(504, "VIDEO_PROVIDER_TIMEOUT", "The video rendering provider timed out");
+  }
+}
+
+class VideoProviderResponseError extends VideoGenerationError {
+  constructor() {
+    super(502, "VIDEO_PROVIDER_RESPONSE_INVALID", "The video rendering provider returned an invalid result");
+  }
+}
+
+class VideoProviderOperationFailedError extends VideoGenerationError {
+  constructor() {
+    super(502, "VIDEO_PROVIDER_FAILED", "The video rendering provider could not complete the generation");
+  }
+}
+
+class VideoAssetPersistenceError extends VideoGenerationError {
+  constructor() {
+    super(503, "VIDEO_ASSET_PERSISTENCE_UNAVAILABLE", "The generated video could not yet be stored durably");
+  }
+}
+
+class VideoReferenceAssetUnavailableError extends VideoGenerationError {
+  constructor() {
+    super(503, "VIDEO_REFERENCE_ASSET_UNAVAILABLE", "An approved video reference asset could not be resolved");
+  }
+}
+
+class VideoContextUnavailableError extends VideoGenerationError {
+  constructor() {
+    super(503, "VIDEO_CONTEXT_UNAVAILABLE", "Approved video-generation context is temporarily unavailable");
+  }
+}
+
+class VideoGenerationInternalError extends VideoGenerationError {
+  constructor() {
+    super(500, "VIDEO_GENERATION_INTERNAL_ERROR", "Video generation failed");
+  }
+}
+
+function formatZodIssues(issues) {
+  return issues.map((issue) => ({
+    path: issue.path.join("."),
+    code: issue.code,
+    message: issue.message,
+  }));
+}
+
+function sendVideoGenerationError(error, res) {
+  if (!(error instanceof VideoGenerationError)) return false;
+  const body = {
+    status: "failed",
+    error: { code: error.code, message: error.message },
+    video: null,
+  };
+  if (error.details) body.error.details = error.details;
+  res.status(error.status).json(body);
+  return true;
+}
+
+module.exports = {
+  VideoAssetPersistenceError,
+  VideoContextUnavailableError,
+  VideoGenerationConflictError,
+  VideoGenerationError,
+  VideoGenerationInternalError,
+  VideoGenerationNotFoundError,
+  VideoGenerationValidationError,
+  VideoProviderOperationFailedError,
+  VideoProviderRejectedError,
+  VideoProviderResponseError,
+  VideoProviderSelectionRequiredError,
+  VideoProviderTimeoutError,
+  VideoProviderUnavailableError,
+  VideoReferenceAssetUnavailableError,
+  formatZodIssues,
+  sendVideoGenerationError,
+};

--- a/src/video-generation/googleVeoProvider.js
+++ b/src/video-generation/googleVeoProvider.js
@@ -1,0 +1,214 @@
+const {
+  VideoProviderRejectedError,
+  VideoProviderResponseError,
+  VideoProviderTimeoutError,
+  VideoProviderUnavailableError,
+} = require("./errors");
+const { VideoGenerationProvider } = require("./provider");
+
+const GOOGLE_VEO_PROVIDER = "google-vertex-ai";
+const GOOGLE_VEO_LOCATION = "us-central1";
+const GOOGLE_VEO_NORMAL_MODEL = "veo-3.1-fast-generate-001";
+const GOOGLE_VEO_PREMIUM_MODEL = "veo-3.1-generate-001";
+const GOOGLE_VEO_MODELS = Object.freeze({
+  normal: GOOGLE_VEO_NORMAL_MODEL,
+  premium: GOOGLE_VEO_PREMIUM_MODEL,
+});
+const GOOGLE_VEO_NATIVE_AUDIO = false;
+const GOOGLE_VEO_RESOLUTION = "720p";
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+function modelForQuality(quality) {
+  const model = GOOGLE_VEO_MODELS[quality];
+  if (!model) throw new VideoProviderRejectedError();
+  return model;
+}
+
+function escapeRegExp(value) { return value.replace(/[.*+?^()|[\]\\{}$]/g, "\\$&"); }
+
+function dimensions(aspectRatio) {
+  if (aspectRatio === "16:9") return { width: 1280, height: 720 };
+  if (aspectRatio === "9:16") return { width: 720, height: 1280 };
+  throw new VideoProviderRejectedError();
+}
+
+function providerImage(asset) {
+  if (!asset || !/^gs:\/\/[^/]+\/.+/i.test(asset.location) || !["image/jpeg", "image/png"].includes(asset.mime_type)) {
+    throw new VideoProviderRejectedError();
+  }
+  return { gcsUri: asset.location, mimeType: asset.mime_type };
+}
+
+function safeDiagnostics(response, payload) {
+  const diagnostics = {};
+  if (typeof response?.requestId === "string" && response.requestId.trim()) diagnostics.request_id = response.requestId.trim().slice(0, 256);
+  const filtered = payload?.response?.raiMediaFilteredCount;
+  if (Number.isInteger(filtered) && filtered >= 0) diagnostics.filtered_count = filtered;
+  return Object.keys(diagnostics).length ? diagnostics : undefined;
+}
+
+function unwrap(response) {
+  if (response && Object.hasOwn(response, "payload")) return response.payload;
+  return response;
+}
+
+class GoogleVertexRestTransport {
+  constructor({ accessTokenProvider, fetchImpl = globalThis.fetch, timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+    if (typeof accessTokenProvider !== "function") throw new TypeError("Google Vertex transport requires an access token provider");
+    if (typeof fetchImpl !== "function") throw new TypeError("Google Vertex transport requires fetch");
+    if (!Number.isInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 120_000) throw new TypeError("Google Vertex transport timeout is invalid");
+    this.accessTokenProvider = accessTokenProvider;
+    this.fetchImpl = fetchImpl;
+    this.timeoutMs = timeoutMs;
+  }
+
+  async post(url, body) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const token = await this.accessTokenProvider();
+      if (typeof token !== "string" || !token.trim()) throw new VideoProviderUnavailableError();
+      const response = await this.fetchImpl(url, {
+        method: "POST",
+        headers: { authorization: `Bearer ${token}`, "content-type": "application/json; charset=utf-8" },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+      if (!response?.ok) {
+        if ([400, 422].includes(response?.status)) throw new VideoProviderRejectedError();
+        throw new VideoProviderUnavailableError();
+      }
+      let payload;
+      try { payload = await response.json(); } catch (_error) { throw new VideoProviderResponseError(); }
+      return { payload, requestId: response.headers?.get?.("x-request-id") || undefined };
+    } catch (error) {
+      if (error instanceof VideoProviderRejectedError || error instanceof VideoProviderResponseError || error instanceof VideoProviderUnavailableError) throw error;
+      if (error?.name === "AbortError") throw new VideoProviderTimeoutError();
+      throw new VideoProviderUnavailableError();
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+class GoogleVertexVeoProvider extends VideoGenerationProvider {
+  constructor({ projectId, outputStorageUri, transport, location = GOOGLE_VEO_LOCATION } = {}) {
+    super();
+    if (typeof projectId !== "string" || !/^[a-z][a-z0-9-]{4,62}$/.test(projectId)) throw new TypeError("Google Veo requires a valid project ID");
+    if (location !== GOOGLE_VEO_LOCATION) throw new TypeError("Google Veo is approved only in us-central1");
+    if (typeof outputStorageUri !== "string" || !/^gs:\/\/[^/]+(?:\/.*)?\/$/i.test(outputStorageUri)) throw new TypeError("Google Veo requires a Cloud Storage output prefix");
+    if (!transport || typeof transport.post !== "function") throw new TypeError("Google Veo requires a transport");
+    this.projectId = projectId;
+    this.outputStorageUri = outputStorageUri;
+    this.transport = transport;
+    this.location = location;
+  }
+
+  base(model) {
+    return `projects/${this.projectId}/locations/${this.location}/publishers/google/models/${model}`;
+  }
+
+  endpoint(model, method) {
+    return `https://${this.location}-aiplatform.googleapis.com/v1/${this.base(model)}:${method}`;
+  }
+
+  operationPattern(model) {
+    return new RegExp(`^${escapeRegExp(this.base(model))}/operations/[A-Za-z0-9._-]+$`);
+  }
+
+  costEvidence(operationName, model, transactionCorrelationId) {
+    return {
+      provider_operation_id: operationName,
+      provider_model: model,
+      ...(transactionCorrelationId ? { transaction_correlation_id: transactionCorrelationId } : {}),
+    };
+  }
+
+  async submit({ prompt, quality, aspect_ratio: aspectRatio, duration_seconds: durationSeconds, input_image: inputImage, reference_assets: referenceAssets = [], metadata = {} } = {}) {
+    const model = modelForQuality(quality);
+    dimensions(aspectRatio);
+    if (typeof prompt !== "string" || !prompt.trim() || ![4, 6, 8].includes(durationSeconds) || !Array.isArray(referenceAssets) || referenceAssets.length > 3 || (inputImage && referenceAssets.length) || (referenceAssets.length && durationSeconds !== 8)) {
+      throw new VideoProviderRejectedError();
+    }
+    const instance = { prompt: prompt.trim() };
+    let task = "textToVideo";
+    if (inputImage) {
+      instance.image = providerImage(inputImage);
+      task = "imageToVideo";
+    } else if (referenceAssets.length) {
+      instance.referenceImages = referenceAssets.map((asset) => ({ image: providerImage(asset), referenceType: "asset" }));
+      task = "referenceToVideo";
+    }
+    const body = {
+      instances: [instance],
+      parameters: {
+        storageUri: this.outputStorageUri,
+        sampleCount: 1,
+        aspectRatio,
+        durationSeconds,
+        resolution: GOOGLE_VEO_RESOLUTION,
+        generateAudio: GOOGLE_VEO_NATIVE_AUDIO,
+        task,
+      },
+    };
+    const response = await this.transport.post(this.endpoint(model, "predictLongRunning"), body);
+    const payload = unwrap(response);
+    const operationName = payload?.name;
+    if (typeof operationName !== "string" || !this.operationPattern(model).test(operationName)) throw new VideoProviderResponseError();
+    return {
+      provider: GOOGLE_VEO_PROVIDER,
+      provider_job_id: operationName,
+      provider_model: model,
+      diagnostics: safeDiagnostics(response, payload),
+      cost_evidence: this.costEvidence(operationName, model, metadata.transaction_correlation_id),
+    };
+  }
+
+  async poll({ provider_job_id: operationName, quality, aspect_ratio: aspectRatio, duration_seconds: durationSeconds, transaction_correlation_id: transactionCorrelationId } = {}) {
+    const model = modelForQuality(quality);
+    const size = dimensions(aspectRatio);
+    if (![4, 6, 8].includes(durationSeconds) || typeof operationName !== "string" || !this.operationPattern(model).test(operationName)) throw new VideoProviderRejectedError();
+    const response = await this.transport.post(this.endpoint(model, "fetchPredictOperation"), { operationName });
+    const payload = unwrap(response);
+    if (!payload || payload.name !== operationName || typeof payload.done !== "boolean") throw new VideoProviderResponseError();
+    const common = {
+      provider: GOOGLE_VEO_PROVIDER,
+      provider_job_id: operationName,
+      provider_model: model,
+      diagnostics: safeDiagnostics(response, payload),
+      cost_evidence: this.costEvidence(operationName, model, transactionCorrelationId),
+    };
+    if (!payload.done) return { ...common, status: "processing" };
+    if (payload.error) return { ...common, status: "failed", error_code: "VIDEO_PROVIDER_FAILED" };
+    const video = payload.response?.videos?.[0];
+    const gcsUri = video?.gcsUri || payload.response?.gcsUris?.[0];
+    const mimeType = video?.mimeType || "video/mp4";
+    if (typeof gcsUri !== "string" || !/^gs:\/\/[^/]+\/.+/i.test(gcsUri) || mimeType !== "video/mp4") throw new VideoProviderResponseError();
+    return {
+      ...common,
+      status: "completed",
+      asset_source: {
+        location: gcsUri,
+        mime_type: "video/mp4",
+        width: size.width,
+        height: size.height,
+        duration_seconds: durationSeconds,
+        container: "mp4",
+      },
+    };
+  }
+}
+
+module.exports = {
+  DEFAULT_TIMEOUT_MS,
+  GOOGLE_VEO_LOCATION,
+  GOOGLE_VEO_MODELS,
+  GOOGLE_VEO_NATIVE_AUDIO,
+  GOOGLE_VEO_NORMAL_MODEL,
+  GOOGLE_VEO_PREMIUM_MODEL,
+  GOOGLE_VEO_PROVIDER,
+  GOOGLE_VEO_RESOLUTION,
+  GoogleVertexRestTransport,
+  GoogleVertexVeoProvider,
+  modelForQuality,
+};

--- a/src/video-generation/index.js
+++ b/src/video-generation/index.js
@@ -1,0 +1,31 @@
+const { VideoAssetStore, UnconfiguredVideoAssetStore } = require("./assetStore");
+const errors = require("./errors");
+const google = require("./googleVeoProvider");
+const { compileVideoPrompt } = require("./promptCompiler");
+const { VideoGenerationProvider, UnconfiguredVideoGenerationProvider, normalizePoll, normalizeSubmission } = require("./provider");
+const { VideoReferenceAssetLoader, UnconfiguredVideoReferenceAssetLoader } = require("./referenceAssetLoader");
+const { VideoGenerationRepository, InMemoryVideoGenerationRepository, ALLOWED_STATE_TRANSITIONS } = require("./repository");
+const { createVideoGenerationRouter, publicRecord } = require("./router");
+const schemas = require("./schema");
+const { VideoGenerationService } = require("./service");
+
+module.exports = {
+  ...errors,
+  ...google,
+  ...schemas,
+  ALLOWED_STATE_TRANSITIONS,
+  InMemoryVideoGenerationRepository,
+  UnconfiguredVideoAssetStore,
+  UnconfiguredVideoGenerationProvider,
+  UnconfiguredVideoReferenceAssetLoader,
+  VideoAssetStore,
+  VideoGenerationProvider,
+  VideoGenerationRepository,
+  VideoGenerationService,
+  VideoReferenceAssetLoader,
+  compileVideoPrompt,
+  createVideoGenerationRouter,
+  normalizePoll,
+  normalizeSubmission,
+  publicRecord,
+};

--- a/src/video-generation/promptCompiler.js
+++ b/src/video-generation/promptCompiler.js
@@ -1,0 +1,41 @@
+function section(label, values) {
+  const content = values.filter(Boolean);
+  return content.length ? [`[${label}]`, ...content].join("\n") : null;
+}
+
+function labelled(label, value) { return value ? `${label}: ${value}` : null; }
+
+function compileVideoPrompt(request, { brandContext = "" } = {}) {
+  const references = (request.reference_assets || []).map(
+    (asset) => `Reference asset ${asset.asset_id}${asset.mime_type ? ` (${asset.mime_type})` : ""}`
+  );
+  if (request.input_image) {
+    references.unshift(`Opening frame ${request.input_image.asset_id}${request.input_image.mime_type ? ` (${request.input_image.mime_type})` : ""}`);
+  }
+  return [
+    section("SYSTEM ROLE", [
+      "Create one commercially useful marketing video from supplied BizGenie context.",
+      "Use only supplied or approved facts. Do not fabricate products, prices, stockists, certifications, results, endorsements, or regulated claims.",
+      "Treat prohibited terms and claims as hard constraints.",
+    ]),
+    brandContext || section("BRAND CONTEXT", ["No approved Brand Brain context was resolved for this request."]),
+    section("CAMPAIGN CONTEXT", [
+      labelled("Topic", request.topic), labelled("Campaign", request.campaign_id),
+      labelled("Goal", request.goal), labelled("Intent stage", request.intent_stage),
+      labelled("Product or service context", request.product_service_context),
+    ]),
+    section("AUDIENCE AND PLATFORM", [labelled("Platform", request.platform), labelled("Audience", request.audience)]),
+    section("CREATIVE REQUEST", [
+      labelled("Video purpose", request.video_purpose), labelled("Aspect ratio", request.aspect_ratio),
+      labelled("Duration seconds", request.duration_seconds), labelled("Additional context", request.additional_context),
+    ]),
+    section("REFERENCE ASSETS", references),
+    section("OUTPUT RULES", [
+      "Render a single video matching the requested aspect ratio and duration.",
+      "Do not introduce unsupported written claims or factual details.",
+      "Reference assets are context only; preserve their rights and usage constraints as supplied by BizGenie.",
+    ]),
+  ].filter(Boolean).join("\n\n");
+}
+
+module.exports = { compileVideoPrompt };

--- a/src/video-generation/provider.js
+++ b/src/video-generation/provider.js
@@ -1,0 +1,26 @@
+const { VideoProviderResponseError, VideoProviderSelectionRequiredError } = require("./errors");
+const { VideoProviderPollSchema, VideoProviderSubmissionSchema } = require("./schema");
+
+class VideoGenerationProvider {
+  async submit(_request) { throw new Error("VideoGenerationProvider.submit is not implemented"); }
+  async poll(_request) { throw new Error("VideoGenerationProvider.poll is not implemented"); }
+}
+
+class UnconfiguredVideoGenerationProvider extends VideoGenerationProvider {
+  async submit() { throw new VideoProviderSelectionRequiredError(); }
+  async poll() { throw new VideoProviderSelectionRequiredError(); }
+}
+
+function normalizeSubmission(value) {
+  const result = VideoProviderSubmissionSchema.safeParse(value);
+  if (!result.success) throw new VideoProviderResponseError();
+  return result.data;
+}
+
+function normalizePoll(value) {
+  const result = VideoProviderPollSchema.safeParse(value);
+  if (!result.success) throw new VideoProviderResponseError();
+  return result.data;
+}
+
+module.exports = { VideoGenerationProvider, UnconfiguredVideoGenerationProvider, normalizePoll, normalizeSubmission };

--- a/src/video-generation/referenceAssetLoader.js
+++ b/src/video-generation/referenceAssetLoader.js
@@ -1,0 +1,18 @@
+const { VideoReferenceAssetUnavailableError } = require("./errors");
+
+class VideoReferenceAssetLoader {
+  async load(_request) {
+    throw new Error("VideoReferenceAssetLoader.load is not implemented");
+  }
+}
+
+class UnconfiguredVideoReferenceAssetLoader extends VideoReferenceAssetLoader {
+  async load() {
+    throw new VideoReferenceAssetUnavailableError();
+  }
+}
+
+module.exports = {
+  UnconfiguredVideoReferenceAssetLoader,
+  VideoReferenceAssetLoader,
+};

--- a/src/video-generation/repository.js
+++ b/src/video-generation/repository.js
@@ -1,0 +1,56 @@
+const { VideoGenerationConflictError } = require("./errors");
+const { VideoGenerationRecordSchema } = require("./schema");
+
+const IMMUTABLE_FIELDS = new Set([
+  "generation_id", "parent_generation_id", "transaction_correlation_id",
+  "execution_id", "user_id", "project_id", "brand_id", "campaign_id",
+  "content_item_id", "video_purpose", "quality", "aspect_ratio",
+  "duration_seconds", "created_at",
+]);
+const ALLOWED_STATE_TRANSITIONS = Object.freeze({
+  queued: new Set(["submitted", "failed"]),
+  submitted: new Set(["processing", "failed"]),
+  processing: new Set(["completed", "failed"]),
+  completed: new Set(),
+  failed: new Set(),
+});
+
+function copy(value) { return value ? structuredClone(value) : value; }
+
+class VideoGenerationRepository {
+  create(_record) { throw new Error("VideoGenerationRepository.create is not implemented"); }
+  getByGenerationId(_generationId) { throw new Error("VideoGenerationRepository.getByGenerationId is not implemented"); }
+  update(_generationId, _patch) { throw new Error("VideoGenerationRepository.update is not implemented"); }
+}
+
+class InMemoryVideoGenerationRepository extends VideoGenerationRepository {
+  constructor() { super(); this.records = new Map(); }
+
+  create(record) {
+    const parsed = VideoGenerationRecordSchema.parse(record);
+    if (parsed.status !== "queued") throw new Error("A new video generation must start in queued state");
+    if (this.records.has(parsed.generation_id)) throw new VideoGenerationConflictError(parsed.generation_id);
+    this.records.set(parsed.generation_id, copy(parsed));
+    return copy(parsed);
+  }
+
+  getByGenerationId(generationId) { return copy(this.records.get(generationId) || null); }
+
+  update(generationId, patch) {
+    const current = this.records.get(generationId);
+    if (!current) throw new Error("Video generation record was not found");
+    for (const field of IMMUTABLE_FIELDS) {
+      if (Object.hasOwn(patch, field) && patch[field] !== current[field]) {
+        throw new Error(`Video generation field '${field}' is immutable`);
+      }
+    }
+    if (patch.status && patch.status !== current.status && !ALLOWED_STATE_TRANSITIONS[current.status].has(patch.status)) {
+      throw new Error(`Invalid video generation state transition from '${current.status}' to '${patch.status}'`);
+    }
+    const parsed = VideoGenerationRecordSchema.parse({ ...current, ...copy(patch) });
+    this.records.set(generationId, copy(parsed));
+    return copy(parsed);
+  }
+}
+
+module.exports = { ALLOWED_STATE_TRANSITIONS, VideoGenerationRepository, InMemoryVideoGenerationRepository };

--- a/src/video-generation/router.js
+++ b/src/video-generation/router.js
@@ -1,0 +1,100 @@
+const express = require("express");
+const {
+  VideoGenerationValidationError,
+  formatZodIssues,
+  sendVideoGenerationError,
+} = require("./errors");
+const { VideoGenerationRequestSchema, identifier } = require("./schema");
+
+function parse(schema, value) {
+  const result = schema.safeParse(value);
+  if (!result.success) throw new VideoGenerationValidationError(formatZodIssues(result.error.issues));
+  return result.data;
+}
+
+function publicRecord(record) {
+  return {
+    status: record.status,
+    execution_id: record.execution_id,
+    generation_id: record.generation_id,
+    video: {
+      parent_generation_id: record.parent_generation_id || null,
+      quality: record.quality,
+      aspect_ratio: record.aspect_ratio,
+      duration_seconds: record.duration_seconds,
+      approval_status: record.approval_status || null,
+      asset: record.asset || null,
+      created_at: record.created_at,
+      updated_at: record.updated_at,
+      completed_at: record.completed_at || null,
+    },
+  };
+}
+
+function responseStatus(record) {
+  return ["submitted", "processing"].includes(record.status) ? 202 : 200;
+}
+
+function createVideoGenerationRouter({ service, logger = console }) {
+  if (!service) throw new Error("A video generation service is required");
+  const router = express.Router();
+
+  router.post("/", async (req, res, next) => {
+    let input;
+    try {
+      input = parse(VideoGenerationRequestSchema, req.body);
+      const record = await service.submit(input);
+      logger.info?.("video generation submitted", {
+        execution_id: record.execution_id,
+        generation_id: record.generation_id,
+        status: record.status,
+      });
+      return res.status(202).json(publicRecord(record));
+    } catch (error) {
+      logger.warn?.("video generation submission failed", {
+        execution_id: input?.execution_id,
+        generation_id: input?.generation_id,
+        code: error?.code || "VIDEO_GENERATION_INTERNAL_ERROR",
+      });
+      return next(error);
+    }
+  });
+
+  router.post("/:generationId/poll", async (req, res, next) => {
+    try {
+      const generationId = parse(identifier, req.params.generationId);
+      const record = await service.poll(generationId);
+      logger.info?.("video generation status checked", {
+        execution_id: record.execution_id,
+        generation_id: record.generation_id,
+        status: record.status,
+      });
+      return res.status(responseStatus(record)).json(publicRecord(record));
+    } catch (error) {
+      logger.warn?.("video generation poll failed", {
+        generation_id: req.params.generationId,
+        code: error?.code || "VIDEO_GENERATION_INTERNAL_ERROR",
+      });
+      return next(error);
+    }
+  });
+
+  router.get("/:generationId", (req, res, next) => {
+    try {
+      const generationId = parse(identifier, req.params.generationId);
+      const record = service.get(generationId);
+      return res.status(responseStatus(record)).json(publicRecord(record));
+    } catch (error) {
+      return next(error);
+    }
+  });
+
+  router.use((error, _req, res, next) => {
+    if (sendVideoGenerationError(error, res)) return;
+    next(error);
+  });
+
+  return router;
+}
+
+module.exports = { createVideoGenerationRouter, publicRecord };

--- a/src/video-generation/schema.js
+++ b/src/video-generation/schema.js
@@ -1,0 +1,190 @@
+const { z } = require("zod");
+
+const identifier = z.string().trim().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/, "Invalid identifier");
+const text = z.string().trim().min(1).max(2_000);
+const context = z.string().trim().min(1).max(8_000);
+const timestamp = z.string().datetime({ offset: true });
+const location = z.string().trim().max(2_000).regex(/^(https?|gs|s3):\/\//i, "Invalid asset location");
+const imageMimeType = z.enum(["image/jpeg", "image/png"]);
+const videoMimeType = z.enum(["video/mp4"]);
+const dimension = z.number().int().positive().max(50_000);
+
+const videoGenerationStates = ["queued", "submitted", "processing", "completed", "failed"];
+const videoApprovalStates = ["pending", "approved", "rejected"];
+const videoQualityTiers = ["normal", "premium"];
+const videoAspectRatios = ["16:9", "9:16"];
+const videoDurations = [4, 6, 8];
+
+const VideoInputImageSchema = z.object({
+  asset_id: identifier,
+  location: location.optional(),
+  mime_type: imageMimeType.optional(),
+  width: dimension.optional(),
+  height: dimension.optional(),
+}).strict();
+
+const ResolvedVideoInputImageSchema = z.object({
+  asset_id: identifier,
+  location: z.string().trim().max(2_000).regex(/^gs:\/\/[^/]+\/.+/i, "Invalid provider-readable asset location"),
+  mime_type: imageMimeType,
+  width: dimension.optional(),
+  height: dimension.optional(),
+}).strict();
+
+const VideoGenerationRequestSchema = z.object({
+  execution_id: identifier,
+  generation_id: identifier,
+  parent_generation_id: identifier.optional(),
+  transaction_correlation_id: identifier.optional(),
+  user_id: identifier,
+  project_id: identifier,
+  brand_id: identifier.optional(),
+  campaign_id: identifier.optional(),
+  content_item_id: identifier.optional(),
+  topic: text,
+  platform: text.optional(),
+  audience: text.optional(),
+  goal: text.optional(),
+  intent_stage: text.optional(),
+  product_service_context: context.optional(),
+  video_purpose: text,
+  quality: z.enum(videoQualityTiers),
+  aspect_ratio: z.enum(videoAspectRatios),
+  duration_seconds: z.union(videoDurations.map((value) => z.literal(value))),
+  additional_context: context.optional(),
+  input_image: VideoInputImageSchema.optional(),
+  reference_assets: z.array(VideoInputImageSchema).min(1).max(3).optional(),
+}).strict().superRefine((request, ctx) => {
+  if (request.parent_generation_id === request.generation_id) {
+    ctx.addIssue({ code: "custom", path: ["parent_generation_id"], message: "A regeneration must use a new generation_id" });
+  }
+  if (request.input_image && request.reference_assets) {
+    ctx.addIssue({ code: "custom", path: ["reference_assets"], message: "input_image and reference_assets cannot be combined" });
+  }
+  if (request.reference_assets && request.duration_seconds !== 8) {
+    ctx.addIssue({ code: "custom", path: ["duration_seconds"], message: "Reference-image video generation requires an 8 second duration" });
+  }
+});
+
+const NormalizedVideoAssetSourceSchema = z.object({
+  location,
+  mime_type: videoMimeType,
+  width: dimension.optional(),
+  height: dimension.optional(),
+  duration_seconds: z.number().positive().max(60),
+  container: z.literal("mp4"),
+}).strict();
+
+const NormalizedVideoAssetSchema = NormalizedVideoAssetSourceSchema.extend({
+  byte_size: z.number().int().positive().optional(),
+}).strict();
+
+const ProviderDiagnosticsSchema = z.object({
+  filtered_count: z.number().int().nonnegative().optional(),
+  request_id: z.string().trim().min(1).max(256).optional(),
+}).strict();
+
+const ProviderCostEvidenceSchema = z.object({
+  provider_operation_id: z.string().trim().min(1).max(1_000),
+  provider_model: z.string().trim().min(1).max(256),
+  transaction_correlation_id: identifier.optional(),
+}).strict();
+
+const VideoProviderSubmissionSchema = z.object({
+  provider: z.string().trim().min(1).max(100),
+  provider_job_id: z.string().trim().min(1).max(1_000),
+  provider_model: z.string().trim().min(1).max(256),
+  diagnostics: ProviderDiagnosticsSchema.optional(),
+  cost_evidence: ProviderCostEvidenceSchema.optional(),
+}).strict();
+
+const VideoProviderPollSchema = z.object({
+  provider: z.string().trim().min(1).max(100),
+  provider_job_id: z.string().trim().min(1).max(1_000),
+  provider_model: z.string().trim().min(1).max(256),
+  status: z.enum(["processing", "completed", "failed"]),
+  asset_source: NormalizedVideoAssetSourceSchema.optional(),
+  error_code: z.literal("VIDEO_PROVIDER_FAILED").optional(),
+  diagnostics: ProviderDiagnosticsSchema.optional(),
+  cost_evidence: ProviderCostEvidenceSchema.optional(),
+}).strict().superRefine((result, ctx) => {
+  if (result.status === "completed" && !result.asset_source) {
+    ctx.addIssue({ code: "custom", path: ["asset_source"], message: "asset_source is required for completed provider results" });
+  }
+  if (result.status !== "completed" && result.asset_source) {
+    ctx.addIssue({ code: "custom", path: ["asset_source"], message: "asset_source is only allowed for completed provider results" });
+  }
+  if (result.status === "failed" && !result.error_code) {
+    ctx.addIssue({ code: "custom", path: ["error_code"], message: "error_code is required for failed provider results" });
+  }
+});
+
+const VideoGenerationRecordSchema = z.object({
+  generation_id: identifier,
+  parent_generation_id: identifier.optional(),
+  transaction_correlation_id: identifier.optional(),
+  execution_id: identifier,
+  user_id: identifier,
+  project_id: identifier,
+  brand_id: identifier.optional(),
+  campaign_id: identifier.optional(),
+  content_item_id: identifier.optional(),
+  video_purpose: text,
+  quality: z.enum(videoQualityTiers),
+  aspect_ratio: z.enum(videoAspectRatios),
+  duration_seconds: z.union(videoDurations.map((value) => z.literal(value))),
+  status: z.enum(videoGenerationStates),
+  approval_status: z.enum(videoApprovalStates).optional(),
+  provider: z.string().trim().min(1).max(100).optional(),
+  provider_job_id: z.string().trim().min(1).max(1_000).optional(),
+  provider_model: z.string().trim().min(1).max(256).optional(),
+  provider_diagnostics: ProviderDiagnosticsSchema.optional(),
+  provider_cost_evidence: ProviderCostEvidenceSchema.optional(),
+  asset: NormalizedVideoAssetSchema.optional(),
+  error_code: z.string().trim().min(1).max(100).optional(),
+  created_at: timestamp,
+  updated_at: timestamp,
+  completed_at: timestamp.optional(),
+}).strict().superRefine((record, ctx) => {
+  const providerFields = ["provider", "provider_job_id", "provider_model"];
+  if (["submitted", "processing", "completed"].includes(record.status)) {
+    for (const field of providerFields) if (!record[field]) ctx.addIssue({ code: "custom", path: [field], message: `${field} is required while generation is ${record.status}` });
+  }
+  if (record.status === "queued") {
+    for (const field of [...providerFields, "approval_status", "asset", "error_code", "completed_at"]) {
+      if (record[field]) ctx.addIssue({ code: "custom", path: [field], message: `${field} is not allowed while generation is queued` });
+    }
+  }
+  if (["submitted", "processing"].includes(record.status)) {
+    for (const field of ["approval_status", "asset", "error_code", "completed_at"]) {
+      if (record[field]) ctx.addIssue({ code: "custom", path: [field], message: `${field} is not allowed while generation is ${record.status}` });
+    }
+  }
+  if (record.status === "completed") {
+    for (const field of ["approval_status", "asset", "completed_at"]) if (!record[field]) ctx.addIssue({ code: "custom", path: [field], message: `${field} is required for a completed generation` });
+    if (record.error_code) ctx.addIssue({ code: "custom", path: ["error_code"], message: "error_code is not allowed for a completed generation" });
+  }
+  if (record.status === "failed") {
+    for (const field of ["error_code", "completed_at"]) if (!record[field]) ctx.addIssue({ code: "custom", path: [field], message: `${field} is required for a failed generation` });
+    for (const field of ["approval_status", "asset"]) if (record[field]) ctx.addIssue({ code: "custom", path: [field], message: `${field} is not allowed for a failed generation` });
+  }
+});
+
+module.exports = {
+  NormalizedVideoAssetSchema,
+  NormalizedVideoAssetSourceSchema,
+  ProviderCostEvidenceSchema,
+  ProviderDiagnosticsSchema,
+  ResolvedVideoInputImageSchema,
+  VideoGenerationRecordSchema,
+  VideoGenerationRequestSchema,
+  VideoInputImageSchema,
+  VideoProviderPollSchema,
+  VideoProviderSubmissionSchema,
+  identifier,
+  videoApprovalStates,
+  videoAspectRatios,
+  videoDurations,
+  videoGenerationStates,
+  videoQualityTiers,
+};

--- a/src/video-generation/service.js
+++ b/src/video-generation/service.js
@@ -1,0 +1,260 @@
+const { resolveBrandBrainContext } = require("../brand-brain");
+const {
+  VideoAssetPersistenceError,
+  VideoContextUnavailableError,
+  VideoGenerationError,
+  VideoGenerationInternalError,
+  VideoGenerationNotFoundError,
+  VideoProviderOperationFailedError,
+  VideoProviderUnavailableError,
+  VideoReferenceAssetUnavailableError,
+} = require("./errors");
+const { compileVideoPrompt } = require("./promptCompiler");
+const { normalizePoll, normalizeSubmission } = require("./provider");
+const {
+  NormalizedVideoAssetSchema,
+  ResolvedVideoInputImageSchema,
+  VideoGenerationRequestSchema,
+} = require("./schema");
+
+const VIDEO_REFERENCE_RIGHT = "video.generate.reference";
+
+class VideoGenerationService {
+  constructor({ repository, provider, assetStore, referenceAssetLoader, brandBrainRepository, now = () => new Date() }) {
+    if (!repository || !provider || !assetStore || !referenceAssetLoader || !brandBrainRepository) {
+      throw new Error("Video generation requires repository, provider, asset store, reference asset loader, and Brand Brain repository dependencies");
+    }
+    this.repository = repository;
+    this.provider = provider;
+    this.assetStore = assetStore;
+    this.referenceAssetLoader = referenceAssetLoader;
+    this.brandBrainRepository = brandBrainRepository;
+    this.now = now;
+  }
+
+  timestamp() { return this.now().toISOString(); }
+
+  get(generationId) {
+    const record = this.repository.getByGenerationId(generationId);
+    if (!record) throw new VideoGenerationNotFoundError(generationId);
+    return record;
+  }
+
+  markFailed(generationId, code) {
+    const record = this.repository.getByGenerationId(generationId);
+    if (!record || ["completed", "failed"].includes(record.status)) return record;
+    const completedAt = this.timestamp();
+    try {
+      return this.repository.update(generationId, {
+        status: "failed",
+        error_code: code,
+        updated_at: completedAt,
+        completed_at: completedAt,
+      });
+    } catch (_error) {
+      return null;
+    }
+  }
+
+  async resolveContext(request) {
+    try {
+      return await resolveBrandBrainContext({
+        repository: this.brandBrainRepository,
+        projectId: request.project_id,
+        brandId: request.brand_id,
+        generationContext: { platform: request.platform, mediaType: "video" },
+      });
+    } catch (_error) {
+      throw new VideoContextUnavailableError();
+    }
+  }
+
+  async resolveReferenceAsset(asset, request, usage) {
+    let loaded;
+    try {
+      loaded = await this.referenceAssetLoader.load({
+        asset_id: asset.asset_id,
+        project_id: request.project_id,
+        requested_by_user_id: request.user_id,
+        required_right: VIDEO_REFERENCE_RIGHT,
+        usage,
+        generation_id: request.generation_id,
+        execution_id: request.execution_id,
+      });
+    } catch (error) {
+      if (error instanceof VideoReferenceAssetUnavailableError) throw error;
+      throw new VideoReferenceAssetUnavailableError();
+    }
+    const parsed = ResolvedVideoInputImageSchema.safeParse(loaded);
+    if (!parsed.success || parsed.data.asset_id !== asset.asset_id) {
+      throw new VideoReferenceAssetUnavailableError();
+    }
+    return parsed.data;
+  }
+
+  async resolveProviderInputs(request) {
+    if (request.input_image) {
+      return {
+        inputImage: await this.resolveReferenceAsset(request.input_image, request, "input_image"),
+        referenceAssets: [],
+      };
+    }
+    const referenceAssets = [];
+    for (const asset of request.reference_assets || []) {
+      referenceAssets.push(await this.resolveReferenceAsset(asset, request, "reference_asset"));
+    }
+    return { inputImage: undefined, referenceAssets };
+  }
+
+  async submit(value) {
+    const request = VideoGenerationRequestSchema.parse(value);
+    const createdAt = this.timestamp();
+    this.repository.create({
+      generation_id: request.generation_id,
+      parent_generation_id: request.parent_generation_id,
+      transaction_correlation_id: request.transaction_correlation_id,
+      execution_id: request.execution_id,
+      user_id: request.user_id,
+      project_id: request.project_id,
+      brand_id: request.brand_id,
+      campaign_id: request.campaign_id,
+      content_item_id: request.content_item_id,
+      video_purpose: request.video_purpose,
+      quality: request.quality,
+      aspect_ratio: request.aspect_ratio,
+      duration_seconds: request.duration_seconds,
+      status: "queued",
+      created_at: createdAt,
+      updated_at: createdAt,
+    });
+
+    try {
+      const brandContext = await this.resolveContext(request);
+      const { inputImage, referenceAssets } = await this.resolveProviderInputs(request);
+      const prompt = compileVideoPrompt({
+        ...request,
+        input_image: inputImage,
+        reference_assets: referenceAssets,
+      }, { brandContext });
+      let result;
+      try {
+        result = normalizeSubmission(await this.provider.submit({
+          prompt,
+          quality: request.quality,
+          aspect_ratio: request.aspect_ratio,
+          duration_seconds: request.duration_seconds,
+          input_image: inputImage,
+          reference_assets: referenceAssets,
+          metadata: {
+            generation_id: request.generation_id,
+            execution_id: request.execution_id,
+            user_id: request.user_id,
+            project_id: request.project_id,
+            brand_id: request.brand_id,
+            campaign_id: request.campaign_id,
+            content_item_id: request.content_item_id,
+            transaction_correlation_id: request.transaction_correlation_id,
+          },
+        }));
+      } catch (error) {
+        if (error instanceof VideoGenerationError) throw error;
+        throw new VideoProviderUnavailableError();
+      }
+
+      return this.repository.update(request.generation_id, {
+        status: "submitted",
+        provider: result.provider,
+        provider_job_id: result.provider_job_id,
+        provider_model: result.provider_model,
+        provider_diagnostics: result.diagnostics,
+        provider_cost_evidence: result.cost_evidence,
+        updated_at: this.timestamp(),
+      });
+    } catch (error) {
+      const safeError = error instanceof VideoGenerationError ? error : new VideoGenerationInternalError();
+      this.markFailed(request.generation_id, safeError.code);
+      throw safeError;
+    }
+  }
+
+  async persistCompletedAsset(record, result) {
+    let stored;
+    try {
+      stored = await this.assetStore.save({
+        source: result.asset_source,
+        lineage: {
+          generation_id: record.generation_id,
+          parent_generation_id: record.parent_generation_id,
+          execution_id: record.execution_id,
+          user_id: record.user_id,
+          project_id: record.project_id,
+          brand_id: record.brand_id,
+          campaign_id: record.campaign_id,
+          content_item_id: record.content_item_id,
+          transaction_correlation_id: record.transaction_correlation_id,
+          provider: record.provider,
+          provider_job_id: record.provider_job_id,
+          provider_model: record.provider_model,
+        },
+      });
+    } catch (_error) {
+      throw new VideoAssetPersistenceError();
+    }
+    const parsed = NormalizedVideoAssetSchema.safeParse(stored);
+    if (!parsed.success) throw new VideoAssetPersistenceError();
+    return parsed.data;
+  }
+
+  async poll(generationId) {
+    let record = this.get(generationId);
+    if (["completed", "failed"].includes(record.status)) return record;
+    if (!record.provider_job_id) throw new VideoGenerationInternalError();
+
+    if (record.status === "submitted") {
+      record = this.repository.update(generationId, { status: "processing", updated_at: this.timestamp() });
+    }
+
+    let result;
+    try {
+      result = normalizePoll(await this.provider.poll({
+        provider_job_id: record.provider_job_id,
+        quality: record.quality,
+        aspect_ratio: record.aspect_ratio,
+        duration_seconds: record.duration_seconds,
+        transaction_correlation_id: record.transaction_correlation_id,
+      }));
+    } catch (error) {
+      if (error instanceof VideoGenerationError) throw error;
+      throw new VideoProviderUnavailableError();
+    }
+
+    if (result.provider_job_id !== record.provider_job_id || result.provider !== record.provider || result.provider_model !== record.provider_model) {
+      throw new VideoGenerationInternalError();
+    }
+    if (result.status === "processing") {
+      return this.repository.update(generationId, {
+        provider_diagnostics: result.diagnostics || record.provider_diagnostics,
+        provider_cost_evidence: result.cost_evidence || record.provider_cost_evidence,
+        updated_at: this.timestamp(),
+      });
+    }
+    if (result.status === "failed") {
+      this.markFailed(generationId, result.error_code);
+      throw new VideoProviderOperationFailedError();
+    }
+
+    const asset = await this.persistCompletedAsset(record, result);
+    const completedAt = this.timestamp();
+    return this.repository.update(generationId, {
+      status: "completed",
+      approval_status: "pending",
+      asset,
+      provider_diagnostics: result.diagnostics || record.provider_diagnostics,
+      provider_cost_evidence: result.cost_evidence || record.provider_cost_evidence,
+      updated_at: completedAt,
+      completed_at: completedAt,
+    });
+  }
+}
+
+module.exports = { VideoGenerationService };

--- a/test/google-veo-provider.test.js
+++ b/test/google-veo-provider.test.js
@@ -1,0 +1,154 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+const {
+  GOOGLE_VEO_NORMAL_MODEL,
+  GOOGLE_VEO_PREMIUM_MODEL,
+  GOOGLE_VEO_NATIVE_AUDIO,
+  GoogleVertexVeoProvider,
+  VideoProviderResponseError,
+  VideoProviderTimeoutError,
+} = require("../src/video-generation");
+
+const projectId = "bizgenie-video-test";
+const outputStorageUri = "gs://bizgenie-test/video-output/";
+
+function operation(model, id = "operation-001") {
+  return `projects/${projectId}/locations/us-central1/publishers/google/models/${model}/operations/${id}`;
+}
+
+function providerWith(responses) {
+  const calls = [];
+  const queue = [...responses];
+  return {
+    calls,
+    provider: new GoogleVertexVeoProvider({
+      projectId,
+      outputStorageUri,
+      transport: {
+        async post(url, body) {
+          calls.push({ url, body });
+          const next = queue.shift();
+          if (next instanceof Error) throw next;
+          return next;
+        },
+      },
+    }),
+  };
+}
+
+function submitRequest(overrides = {}) {
+  return {
+    prompt: "A premium product moves through warm studio light.",
+    quality: "normal",
+    aspect_ratio: "16:9",
+    duration_seconds: 6,
+    reference_assets: [],
+    metadata: { transaction_correlation_id: "txn_001" },
+    ...overrides,
+  };
+}
+
+describe("Google Vertex Veo submission mapping", () => {
+  it("maps Normal to the approved fast model without native audio", async () => {
+    const op = operation(GOOGLE_VEO_NORMAL_MODEL);
+    const test = providerWith([{ payload: { name: op }, requestId: "request-001" }]);
+    const result = await test.provider.submit(submitRequest());
+    assert.equal(result.provider_model, GOOGLE_VEO_NORMAL_MODEL);
+    assert.equal(result.provider_job_id, op);
+    assert.equal(result.cost_evidence.transaction_correlation_id, "txn_001");
+    assert.match(test.calls[0].url, new RegExp(`${GOOGLE_VEO_NORMAL_MODEL}:predictLongRunning$`));
+    assert.deepEqual(test.calls[0].body.instances, [{ prompt: submitRequest().prompt }]);
+    assert.deepEqual(test.calls[0].body.parameters, {
+      storageUri: outputStorageUri,
+      sampleCount: 1,
+      aspectRatio: "16:9",
+      durationSeconds: 6,
+      resolution: "720p",
+      generateAudio: false,
+      task: "textToVideo",
+    });
+    assert.equal(GOOGLE_VEO_NATIVE_AUDIO, false);
+  });
+
+  it("maps Premium to the approved quality model", async () => {
+    const op = operation(GOOGLE_VEO_PREMIUM_MODEL);
+    const test = providerWith([{ name: op }]);
+    const result = await test.provider.submit(submitRequest({ quality: "premium" }));
+    assert.equal(result.provider_model, GOOGLE_VEO_PREMIUM_MODEL);
+    assert.match(test.calls[0].url, new RegExp(`${GOOGLE_VEO_PREMIUM_MODEL}:predictLongRunning$`));
+    assert.equal(test.calls[0].body.parameters.generateAudio, false);
+  });
+
+  it("maps a starting image to image-to-video", async () => {
+    const test = providerWith([{ name: operation(GOOGLE_VEO_NORMAL_MODEL) }]);
+    await test.provider.submit(submitRequest({
+      input_image: { asset_id: "image_001", location: "gs://bizgenie-test/input/start.png", mime_type: "image/png" },
+    }));
+    assert.deepEqual(test.calls[0].body.instances[0].image, {
+      gcsUri: "gs://bizgenie-test/input/start.png",
+      mimeType: "image/png",
+    });
+    assert.equal(test.calls[0].body.parameters.task, "imageToVideo");
+  });
+
+  it("maps supported subject references and locks them to eight seconds", async () => {
+    const test = providerWith([{ name: operation(GOOGLE_VEO_NORMAL_MODEL) }]);
+    await test.provider.submit(submitRequest({
+      duration_seconds: 8,
+      reference_assets: [
+        { asset_id: "product_001", location: "gs://bizgenie-test/input/product.jpg", mime_type: "image/jpeg" },
+      ],
+    }));
+    assert.deepEqual(test.calls[0].body.instances[0].referenceImages, [{
+      image: { gcsUri: "gs://bizgenie-test/input/product.jpg", mimeType: "image/jpeg" },
+      referenceType: "asset",
+    }]);
+    assert.equal(test.calls[0].body.parameters.task, "referenceToVideo");
+  });
+});
+
+describe("Google Vertex Veo operation polling", () => {
+  it("normalizes processing and completed long-running operations", async () => {
+    const op = operation(GOOGLE_VEO_NORMAL_MODEL);
+    const test = providerWith([
+      { name: op, done: false },
+      { name: op, done: true, response: { raiMediaFilteredCount: 0, videos: [{ gcsUri: "gs://bizgenie-test/video-output/result.mp4", mimeType: "video/mp4" }] } },
+    ]);
+    const request = { provider_job_id: op, quality: "normal", aspect_ratio: "9:16", duration_seconds: 8 };
+    assert.equal((await test.provider.poll(request)).status, "processing");
+    const completed = await test.provider.poll(request);
+    assert.equal(completed.status, "completed");
+    assert.deepEqual(completed.asset_source, {
+      location: "gs://bizgenie-test/video-output/result.mp4",
+      mime_type: "video/mp4",
+      width: 720,
+      height: 1280,
+      duration_seconds: 8,
+      container: "mp4",
+    });
+    assert.equal(test.calls[0].body.operationName, op);
+    assert.match(test.calls[0].url, /:fetchPredictOperation$/);
+  });
+
+  it("normalizes a provider terminal failure without exposing diagnostics", async () => {
+    const op = operation(GOOGLE_VEO_NORMAL_MODEL);
+    const test = providerWith([{ name: op, done: true, error: { code: 13, message: "private provider trace" } }]);
+    const result = await test.provider.poll({ provider_job_id: op, quality: "normal", aspect_ratio: "16:9", duration_seconds: 4 });
+    assert.deepEqual(result.error_code, "VIDEO_PROVIDER_FAILED");
+    assert.doesNotMatch(JSON.stringify(result), /private provider trace/);
+  });
+
+  it("preserves a sanitized timeout and rejects malformed success", async () => {
+    const op = operation(GOOGLE_VEO_NORMAL_MODEL);
+    const timedOut = providerWith([new VideoProviderTimeoutError()]);
+    await assert.rejects(
+      timedOut.provider.poll({ provider_job_id: op, quality: "normal", aspect_ratio: "16:9", duration_seconds: 4 }),
+      (error) => error.code === "VIDEO_PROVIDER_TIMEOUT"
+    );
+    const malformed = providerWith([{ name: op, done: true, response: { videos: [] } }]);
+    await assert.rejects(
+      malformed.provider.poll({ provider_job_id: op, quality: "normal", aspect_ratio: "16:9", duration_seconds: 4 }),
+      VideoProviderResponseError
+    );
+  });
+});

--- a/test/video-generation.test.js
+++ b/test/video-generation.test.js
@@ -1,0 +1,401 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+const request = require("supertest");
+const { createApp } = require("../index");
+const { InMemoryBrandBrainRepository } = require("../src/brand-brain");
+const {
+  InMemoryVideoGenerationRepository,
+  VideoGenerationRequestSchema,
+  VideoGenerationService,
+  VideoProviderTimeoutError,
+  VideoProviderUnavailableError,
+} = require("../src/video-generation");
+
+const ADMIN_KEY = "video-generation-test-admin-key";
+
+function validRequest(overrides = {}) {
+  return {
+    execution_id: "execution_video_001",
+    generation_id: "generation_video_001",
+    transaction_correlation_id: "transaction_001",
+    user_id: "user_001",
+    project_id: "project_001",
+    brand_id: "brand_001",
+    campaign_id: "campaign_001",
+    content_item_id: "content_001",
+    topic: "Launch a new premium drink",
+    platform: "TikTok",
+    audience: "Adults interested in premium soft drinks",
+    goal: "Awareness",
+    intent_stage: "awareness",
+    product_service_context: "Use only approved product claims.",
+    video_purpose: "Short product launch film",
+    quality: "normal",
+    aspect_ratio: "9:16",
+    duration_seconds: 8,
+    additional_context: "Warm studio lighting.",
+    ...overrides,
+  };
+}
+
+function submission(jobId = "provider-operation-001") {
+  return {
+    provider: "mock-google-vertex-ai",
+    provider_job_id: jobId,
+    provider_model: "mock-veo-model",
+    cost_evidence: {
+      provider_operation_id: jobId,
+      provider_model: "mock-veo-model",
+      transaction_correlation_id: "transaction_001",
+    },
+  };
+}
+
+function completedPoll(jobId = "provider-operation-001") {
+  return {
+    ...submission(jobId),
+    status: "completed",
+    asset_source: {
+      location: "gs://provider-output/generated.mp4",
+      mime_type: "video/mp4",
+      width: 720,
+      height: 1280,
+      duration_seconds: 8,
+      container: "mp4",
+    },
+  };
+}
+
+function fakeProvider({ pollResults = [completedPoll()], submitResult = submission() } = {}) {
+  const state = { submitCalls: [], pollCalls: [], pollResults: [...pollResults] };
+  return {
+    state,
+    provider: {
+      async submit(value) { state.submitCalls.push(value); if (submitResult instanceof Error) throw submitResult; return submitResult; },
+      async poll(value) { state.pollCalls.push(value); const next = state.pollResults.shift(); if (next instanceof Error) throw next; return next; },
+    },
+  };
+}
+
+function durableAsset(source, overrides = {}) {
+  return { ...source, location: "s3://bizgenie-assets/video/generated.mp4", byte_size: 1024, ...overrides };
+}
+
+function harness(options = {}) {
+  const repository = options.repository || new InMemoryVideoGenerationRepository();
+  const fake = options.fake || fakeProvider();
+  const assetState = { calls: 0 };
+  const assetStore = options.assetStore || {
+    async save({ source }) { assetState.calls += 1; return durableAsset(source); },
+  };
+  const referenceState = { calls: [] };
+  const referenceAssetLoader = options.referenceAssetLoader || {
+    async load(value) {
+      referenceState.calls.push(value);
+      return {
+        asset_id: value.asset_id,
+        location: `gs://bizgenie-approved-video-inputs/${value.asset_id}.png`,
+        mime_type: "image/png",
+      };
+    },
+  };
+  const service = new VideoGenerationService({
+    repository,
+    provider: fake.provider,
+    assetStore,
+    referenceAssetLoader,
+    brandBrainRepository: new InMemoryBrandBrainRepository(),
+  });
+  return { repository, fake, assetState, assetStore, referenceState, referenceAssetLoader, service };
+}
+
+function admin(agent) { return agent.set("x-admin-key", ADMIN_KEY); }
+
+describe("video generation request contract", () => {
+  it("accepts bounded Normal/Premium requests and rejects conflicting image modes", () => {
+    assert.equal(VideoGenerationRequestSchema.parse(validRequest()).quality, "normal");
+    assert.equal(VideoGenerationRequestSchema.parse(validRequest({ quality: "premium" })).quality, "premium");
+    const invalid = VideoGenerationRequestSchema.safeParse(validRequest({
+      input_image: { asset_id: "start", location: "gs://input/start.png", mime_type: "image/png" },
+      reference_assets: [{ asset_id: "subject", location: "gs://input/subject.png", mime_type: "image/png" }],
+    }));
+    assert.equal(invalid.success, false);
+    assert.equal(VideoGenerationRequestSchema.safeParse(validRequest({ duration_seconds: 6, reference_assets: [{ asset_id: "subject", location: "gs://input/subject.png", mime_type: "image/png" }] })).success, false);
+    assert.equal(VideoGenerationRequestSchema.safeParse(validRequest({ input_image: { asset_id: "approved_start" } })).success, true);
+    assert.equal(VideoGenerationRequestSchema.safeParse(validRequest({ generateAudio: true })).success, false);
+  });
+});
+
+describe("video reference asset authority", () => {
+  it("resolves an input identity with project and rights context and ignores caller-controlled locations", async () => {
+    const calls = [];
+    const fake = fakeProvider({ pollResults: [] });
+    const test = harness({
+      fake,
+      referenceAssetLoader: {
+        async load(value) {
+          calls.push(value);
+          return {
+            asset_id: value.asset_id,
+            location: "gs://bizgenie-approved-video-inputs/start.png",
+            mime_type: "image/png",
+          };
+        },
+      },
+    });
+    await test.service.submit(validRequest({
+      input_image: {
+        asset_id: "approved_start",
+        location: "gs://attacker-controlled-bucket/private.png",
+        mime_type: "image/jpeg",
+      },
+    }));
+    assert.deepEqual(calls, [{
+      asset_id: "approved_start",
+      project_id: "project_001",
+      requested_by_user_id: "user_001",
+      required_right: "video.generate.reference",
+      usage: "input_image",
+      generation_id: "generation_video_001",
+      execution_id: "execution_video_001",
+    }]);
+    assert.deepEqual(fake.state.submitCalls[0].input_image, {
+      asset_id: "approved_start",
+      location: "gs://bizgenie-approved-video-inputs/start.png",
+      mime_type: "image/png",
+    });
+    assert.doesNotMatch(JSON.stringify(fake.state.submitCalls[0]), /attacker-controlled/);
+  });
+
+  it("resolves every reference identity server-side and never forwards HTTP or S3 caller locations", async () => {
+    const calls = [];
+    const fake = fakeProvider({ pollResults: [] });
+    const test = harness({
+      fake,
+      referenceAssetLoader: {
+        async load(value) {
+          calls.push(value);
+          return {
+            asset_id: value.asset_id,
+            location: `gs://bizgenie-approved-video-inputs/${value.asset_id}.jpg`,
+            mime_type: "image/jpeg",
+          };
+        },
+      },
+    });
+    await test.service.submit(validRequest({
+      reference_assets: [
+        { asset_id: "approved_product", location: "https://evil.example/product.jpg", mime_type: "image/png" },
+        { asset_id: "approved_person", location: "s3://caller-bucket/person.jpg", mime_type: "image/png" },
+      ],
+    }));
+    assert.equal(calls.length, 2);
+    assert.equal(calls.every((value) => value.project_id === "project_001" && value.required_right === "video.generate.reference" && value.usage === "reference_asset"), true);
+    assert.equal(calls.every((value) => !Object.hasOwn(value, "location") && !Object.hasOwn(value, "mime_type")), true);
+    assert.deepEqual(fake.state.submitCalls[0].reference_assets.map((asset) => asset.location), [
+      "gs://bizgenie-approved-video-inputs/approved_product.jpg",
+      "gs://bizgenie-approved-video-inputs/approved_person.jpg",
+    ]);
+    assert.doesNotMatch(JSON.stringify(fake.state.submitCalls[0]), /evil\.example|caller-bucket/);
+  });
+
+  it("fails closed before provider submission when the rights-aware loader is not configured", async () => {
+    process.env.ADMIN_KEY = ADMIN_KEY;
+    const fake = fakeProvider({ pollResults: [] });
+    const app = createApp({
+      videoProvider: fake.provider,
+      videoAssetStore: { async save({ source }) { return durableAsset(source); } },
+      logger: { info() {}, warn() {}, error() {} },
+    });
+    const response = await admin(request(app).post("/generate-video").send(validRequest({
+      input_image: {
+        asset_id: "approved_start",
+        location: "gs://attacker-controlled-bucket/private.png",
+        mime_type: "image/png",
+      },
+    })));
+    assert.equal(response.status, 503);
+    assert.equal(response.body.error.code, "VIDEO_REFERENCE_ASSET_UNAVAILABLE");
+    assert.equal(fake.state.submitCalls.length, 0);
+  });
+
+  it("rejects a mismatched or non-GCS loader result before provider submission", async () => {
+    const fake = fakeProvider({ pollResults: [] });
+    const test = harness({
+      fake,
+      referenceAssetLoader: {
+        async load() {
+          return {
+            asset_id: "different_asset",
+            location: "https://untrusted.example/reference.png",
+            mime_type: "image/png",
+          };
+        },
+      },
+    });
+    await assert.rejects(
+      test.service.submit(validRequest({ input_image: { asset_id: "approved_start" } })),
+      (error) => error.code === "VIDEO_REFERENCE_ASSET_UNAVAILABLE"
+    );
+    assert.equal(fake.state.submitCalls.length, 0);
+  });
+});
+
+describe("video asynchronous orchestration", () => {
+  it("submits once, polls the accepted operation, and completes only after durable persistence", async () => {
+    const fake = fakeProvider({ pollResults: [{ ...submission(), status: "processing" }, completedPoll()] });
+    const test = harness({ fake });
+    const submitted = await test.service.submit(validRequest());
+    assert.equal(submitted.status, "submitted");
+    assert.equal(test.fake.state.submitCalls.length, 1);
+    assert.equal((await test.service.poll(submitted.generation_id)).status, "processing");
+    const completed = await test.service.poll(submitted.generation_id);
+    assert.equal(completed.status, "completed");
+    assert.equal(completed.approval_status, "pending");
+    assert.equal(completed.asset.location, "s3://bizgenie-assets/video/generated.mp4");
+    assert.equal(test.fake.state.submitCalls.length, 1);
+    assert.equal(test.fake.state.pollCalls.length, 2);
+    assert.equal(test.assetState.calls, 1);
+  });
+
+  it("retries transient polling without another billable submission", async () => {
+    const fake = fakeProvider({ pollResults: [new VideoProviderUnavailableError(), completedPoll()] });
+    const test = harness({ fake });
+    await test.service.submit(validRequest());
+    await assert.rejects(test.service.poll("generation_video_001"), (error) => error.code === "VIDEO_PROVIDER_UNAVAILABLE");
+    assert.equal(test.repository.getByGenerationId("generation_video_001").status, "processing");
+    assert.equal((await test.service.poll("generation_video_001")).status, "completed");
+    assert.equal(test.fake.state.submitCalls.length, 1);
+  });
+
+  it("re-polls a completed provider operation after asset persistence failure without resubmitting", async () => {
+    const fake = fakeProvider({ pollResults: [completedPoll(), completedPoll()] });
+    let persistenceCalls = 0;
+    const test = harness({
+      fake,
+      assetStore: {
+        async save({ source }) {
+          persistenceCalls += 1;
+          if (persistenceCalls === 1) throw new Error("private storage detail");
+          return durableAsset(source);
+        },
+      },
+    });
+    await test.service.submit(validRequest());
+    await assert.rejects(test.service.poll("generation_video_001"), (error) => error.code === "VIDEO_ASSET_PERSISTENCE_UNAVAILABLE" && !/private/.test(error.message));
+    assert.equal(test.repository.getByGenerationId("generation_video_001").status, "processing");
+    assert.equal((await test.service.poll("generation_video_001")).status, "completed");
+    assert.equal(test.fake.state.submitCalls.length, 1);
+    assert.equal(persistenceCalls, 2);
+  });
+
+  it("records provider failure without a false asset and never resurrects terminal jobs", async () => {
+    const failedPoll = { ...submission(), status: "failed", error_code: "VIDEO_PROVIDER_FAILED" };
+    const fake = fakeProvider({ pollResults: [failedPoll, completedPoll()] });
+    const test = harness({ fake });
+    await test.service.submit(validRequest());
+    await assert.rejects(test.service.poll("generation_video_001"), (error) => error.code === "VIDEO_PROVIDER_FAILED");
+    const failed = test.repository.getByGenerationId("generation_video_001");
+    assert.equal(failed.status, "failed");
+    assert.equal(failed.asset, undefined);
+    assert.equal((await test.service.poll("generation_video_001")).status, "failed");
+    assert.equal(test.fake.state.pollCalls.length, 1);
+  });
+
+  it("preserves regeneration lineage and immutable history", async () => {
+    const fake = fakeProvider({
+      submitResult: submission("provider-operation-child"),
+      pollResults: [],
+    });
+    const repository = new InMemoryVideoGenerationRepository();
+    const parentTest = harness({ repository, fake: fakeProvider({ submitResult: submission("provider-operation-parent"), pollResults: [] }) });
+    await parentTest.service.submit(validRequest({ generation_id: "generation_parent" }));
+    const childTest = harness({ repository, fake });
+    await childTest.service.submit(validRequest({ generation_id: "generation_child", parent_generation_id: "generation_parent" }));
+    assert.equal(repository.getByGenerationId("generation_child").parent_generation_id, "generation_parent");
+    assert.equal(repository.getByGenerationId("generation_parent").parent_generation_id, undefined);
+  });
+
+  it("keeps polling timeout non-terminal and sanitized", async () => {
+    const fake = fakeProvider({ pollResults: [new VideoProviderTimeoutError()] });
+    const test = harness({ fake });
+    await test.service.submit(validRequest());
+    await assert.rejects(test.service.poll("generation_video_001"), (error) => error.code === "VIDEO_PROVIDER_TIMEOUT");
+    assert.equal(test.repository.getByGenerationId("generation_video_001").status, "processing");
+  });
+
+  it("never retries or duplicates a submission whose outcome may be unknown", async () => {
+    const fake = fakeProvider({ submitResult: new VideoProviderTimeoutError(), pollResults: [] });
+    const test = harness({ fake });
+    await assert.rejects(test.service.submit(validRequest()), (error) => error.code === "VIDEO_PROVIDER_TIMEOUT");
+    const failed = test.repository.getByGenerationId("generation_video_001");
+    assert.equal(failed.status, "failed");
+    assert.equal(failed.asset, undefined);
+    await assert.rejects(test.service.submit(validRequest()), (error) => error.code === "VIDEO_GENERATION_EXISTS");
+    assert.equal(test.fake.state.submitCalls.length, 1);
+  });
+
+  it("keeps a malformed poll response retryable without resubmission", async () => {
+    const fake = fakeProvider({ pollResults: [{ provider: "private-invalid-payload" }, completedPoll()] });
+    const test = harness({ fake });
+    await test.service.submit(validRequest());
+    await assert.rejects(test.service.poll("generation_video_001"), (error) => error.code === "VIDEO_PROVIDER_RESPONSE_INVALID");
+    assert.equal(test.repository.getByGenerationId("generation_video_001").status, "processing");
+    assert.equal((await test.service.poll("generation_video_001")).status, "completed");
+    assert.equal(test.fake.state.submitCalls.length, 1);
+  });
+});
+
+describe("generate-video endpoint and non-regression", () => {
+  it("preserves admin authentication and hides provider/model/operation details", async () => {
+    process.env.ADMIN_KEY = ADMIN_KEY;
+    const fake = fakeProvider();
+    const app = createApp({ videoProvider: fake.provider, videoAssetStore: { async save({ source }) { return durableAsset(source); } }, logger: { info() {}, warn() {}, error() {} } });
+    const unauthorised = await request(app).post("/generate-video").send(validRequest());
+    assert.equal(unauthorised.status, 403);
+    const submitted = await admin(request(app).post("/generate-video").send(validRequest()));
+    assert.equal(submitted.status, 202);
+    assert.equal(submitted.body.status, "submitted");
+    assert.equal(submitted.body.video.asset, null);
+    assert.equal(Object.hasOwn(submitted.body.video, "provider"), false);
+    assert.doesNotMatch(JSON.stringify(submitted.body), /mock-veo-model|provider-operation/);
+  });
+
+  it("supports explicit status reads and polling to completion", async () => {
+    process.env.ADMIN_KEY = ADMIN_KEY;
+    const fake = fakeProvider();
+    const app = createApp({ videoProvider: fake.provider, videoAssetStore: { async save({ source }) { return durableAsset(source); } }, logger: { info() {}, warn() {}, error() {} } });
+    await admin(request(app).post("/generate-video").send(validRequest()));
+    const current = await admin(request(app).get("/generate-video/generation_video_001"));
+    assert.equal(current.status, 202);
+    assert.equal(current.body.status, "submitted");
+    const completed = await admin(request(app).post("/generate-video/generation_video_001/poll"));
+    assert.equal(completed.status, 200);
+    assert.equal(completed.body.status, "completed");
+    assert.equal(completed.body.video.asset.mime_type, "video/mp4");
+  });
+
+  it("returns structured validation, malformed JSON, and explicit unconfigured-provider errors", async () => {
+    process.env.ADMIN_KEY = ADMIN_KEY;
+    const app = createApp({ logger: { info() {}, warn() {}, error() {} } });
+    const invalid = await admin(request(app).post("/generate-video").send({ generation_id: "bad id" }));
+    assert.equal(invalid.status, 400);
+    assert.equal(invalid.body.error.code, "VALIDATION_ERROR");
+    const malformed = await request(app).post("/generate-video").set("x-admin-key", ADMIN_KEY).set("content-type", "application/json").send('{"generation_id":');
+    assert.equal(malformed.status, 400);
+    assert.equal(malformed.body.error.details[0].code, "invalid_json");
+    const unconfigured = await admin(request(app).post("/generate-video").send(validRequest()));
+    assert.equal(unconfigured.status, 503);
+    assert.equal(unconfigured.body.error.code, "VIDEO_PROVIDER_SELECTION_REQUIRED");
+  });
+
+  it("leaves generate-script and generate-image contracts unchanged", async () => {
+    process.env.ADMIN_KEY = ADMIN_KEY;
+    const app = createApp({ logger: { info() {}, warn() {}, error() {} } });
+    const script = await admin(request(app).post("/generate-script").send({}));
+    assert.deepEqual(script.body, { status: "failed", error: "Missing required fields", script_body: "" });
+    const image = await admin(request(app).post("/generate-image").send({ generation_id: "bad id" }));
+    assert.equal(image.status, 400);
+    assert.equal(image.body.error.code, "VALIDATION_ERROR");
+  });
+});


### PR DESCRIPTION
## Summary

Publishes the independently reviewed and remediated BG-MEDIA-002B video-generation foundation against current `main`.

## Provenance

- Base: `f3f22759bf2b2dd78ddc43b9220ff5cd6c80abe3`
- Independently reviewed final local implementation: `1063ae01f48797d61d59aa1fbf0a91aec0bd399d`
- Reviewed final tree: `62d11ccb98a338f9fe94ca31a2b5d677fd4059ca`
- Published remote tree: `62d11ccb98a338f9fe94ca31a2b5d677fd4059ca`
- Local full-suite verification before publication: 150 passed / 0 failed on Node 22.23.2.

## Architecture

- Adds provider-neutral asynchronous `VideoGenerationProvider` boundary.
- Normal maps only to Google Vertex AI `veo-3.1-fast-generate-001`.
- Premium maps only to Google Vertex AI `veo-3.1-generate-001`.
- Submission and polling remain separate to prevent duplicate billable submissions.
- Accepted operations are resumed by stored provider operation ID.
- Terminal jobs cannot be resurrected.
- Completed jobs require durable asset persistence.
- Public responses hide provider/model/operation/cost evidence.

## Independent-review remediation

Two review findings were corrected before publication:

1. Every Veo submission now explicitly sends `generateAudio: false`; clients cannot override it.
2. Input/reference assets are resolved through a server-side `VideoReferenceAssetLoader`. Caller-supplied GCS/HTTP/S3 locations are never authority and never reach the provider directly.

## Security and production boundaries

- Existing `ADMIN_KEY` authentication remains the only Video route boundary in this PR.
- `user_id` remains metadata, not customer identity proof.
- Customer JWT/Auth integration remains separate.
- No production provider, asset store, or rights-aware loader is configured by default.
- No credentials are added.
- No production storage is provisioned.
- No Supabase migration is applied.
- No deployment or production activation occurs.
- No billable provider calls were made.

## Validation already completed before publication

- full suite: 150/150 passed
- focused Video tests: 24 passed
- Text/Image regressions: passed
- Auth/BG-AUTH-002A regressions: passed
- Brand Brain: passed
- Mission Control: passed
- single-submission and terminal-state protections: passed
- mocked provider transports only

GitHub exact-head CI is required before merge.
