### PR TITLE
BG-AUTH-002B — Customer token verification and generation route enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,25 @@ PostgreSQL repository. The version-controlled schema and complete accounting,
 tenant-isolation, Sheets/Make projection, and follow-up contract are documented
 in `docs/billing/COMMERCIAL_CREDIT_LEDGER_FOUNDATION.md`.
 
+## Customer-authenticated generation
+
+BG-AUTH-002B adds separate, fail-closed customer paths without changing the
+existing administrator paths:
+
+- `POST /customer/generate-script`
+- `POST /customer/generate-image`
+
+They require a verified Supabase Bearer token plus `tenant_id` and `project_id`.
+When `brand_id` is supplied it is authorized through the same tenant-owned
+project. Any body `user_id` is ignored and replaced with the verified Supabase
+Auth UUID before the existing generation contract runs.
+
+Runtime verification uses `SUPABASE_URL` and `SUPABASE_PUBLISHABLE_KEY`. Neither
+is present in source control. With both absent the customer paths remain
+fail-closed; partial configuration fails startup. See
+`docs/security/CUSTOMER_TOKEN_VERIFICATION.md` for the full verification,
+principal-separation, rollout, and dormant Image boundary.
+
 ## Customer identity and authorization foundation
 
 BG-AUTH-002A adds the provider-neutral customer actor, tenant membership,

--- a/docs/security/CUSTOMER_TOKEN_VERIFICATION.md
+++ b/docs/security/CUSTOMER_TOKEN_VERIFICATION.md
@@ -1,0 +1,78 @@
+# Customer token verification and generation boundary
+
+BG-AUTH-002B adds the reusable customer boundary on top of BG-AUTH-002A. It
+does not apply the staged database migration, activate production customer
+authentication, deploy code, or create customer credentials.
+
+## Verification contract
+
+The server uses `supabase.auth.getClaims(accessToken)` from the pinned
+`@supabase/supabase-js` dependency. Supabase verifies asymmetric tokens against
+the project's cached JWKS endpoint and falls back to an Auth-server validation
+call for legacy symmetric signing. BizGenie then requires the expected project
+issuer, the `authenticated` audience, an unexpired integer `exp`, and a UUID
+`sub` before creating the canonical customer actor.
+
+This is deliberately not a decode-only flow. Provider errors, malformed JWTs,
+expired tokens, invalid signatures, invalid claims, and missing Bearer headers
+all produce the same sanitized `AUTHENTICATION_REQUIRED` response. Raw JWTs and
+authorization headers are never logged, persisted, or forwarded.
+
+Production construction uses:
+
+- `SUPABASE_URL`: the HTTPS project URL.
+- `SUPABASE_PUBLISHABLE_KEY`: the current publishable API key used by the
+  Supabase client, including for the legacy symmetric-token network fallback.
+
+Both variables must be configured together. With neither configured, customer
+authentication remains fail-closed while existing administration continues to
+start. A partial or insecure configuration fails startup.
+
+## Principal separation
+
+- Customer: verified Supabase Auth UUID only.
+- Administrator: existing exact `x-admin-key`/`ADMIN_KEY` comparison only.
+- Service: reserved for BG-AUTH-002C and not implemented here.
+
+A customer JWT is ignored by administrator middleware. `ADMIN_KEY` is ignored
+by the customer boundary. Neither credential can acquire the other's principal.
+
+## Customer generation paths
+
+- `POST /customer/generate-script`
+- `POST /customer/generate-image`
+
+Both paths require `Authorization: Bearer <access-token>`, `tenant_id`, and
+`project_id`. `brand_id` remains optional, but when supplied it must resolve
+through the same tenant-owned project. The boundary calls the existing
+`AuthorizationService` with `generation:create`, removes the routing-only
+`tenant_id`, replaces any body `user_id` with the verified actor's Auth UUID,
+and only then invokes the existing generation handler/service.
+
+Unknown resources, missing membership, cross-tenant projects, and project/brand
+mismatches share the same non-enumerating `RESOURCE_NOT_AVAILABLE` response.
+Unexpected authorization persistence failures return a sanitized temporary
+unavailability response and never proceed to a provider.
+
+The operational internal paths remain unchanged:
+
+- `POST /generate-script` requires `x-admin-key` and preserves its request and
+  response contract.
+- `POST /generate-image` requires `x-admin-key` and preserves BG-MEDIA-001.
+- `/_admin/*` remains administrator-only.
+
+## Image activation boundary
+
+The customer image path uses the same authorization architecture as text, but
+BG-MEDIA-001 remains dormant by default. No OpenAI adapter, credentials,
+storage, reference loading, or billable call is activated. Production image
+execution still requires an approved provider and durable tenant-owned asset
+storage/reference-loading design in a separate task.
+
+## Rollout boundary
+
+Before production activation, the BG-AUTH-002A migration and deliberate legacy
+ownership backfill must be reviewed and applied in an authorized staging flow.
+Production then needs the two-tenant real-database adversarial acceptance in
+BG-AUTH-002D. BG-AUTH-002C must first add the authorized generation-job and
+Make/service-principal boundary; customer JWTs must never be sent to Make.

--- a/index.js
+++ b/index.js
@@ -7,6 +7,16 @@ console.log(`🚀 ${brandingConfig.marketingStrings.apiBooting}`);
 
 const express = require("express");
 const {
+  AuthorizationService,
+  InMemoryAuthorizationRepository,
+  PostgresAuthorizationRepository,
+} = require("./src/authorization");
+const {
+  UnconfiguredCustomerTokenVerifier,
+  createCustomerGenerationBoundary,
+  createSupabaseCustomerTokenVerifierFromEnv,
+} = require("./src/authentication");
+const {
   InMemoryBrandBrainRepository,
   createPostgresBrandBrainRepositoryFromEnv,
   createBrandBrainRouter,
@@ -50,68 +60,13 @@ function requireAdmin(req, res, next) {
   next();
 }
 
-function createApp({
-  missionControlRepository = new InMemoryMissionControlRepository(),
-  brandBrainRepository = new InMemoryBrandBrainRepository(),
-  imageGenerationRepository = new InMemoryImageGenerationRepository(),
-  imageProvider = new UnconfiguredImageGenerationProvider(),
-  videoGenerationRepository = new InMemoryVideoGenerationRepository(),
-  videoProvider = new UnconfiguredVideoGenerationProvider(),
-  videoAssetStore = new UnconfiguredVideoAssetStore(),
-  videoReferenceAssetLoader = new UnconfiguredVideoReferenceAssetLoader(),
-  branding = brandingConfig,
-  scriptGenerator = generateScriptWithVertex,
-  logger = console,
-} = {}) {
-  const resolvedBranding = BrandingConfigSchema.parse(branding);
-  const imageGenerationService = new ImageGenerationService({
-    repository: imageGenerationRepository,
-    provider: imageProvider,
-    brandBrainRepository,
-  });
-  const videoGenerationService = new VideoGenerationService({
-    repository: videoGenerationRepository,
-    provider: videoProvider,
-    assetStore: videoAssetStore,
-    referenceAssetLoader: videoReferenceAssetLoader,
-    brandBrainRepository,
-  });
-  const app = express();
-  app.use(express.json());
-
-  app.get("/", (_req, res) => {
-    res.send(resolvedBranding.marketingStrings.serviceStatus);
-  });
-
-  app.get("/_admin/ping", requireAdmin, (_req, res) => {
-    res.json({ status: "ok" });
-  });
-
-  app.use(
-    "/_admin/mission-control",
-    requireAdmin,
-    createMissionControlRouter({ repository: missionControlRepository })
-  );
-
-  app.use(
-    "/_admin/brand-brains",
-    requireAdmin,
-    createBrandBrainRouter({ repository: brandBrainRepository })
-  );
-
-  app.use(
-    "/generate-image",
-    requireAdmin,
-    createImageGenerationRouter({ service: imageGenerationService, logger })
-  );
-
-  app.use(
-    "/generate-video",
-    requireAdmin,
-    createVideoGenerationRouter({ service: videoGenerationService, logger })
-  );
-
-  app.post("/generate-script", requireAdmin, async (req, res) => {
+function createGenerateScriptHandler({
+  brandBrainRepository,
+  branding,
+  scriptGenerator,
+  logger,
+}) {
+  return async function generateScript(req, res) {
     const {
       execution_id,
       user_id,
@@ -148,7 +103,7 @@ function createApp({
       });
 
       const generation = await scriptGenerator(compiled_prompt, {
-        branding: resolvedBranding,
+        branding,
         promptOptions: {
           platform,
           scriptType: script_type,
@@ -218,19 +173,125 @@ function createApp({
         script_body: ""
       });
     }
+  };
+}
+
+function createApp({
+  missionControlRepository = new InMemoryMissionControlRepository(),
+  brandBrainRepository = new InMemoryBrandBrainRepository(),
+  imageGenerationRepository = new InMemoryImageGenerationRepository(),
+  imageProvider = new UnconfiguredImageGenerationProvider(),
+  videoGenerationRepository = new InMemoryVideoGenerationRepository(),
+  videoProvider = new UnconfiguredVideoGenerationProvider(),
+  videoAssetStore = new UnconfiguredVideoAssetStore(),
+  videoReferenceAssetLoader = new UnconfiguredVideoReferenceAssetLoader(),
+  branding = brandingConfig,
+  scriptGenerator = generateScriptWithVertex,
+  authorizationRepository = new InMemoryAuthorizationRepository(),
+  authorizationService,
+  customerTokenVerifier = new UnconfiguredCustomerTokenVerifier(),
+  logger = console,
+} = {}) {
+  const resolvedBranding = BrandingConfigSchema.parse(branding);
+  const resolvedAuthorizationService =
+    authorizationService || new AuthorizationService({
+      repository: authorizationRepository,
+    });
+  const imageGenerationService = new ImageGenerationService({
+    repository: imageGenerationRepository,
+    provider: imageProvider,
+    brandBrainRepository,
   });
+  const videoGenerationService = new VideoGenerationService({
+    repository: videoGenerationRepository,
+    provider: videoProvider,
+    assetStore: videoAssetStore,
+    referenceAssetLoader: videoReferenceAssetLoader,
+    brandBrainRepository,
+  });
+  const app = express();
+  app.use(express.json());
+  const scriptHandler = createGenerateScriptHandler({
+    brandBrainRepository,
+    branding: resolvedBranding,
+    scriptGenerator,
+    logger,
+  });
+  const customerScriptBoundary = createCustomerGenerationBoundary({
+    tokenVerifier: customerTokenVerifier,
+    authorizationService: resolvedAuthorizationService,
+    kind: "script",
+    logger,
+  });
+  const customerImageBoundary = createCustomerGenerationBoundary({
+    tokenVerifier: customerTokenVerifier,
+    authorizationService: resolvedAuthorizationService,
+    kind: "image",
+    logger,
+  });
+
+  app.get("/", (_req, res) => {
+    res.send(resolvedBranding.marketingStrings.serviceStatus);
+  });
+
+  app.get("/_admin/ping", requireAdmin, (_req, res) => {
+    res.json({ status: "ok" });
+  });
+
+  app.use(
+    "/_admin/mission-control",
+    requireAdmin,
+    createMissionControlRouter({ repository: missionControlRepository })
+  );
+
+  app.use(
+    "/_admin/brand-brains",
+    requireAdmin,
+    createBrandBrainRouter({ repository: brandBrainRepository })
+  );
+
+  app.use(
+    "/generate-image",
+    requireAdmin,
+    createImageGenerationRouter({ service: imageGenerationService, logger })
+  );
+
+  app.use(
+    "/generate-video",
+    requireAdmin,
+    createVideoGenerationRouter({ service: videoGenerationService, logger })
+  );
+
+  app.post("/generate-script", requireAdmin, scriptHandler);
+
+  app.post(
+    "/customer/generate-script",
+    customerScriptBoundary,
+    scriptHandler
+  );
+
+  app.use(
+    "/customer/generate-image",
+    customerImageBoundary,
+    createImageGenerationRouter({ service: imageGenerationService, logger })
+  );
 
   app.use((error, req, res, next) => {
     if (
       (req.path.startsWith("/_admin/mission-control") ||
         req.path.startsWith("/_admin/brand-brains") ||
         req.path.startsWith("/generate-image") ||
-        req.path.startsWith("/generate-video")) &&
+        req.path.startsWith("/generate-video") ||
+        req.path.startsWith("/customer/generate-image") ||
+        req.path.startsWith("/customer/generate-script")) &&
       error instanceof SyntaxError &&
       error.status === 400 &&
       Object.hasOwn(error, "body")
     ) {
-      if (req.path.startsWith("/generate-image")) {
+      if (
+        req.path.startsWith("/generate-image") ||
+        req.path.startsWith("/customer/generate-image")
+      ) {
         return res.status(400).json({
           status: "failed",
           error: {
@@ -257,6 +318,17 @@ function createApp({
             details: [{ path: "", code: "invalid_json", message: "Malformed JSON request body" }],
           },
           video: null,
+        });
+      }
+
+      if (req.path.startsWith("/customer/generate-script")) {
+        return res.status(400).json({
+          status: "failed",
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Malformed JSON request body",
+          },
+          script_body: "",
         });
       }
 
@@ -288,9 +360,22 @@ async function createProductionApp({ env = process.env, logger = console } = {})
     env,
   });
   await brandBrainRepository.initialize();
+  const authorizationRepository = new PostgresAuthorizationRepository({
+    pool: brandBrainRepository.pool,
+  });
+  const customerTokenVerifier = createSupabaseCustomerTokenVerifierFromEnv({
+    env,
+  });
   return {
-    app: createApp({ brandBrainRepository, logger }),
+    app: createApp({
+      authorizationRepository,
+      brandBrainRepository,
+      customerTokenVerifier,
+      logger,
+    }),
+    authorizationRepository,
     brandBrainRepository,
+    customerTokenVerifier,
   };
 }
 
@@ -317,6 +402,7 @@ if (require.main === module) {
 module.exports = {
   app,
   createApp,
+  createGenerateScriptHandler,
   createProductionApp,
   generateScriptWithVertex,
   requireAdmin,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@google-cloud/vertexai": "^1.0.0",
+        "@supabase/supabase-js": "2.112.3",
         "express": "^4.19.2",
         "pg": "^8.22.0",
         "zod": "^4.4.3"
@@ -208,6 +209,98 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
       "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.112.3.tgz",
+      "integrity": "sha512-NA0rsgAlWZPvbhw8aUdmgfpHVgUAcd8zK5ov43l++o1bLIPXZhRiAlRobhwF5AatQuovpqxsMH50F4oyyV4XZw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.112.3.tgz",
+      "integrity": "sha512-gfv481mTOVWtZIJgXupxZpni2V2UWPf6jeF/jOK7HdMHdH+mt6sU0sHHwf0POsPip8ltlulu9OUHgwVzl5ddRw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.5.tgz",
+      "integrity": "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.112.3.tgz",
+      "integrity": "sha512-+Mf6uCpzr00bqxwX8hTK2X2L9eAL/1vuOjdEjx6upz9ulb0RmQT16XeU/JkMUlVHw/B46ZnPa2busY4Kd9YCzw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.112.3.tgz",
+      "integrity": "sha512-E6wljXWs7DUOloyIB69i3YFInWE6IyCvgTAbQ0KYxOHv26FdA1KzEXTuzxrYEdf70t406Z9BRwUlGyclGF2FXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "0.4.5",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.112.3.tgz",
+      "integrity": "sha512-oSK61tzlUvg+BWPqpKQCu9qqonsO26btaoAR9D6Gest2aj7xUqToj9rKyaoYOJczkhg9BjqA1REbYy9tPI4bDA==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.112.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.112.3.tgz",
+      "integrity": "sha512-Jv1bxVQmEJNkjvPEhFaKjPzsh+Ozyew6lWGD+SoYcsclDEP1z7yEvKvfUQfzy0DkxRIQnZNxmmWtAzw5XLTQoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.112.3",
+        "@supabase/functions-js": "2.112.3",
+        "@supabase/postgrest-js": "2.112.3",
+        "@supabase/realtime-js": "2.112.3",
+        "@supabase/storage-js": "2.112.3"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@types/node": {
       "version": "26.1.2",
@@ -974,6 +1067,15 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1714,6 +1816,12 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@google-cloud/vertexai": "^1.0.0",
+    "@supabase/supabase-js": "2.112.3",
     "express": "^4.19.2",
     "pg": "^8.22.0",
     "zod": "^4.4.3"

--- a/src/authentication/customerGenerationBoundary.js
+++ b/src/authentication/customerGenerationBoundary.js
@@ -1,0 +1,123 @@
+const {
+  AuthenticationRequiredError,
+  AuthorizationDeniedError,
+} = require("../authorization");
+
+const AUTHENTICATION_ERROR = Object.freeze({
+  code: "AUTHENTICATION_REQUIRED",
+  message: "Customer authentication is required",
+});
+const AUTHORIZATION_ERROR = Object.freeze({
+  code: "RESOURCE_NOT_AVAILABLE",
+  message: "The requested resource is not available",
+});
+const AUTHORIZATION_UNAVAILABLE_ERROR = Object.freeze({
+  code: "AUTHORIZATION_UNAVAILABLE",
+  message: "Customer authorization is temporarily unavailable",
+});
+
+function extractBearerToken(authorizationHeader) {
+  if (typeof authorizationHeader !== "string") {
+    throw new AuthenticationRequiredError();
+  }
+
+  const match = authorizationHeader.match(/^Bearer ([^\s,]+)$/i);
+  if (!match) {
+    throw new AuthenticationRequiredError();
+  }
+  return match[1];
+}
+
+function responseBody(kind, error) {
+  if (kind === "script") {
+    return {
+      status: "failed",
+      error,
+      script_body: "",
+    };
+  }
+  return {
+    status: "failed",
+    error,
+    media: null,
+  };
+}
+
+function createCustomerGenerationBoundary({
+  tokenVerifier,
+  authorizationService,
+  kind,
+  logger = console,
+}) {
+  if (!tokenVerifier || !authorizationService) {
+    throw new TypeError(
+      "Customer generation requires token verification and authorization dependencies"
+    );
+  }
+  if (!new Set(["script", "image"]).has(kind)) {
+    throw new TypeError("Customer generation kind must be script or image");
+  }
+
+  return async function requireAuthorizedCustomer(req, res, next) {
+    try {
+      const accessToken = extractBearerToken(req.header("authorization"));
+      const actor = await tokenVerifier.verifyAccessToken(accessToken);
+      const body = req.body && typeof req.body === "object" ? req.body : {};
+      const { tenant_id: tenantId, ...generationRequest } = body;
+
+      const authorization = body.brand_id
+        ? await authorizationService.authorizeProjectBrand({
+            actor,
+            tenantId,
+            projectId: body.project_id,
+            brandId: body.brand_id,
+            action: "generation:create",
+          })
+        : await authorizationService.authorizeProject({
+            actor,
+            tenantId,
+            projectId: body.project_id,
+            action: "generation:create",
+          });
+
+      req.body = {
+        ...generationRequest,
+        user_id: actor.auth_user_id,
+      };
+      res.locals.customerAuthorization = authorization;
+      return next();
+    } catch (error) {
+      if (error instanceof AuthenticationRequiredError) {
+        logger.warn?.("customer authentication rejected", {
+          code: AUTHENTICATION_ERROR.code,
+          path: req.path,
+        });
+        return res.status(401).json(responseBody(kind, AUTHENTICATION_ERROR));
+      }
+
+      if (error instanceof AuthorizationDeniedError) {
+        logger.warn?.("customer authorization rejected", {
+          code: AUTHORIZATION_ERROR.code,
+          path: req.path,
+        });
+        return res.status(404).json(responseBody(kind, AUTHORIZATION_ERROR));
+      }
+
+      logger.error?.("customer authorization unavailable", {
+        code: AUTHORIZATION_UNAVAILABLE_ERROR.code,
+        path: req.path,
+      });
+      return res
+        .status(503)
+        .json(responseBody(kind, AUTHORIZATION_UNAVAILABLE_ERROR));
+    }
+  };
+}
+
+module.exports = {
+  AUTHENTICATION_ERROR,
+  AUTHORIZATION_ERROR,
+  AUTHORIZATION_UNAVAILABLE_ERROR,
+  createCustomerGenerationBoundary,
+  extractBearerToken,
+};

--- a/src/authentication/index.js
+++ b/src/authentication/index.js
@@ -1,0 +1,7 @@
+const boundary = require("./customerGenerationBoundary");
+const tokenVerifier = require("./tokenVerifier");
+
+module.exports = {
+  ...boundary,
+  ...tokenVerifier,
+};

--- a/src/authentication/tokenVerifier.js
+++ b/src/authentication/tokenVerifier.js
@@ -1,0 +1,151 @@
+const { createClient } = require("@supabase/supabase-js");
+const {
+  AuthenticationRequiredError,
+  createCustomerActorFromVerifiedIdentity,
+} = require("../authorization");
+
+const DEFAULT_AUDIENCE = "authenticated";
+
+class CustomerAuthenticationConfigurationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "CustomerAuthenticationConfigurationError";
+    this.code = "CUSTOMER_AUTHENTICATION_CONFIGURATION_ERROR";
+  }
+}
+
+class CustomerTokenVerifier {
+  verifyAccessToken(_accessToken) {
+    throw new Error("CustomerTokenVerifier.verifyAccessToken is not implemented");
+  }
+}
+
+function authenticationRequired() {
+  return new AuthenticationRequiredError();
+}
+
+function normalizedProjectUrl(value) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new CustomerAuthenticationConfigurationError(
+      "SUPABASE_URL is required when customer authentication is configured"
+    );
+  }
+
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:") {
+      throw new Error("invalid protocol");
+    }
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    throw new CustomerAuthenticationConfigurationError(
+      "SUPABASE_URL must be a valid HTTPS URL"
+    );
+  }
+}
+
+function validAudience(value, expectedAudience) {
+  if (Array.isArray(value)) {
+    return value.includes(expectedAudience);
+  }
+  return value === expectedAudience;
+}
+
+class SupabaseCustomerTokenVerifier extends CustomerTokenVerifier {
+  constructor({
+    supabaseClient,
+    projectUrl,
+    audience = DEFAULT_AUDIENCE,
+    now = () => new Date(),
+  }) {
+    super();
+    if (!supabaseClient?.auth || typeof supabaseClient.auth.getClaims !== "function") {
+      throw new TypeError("A Supabase Auth client with getClaims is required");
+    }
+    this.supabaseClient = supabaseClient;
+    this.expectedIssuer = `${normalizedProjectUrl(projectUrl)}/auth/v1`;
+    this.audience = audience;
+    this.now = now;
+  }
+
+  async verifyAccessToken(accessToken) {
+    if (typeof accessToken !== "string" || !accessToken.trim()) {
+      throw authenticationRequired();
+    }
+
+    let result;
+    try {
+      result = await this.supabaseClient.auth.getClaims(accessToken);
+    } catch {
+      throw authenticationRequired();
+    }
+
+    const claims = result?.data?.claims;
+    const expiresAt = claims?.exp;
+    const nowSeconds = Math.floor(this.now().getTime() / 1000);
+
+    if (
+      result?.error ||
+      !claims ||
+      claims.iss !== this.expectedIssuer ||
+      !validAudience(claims.aud, this.audience) ||
+      !Number.isSafeInteger(expiresAt) ||
+      expiresAt <= nowSeconds
+    ) {
+      throw authenticationRequired();
+    }
+
+    return createCustomerActorFromVerifiedIdentity({
+      verifiedAuthUserId: claims.sub,
+    });
+  }
+}
+
+class UnconfiguredCustomerTokenVerifier extends CustomerTokenVerifier {
+  async verifyAccessToken() {
+    throw authenticationRequired();
+  }
+}
+
+function createSupabaseCustomerTokenVerifierFromEnv({
+  env = process.env,
+  createClientImpl = createClient,
+  now,
+} = {}) {
+  const projectUrl = env.SUPABASE_URL;
+  const publishableKey = env.SUPABASE_PUBLISHABLE_KEY;
+
+  if (!projectUrl && !publishableKey) {
+    return new UnconfiguredCustomerTokenVerifier();
+  }
+  if (!projectUrl || !publishableKey) {
+    throw new CustomerAuthenticationConfigurationError(
+      "SUPABASE_URL and SUPABASE_PUBLISHABLE_KEY must be configured together"
+    );
+  }
+
+  const normalizedUrl = normalizedProjectUrl(projectUrl);
+  const client = createClientImpl(normalizedUrl, publishableKey, {
+    auth: {
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+      persistSession: false,
+    },
+  });
+
+  return new SupabaseCustomerTokenVerifier({
+    supabaseClient: client,
+    projectUrl: normalizedUrl,
+    now,
+  });
+}
+
+module.exports = {
+  CustomerAuthenticationConfigurationError,
+  CustomerTokenVerifier,
+  DEFAULT_AUDIENCE,
+  SupabaseCustomerTokenVerifier,
+  UnconfiguredCustomerTokenVerifier,
+  createSupabaseCustomerTokenVerifierFromEnv,
+  normalizedProjectUrl,
+};

--- a/test/customer-authentication.test.js
+++ b/test/customer-authentication.test.js
@@ -1,0 +1,188 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+
+const {
+  AuthenticationRequiredError,
+} = require("../src/authorization");
+const {
+  CustomerAuthenticationConfigurationError,
+  SupabaseCustomerTokenVerifier,
+  UnconfiguredCustomerTokenVerifier,
+  createSupabaseCustomerTokenVerifierFromEnv,
+  extractBearerToken,
+} = require("../src/authentication");
+
+const PROJECT_URL = "https://bizgenie-test.supabase.co";
+const USER_A = "11111111-1111-4111-8111-111111111111";
+const NOW = new Date("2026-08-19T12:00:00.000Z");
+
+function verifiedClaims(overrides = {}) {
+  return {
+    iss: `${PROJECT_URL}/auth/v1`,
+    sub: USER_A,
+    aud: "authenticated",
+    exp: Math.floor(NOW.getTime() / 1000) + 300,
+    iat: Math.floor(NOW.getTime() / 1000) - 60,
+    role: "authenticated",
+    ...overrides,
+  };
+}
+
+function verifierWith(getClaims) {
+  return new SupabaseCustomerTokenVerifier({
+    supabaseClient: { auth: { getClaims } },
+    projectUrl: PROJECT_URL,
+    now: () => NOW,
+  });
+}
+
+describe("Supabase customer token verification", () => {
+  it("creates the canonical customer actor only after getClaims verifies the token", async () => {
+    const calls = [];
+    const verifier = verifierWith(async (token) => {
+      calls.push(token);
+      return { data: { claims: verifiedClaims() }, error: null };
+    });
+
+    const actor = await verifier.verifyAccessToken("signed-token-a");
+
+    assert.deepEqual(calls, ["signed-token-a"]);
+    assert.deepEqual(actor, {
+      kind: "customer",
+      auth_user_id: USER_A,
+    });
+    assert.equal(Object.isFrozen(actor), true);
+  });
+
+  it("rejects malformed and invalid-signature tokens with one sanitized error", async () => {
+    for (const getClaims of [
+      async () => ({ data: null, error: new Error("invalid JWT signature") }),
+      async () => {
+        throw new Error("provider diagnostics for malformed token");
+      },
+    ]) {
+      const verifier = verifierWith(getClaims);
+      await assert.rejects(
+        verifier.verifyAccessToken("raw.jwt.value"),
+        (error) => {
+          assert.ok(error instanceof AuthenticationRequiredError);
+          assert.equal(error.code, "AUTHENTICATION_REQUIRED");
+          assert.doesNotMatch(error.message, /jwt|signature|provider/i);
+          assert.doesNotMatch(JSON.stringify(error), /raw\.jwt\.value/);
+          return true;
+        }
+      );
+    }
+  });
+
+  it("rejects expired tokens even if a verifier dependency returns claims", async () => {
+    const verifier = verifierWith(async () => ({
+      data: {
+        claims: verifiedClaims({
+          exp: Math.floor(NOW.getTime() / 1000),
+        }),
+      },
+      error: null,
+    }));
+
+    await assert.rejects(
+      verifier.verifyAccessToken("expired-token"),
+      AuthenticationRequiredError
+    );
+  });
+
+  it("rejects wrong-project, wrong-audience, and invalid-subject claims", async () => {
+    for (const overrides of [
+      { iss: "https://other-project.supabase.co/auth/v1" },
+      { aud: "service_role" },
+      { sub: "request-body-user" },
+    ]) {
+      const verifier = verifierWith(async () => ({
+        data: { claims: verifiedClaims(overrides) },
+        error: null,
+      }));
+      await assert.rejects(
+        verifier.verifyAccessToken("invalid-claims-token"),
+        AuthenticationRequiredError
+      );
+    }
+  });
+
+  it("strictly extracts a single Bearer token", () => {
+    assert.equal(extractBearerToken("Bearer one.token.value"), "one.token.value");
+    assert.equal(extractBearerToken("bearer token-a"), "token-a");
+
+    for (const header of [
+      undefined,
+      "",
+      "Basic credentials",
+      "Bearer",
+      "Bearer token-a token-b",
+      "Bearer token-a,token-b",
+    ]) {
+      assert.throws(() => extractBearerToken(header), AuthenticationRequiredError);
+    }
+  });
+});
+
+describe("Supabase verifier configuration", () => {
+  it("builds a non-persistent server client from publishable configuration", async () => {
+    let clientArguments;
+    const verifier = createSupabaseCustomerTokenVerifierFromEnv({
+      env: {
+        SUPABASE_URL: `${PROJECT_URL}/`,
+        SUPABASE_PUBLISHABLE_KEY: "sb_publishable_test",
+      },
+      createClientImpl(...args) {
+        clientArguments = args;
+        return {
+          auth: {
+            async getClaims() {
+              return { data: { claims: verifiedClaims() }, error: null };
+            },
+          },
+        };
+      },
+      now: () => NOW,
+    });
+
+    assert.deepEqual(clientArguments, [
+      PROJECT_URL,
+      "sb_publishable_test",
+      {
+        auth: {
+          autoRefreshToken: false,
+          detectSessionInUrl: false,
+          persistSession: false,
+        },
+      },
+    ]);
+    assert.equal(
+      (await verifier.verifyAccessToken("signed-token-a")).auth_user_id,
+      USER_A
+    );
+  });
+
+  it("fails closed when unconfigured and rejects partial or insecure configuration", async () => {
+    const unconfigured = createSupabaseCustomerTokenVerifierFromEnv({ env: {} });
+    assert.ok(unconfigured instanceof UnconfiguredCustomerTokenVerifier);
+    await assert.rejects(
+      unconfigured.verifyAccessToken("anything"),
+      AuthenticationRequiredError
+    );
+
+    for (const env of [
+      { SUPABASE_URL: PROJECT_URL },
+      { SUPABASE_PUBLISHABLE_KEY: "sb_publishable_test" },
+      {
+        SUPABASE_URL: "http://insecure.example",
+        SUPABASE_PUBLISHABLE_KEY: "sb_publishable_test",
+      },
+    ]) {
+      assert.throws(
+        () => createSupabaseCustomerTokenVerifierFromEnv({ env }),
+        CustomerAuthenticationConfigurationError
+      );
+    }
+  });
+});

--- a/test/customer-generation.test.js
+++ b/test/customer-generation.test.js
@@ -1,0 +1,446 @@
+const assert = require("node:assert/strict");
+const { beforeEach, describe, it } = require("node:test");
+const request = require("supertest");
+
+const {
+  AuthenticationRequiredError,
+  InMemoryAuthorizationRepository,
+  createCustomerActorFromVerifiedIdentity,
+} = require("../src/authorization");
+const {
+  SupabaseCustomerTokenVerifier,
+} = require("../src/authentication");
+const {
+  InMemoryBrandBrainRepository,
+} = require("../src/brand-brain");
+const {
+  InMemoryImageGenerationRepository,
+} = require("../src/image-generation");
+const { createApp } = require("../index");
+
+const ADMIN_KEY = "customer-generation-admin-key";
+const USER_A = "11111111-1111-4111-8111-111111111111";
+const USER_B = "22222222-2222-4222-8222-222222222222";
+const PROJECT_URL = "https://bizgenie-test.supabase.co";
+const RAW_INVALID_TOKEN = "invalid.raw.jwt-that-must-never-leak";
+const COMPLETE_OUTPUT = [
+  "Hook: Stop scrolling and make planning work for you.",
+  "Concept: Show a simple plan becoming a finished post.",
+  "Script: Start with one clear goal, choose the next action, and publish consistently.",
+  "CTA: Try the planning workflow today.",
+  "Caption: A practical plan turns ideas into progress.",
+  "Hashtags: #Planning #Content #SmallBusiness",
+  "Filming instructions:",
+  "- Open on a close-up of the written plan.",
+].join("\n");
+
+function authorizationRepository() {
+  return new InMemoryAuthorizationRepository({
+    customerProfiles: [
+      { auth_user_id: USER_A, display_name: "Customer A" },
+      { auth_user_id: USER_B, display_name: "Customer B" },
+    ],
+    tenants: [
+      { tenant_id: "tenant_a", name: "Tenant A", created_by: USER_A },
+      { tenant_id: "tenant_b", name: "Tenant B", created_by: USER_B },
+    ],
+    memberships: [
+      { tenant_id: "tenant_a", auth_user_id: USER_A, role: "owner" },
+      { tenant_id: "tenant_b", auth_user_id: USER_B, role: "owner" },
+    ],
+    projects: [
+      { project_id: "project_a", tenant_id: "tenant_a", name: "Project A" },
+      { project_id: "project_b", tenant_id: "tenant_b", name: "Project B" },
+    ],
+    brands: [
+      { brand_id: "brand_a", project_id: "project_a", name: "Brand A" },
+      { brand_id: "brand_b", project_id: "project_b", name: "Brand B" },
+    ],
+  });
+}
+
+function brandBrainRecord({
+  brandId = "brand_a",
+  projectId = "project_a",
+  name = "Tenant A Brand",
+} = {}) {
+  return {
+    brand_id: brandId,
+    project_id: projectId,
+    name,
+    identity: { positioning: `${name} private positioning` },
+    metadata: {
+      version: 1,
+      status: "approved",
+      created_at: "2026-08-19T09:00:00.000Z",
+      updated_at: "2026-08-19T09:00:00.000Z",
+    },
+  };
+}
+
+function brandBrainRepository() {
+  const repository = new InMemoryBrandBrainRepository();
+  repository.upsert(brandBrainRecord());
+  repository.upsert(
+    brandBrainRecord({
+      brandId: "brand_b",
+      projectId: "project_b",
+      name: "Tenant B Brand",
+    })
+  );
+  return repository;
+}
+
+class FixtureTokenVerifier {
+  constructor() {
+    this.calls = [];
+  }
+
+  async verifyAccessToken(token) {
+    this.calls.push(token);
+    if (token === "token-a") {
+      return createCustomerActorFromVerifiedIdentity({
+        verifiedAuthUserId: USER_A,
+      });
+    }
+    if (token === "token-b") {
+      return createCustomerActorFromVerifiedIdentity({
+        verifiedAuthUserId: USER_B,
+      });
+    }
+    throw new AuthenticationRequiredError();
+  }
+}
+
+function scriptRequest(overrides = {}) {
+  return {
+    execution_id: "execution_customer_001",
+    tenant_id: "tenant_a",
+    project_id: "project_a",
+    brand_id: "brand_a",
+    compiled_prompt: "Create a customer-authorized script",
+    ...overrides,
+  };
+}
+
+function imageRequest(overrides = {}) {
+  return {
+    execution_id: "execution_image_customer_001",
+    generation_id: "generation_customer_001",
+    tenant_id: "tenant_a",
+    project_id: "project_a",
+    brand_id: "brand_a",
+    topic: "A calm planning workflow",
+    image_purpose: "Social media campaign image",
+    aspect_ratio: "1:1",
+    ...overrides,
+  };
+}
+
+function customer(client, token = "token-a") {
+  return client.set("authorization", `Bearer ${token}`);
+}
+
+function appFixture(overrides = {}) {
+  const tokenVerifier = overrides.customerTokenVerifier || new FixtureTokenVerifier();
+  const imageGenerationRepository = new InMemoryImageGenerationRepository();
+  const providerCalls = [];
+  let scriptCalls = 0;
+  let scriptOptions;
+  const logs = [];
+  const logger = {
+    info(message, details) {
+      logs.push({ level: "info", message, details });
+    },
+    warn(message, details) {
+      logs.push({ level: "warn", message, details });
+    },
+    error(message, details) {
+      logs.push({ level: "error", message, details });
+    },
+  };
+  const app = createApp({
+    authorizationRepository: authorizationRepository(),
+    brandBrainRepository: brandBrainRepository(),
+    customerTokenVerifier: tokenVerifier,
+    imageGenerationRepository,
+    imageProvider: {
+      async generate(value) {
+        providerCalls.push(structuredClone(value));
+        return {
+          provider: "fixture-image-provider",
+          provider_job_id: "fixture-job-001",
+          asset: {
+            location: "gs://fixture-assets/generated/image.png",
+            mime_type: "image/png",
+            width: 1024,
+            height: 1024,
+          },
+        };
+      },
+    },
+    scriptGenerator: async (_prompt, options) => {
+      scriptCalls += 1;
+      scriptOptions = options;
+      return { text: COMPLETE_OUTPUT, metadata: { provider: "fixture" } };
+    },
+    logger,
+  });
+
+  return {
+    app,
+    imageGenerationRepository,
+    logs,
+    providerCalls,
+    scriptCallCount: () => scriptCalls,
+    scriptOptions: () => scriptOptions,
+    tokenVerifier,
+  };
+}
+
+beforeEach(() => {
+  process.env.ADMIN_KEY = ADMIN_KEY;
+});
+
+describe("customer generation authentication", () => {
+  it("rejects a missing, malformed, expired, or invalid token before generation", async () => {
+    const fixture = appFixture();
+
+    const missing = await request(fixture.app)
+      .post("/customer/generate-script")
+      .send(scriptRequest());
+    const malformed = await request(fixture.app)
+      .post("/customer/generate-script")
+      .set("authorization", "Basic not-a-bearer-token")
+      .send(scriptRequest());
+    const invalid = await customer(
+      request(fixture.app).post("/customer/generate-script"),
+      "invalid-token"
+    ).send(scriptRequest());
+
+    for (const response of [missing, malformed, invalid]) {
+      assert.equal(response.status, 401);
+      assert.deepEqual(response.body, {
+        status: "failed",
+        error: {
+          code: "AUTHENTICATION_REQUIRED",
+          message: "Customer authentication is required",
+        },
+        script_body: "",
+      });
+    }
+    assert.equal(fixture.scriptCallCount(), 0);
+
+    const expiredVerifier = new SupabaseCustomerTokenVerifier({
+      projectUrl: PROJECT_URL,
+      now: () => new Date("2026-08-19T12:00:00.000Z"),
+      supabaseClient: {
+        auth: {
+          async getClaims() {
+            return {
+              data: {
+                claims: {
+                  iss: `${PROJECT_URL}/auth/v1`,
+                  sub: USER_A,
+                  aud: "authenticated",
+                  exp: 1787140800,
+                },
+              },
+              error: null,
+            };
+          },
+        },
+      },
+    });
+    const expiredFixture = appFixture({
+      customerTokenVerifier: expiredVerifier,
+    });
+    const expired = await customer(
+      request(expiredFixture.app).post("/customer/generate-script"),
+      "expired-token"
+    ).send(scriptRequest());
+    assert.equal(expired.status, 401);
+    assert.equal(expiredFixture.scriptCallCount(), 0);
+  });
+
+  it("never returns or logs a raw JWT or provider verification details", async () => {
+    const verifier = new SupabaseCustomerTokenVerifier({
+      projectUrl: PROJECT_URL,
+      supabaseClient: {
+        auth: {
+          async getClaims() {
+            return {
+              data: null,
+              error: new Error(
+                `signature verification failed for ${RAW_INVALID_TOKEN}`
+              ),
+            };
+          },
+        },
+      },
+    });
+    const fixture = appFixture({ customerTokenVerifier: verifier });
+
+    const response = await customer(
+      request(fixture.app).post("/customer/generate-script"),
+      RAW_INVALID_TOKEN
+    ).send(scriptRequest());
+    const observable = JSON.stringify({ body: response.body, logs: fixture.logs });
+
+    assert.equal(response.status, 401);
+    assert.doesNotMatch(observable, /invalid\.raw\.jwt-that-must-never-leak/);
+    assert.doesNotMatch(observable, /signature verification failed/i);
+    assert.doesNotMatch(observable, /authorization/i);
+  });
+});
+
+describe("customer tenant, project, and Brand Brain enforcement", () => {
+  it("authorizes Tenant A and ignores an impersonating body user_id", async () => {
+    const fixture = appFixture();
+    const response = await customer(
+      request(fixture.app).post("/customer/generate-script")
+    ).send(scriptRequest({ user_id: USER_B }));
+
+    assert.equal(response.status, 200);
+    assert.equal(fixture.scriptCallCount(), 1);
+    assert.match(
+      fixture.scriptOptions().promptOptions.brandContext,
+      /Tenant A Brand private positioning/
+    );
+    assert.doesNotMatch(
+      fixture.scriptOptions().promptOptions.brandContext,
+      /Tenant B Brand/
+    );
+  });
+
+  it("does not require body user_id because verified identity is authoritative", async () => {
+    const fixture = appFixture();
+    const response = await customer(
+      request(fixture.app).post("/customer/generate-script")
+    ).send(scriptRequest());
+
+    assert.equal(response.status, 200);
+    assert.equal(fixture.scriptCallCount(), 1);
+  });
+
+  it("returns one non-enumerating denial for cross-tenant, cross-brand, and unknown resources", async () => {
+    const attempts = [
+      scriptRequest({ tenant_id: "tenant_b", project_id: "project_b", brand_id: undefined }),
+      scriptRequest({ brand_id: "brand_b" }),
+      scriptRequest({
+        tenant_id: "tenant_missing",
+        project_id: "project_missing",
+        brand_id: "brand_missing",
+      }),
+    ];
+
+    for (const body of attempts) {
+      const fixture = appFixture();
+      const response = await customer(
+        request(fixture.app).post("/customer/generate-script")
+      ).send(body);
+
+      assert.equal(response.status, 404);
+      assert.deepEqual(response.body, {
+        status: "failed",
+        error: {
+          code: "RESOURCE_NOT_AVAILABLE",
+          message: "The requested resource is not available",
+        },
+        script_body: "",
+      });
+      assert.equal(fixture.scriptCallCount(), 0);
+    }
+  });
+
+  it("protects image generation with the same actor and ownership chain", async () => {
+    const fixture = appFixture();
+    const response = await customer(
+      request(fixture.app).post("/customer/generate-image")
+    ).send(imageRequest({ user_id: USER_B }));
+
+    assert.equal(response.status, 200);
+    const stored = fixture.imageGenerationRepository.getByGenerationId(
+      "generation_customer_001"
+    );
+    assert.equal(stored.user_id, USER_A);
+    assert.equal(fixture.providerCalls[0].metadata.user_id, USER_A);
+    assert.equal(fixture.providerCalls[0].metadata.project_id, "project_a");
+    assert.doesNotMatch(JSON.stringify(fixture.providerCalls), /token-a/i);
+  });
+
+  it("blocks cross-tenant image generation before persistence or provider access", async () => {
+    const fixture = appFixture();
+    const response = await customer(
+      request(fixture.app).post("/customer/generate-image")
+    ).send(
+      imageRequest({
+        tenant_id: "tenant_b",
+        project_id: "project_b",
+        brand_id: "brand_b",
+      })
+    );
+
+    assert.equal(response.status, 404);
+    assert.equal(fixture.providerCalls.length, 0);
+    assert.equal(
+      fixture.imageGenerationRepository.getByGenerationId(
+        "generation_customer_001"
+      ),
+      null
+    );
+  });
+});
+
+describe("customer and administrator principal separation", () => {
+  it("does not grant administrator authority to a valid customer token", async () => {
+    const fixture = appFixture();
+    const response = await customer(request(fixture.app).get("/_admin/ping"));
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(response.body, { error: "Forbidden" });
+  });
+
+  it("does not accept ADMIN_KEY as a customer session", async () => {
+    const fixture = appFixture();
+    const response = await request(fixture.app)
+      .post("/customer/generate-script")
+      .set("x-admin-key", ADMIN_KEY)
+      .send(scriptRequest());
+
+    assert.equal(response.status, 401);
+    assert.equal(fixture.scriptCallCount(), 0);
+  });
+
+  it("preserves the existing ADMIN_KEY script and image paths", async () => {
+    const fixture = appFixture();
+    const script = await request(fixture.app)
+      .post("/generate-script")
+      .set("x-admin-key", ADMIN_KEY)
+      .send({
+        execution_id: "admin_execution_001",
+        user_id: "internal_user_001",
+        project_id: "project_a",
+        compiled_prompt: "Preserve the internal contract",
+      });
+    const image = await request(fixture.app)
+      .post("/generate-image")
+      .set("x-admin-key", ADMIN_KEY)
+      .send({
+        ...imageRequest({
+          generation_id: "admin_generation_001",
+          user_id: "internal_user_001",
+        }),
+        tenant_id: undefined,
+      });
+
+    assert.equal(script.status, 200);
+    assert.equal(image.status, 200);
+    assert.equal(
+      fixture.imageGenerationRepository.getByGenerationId(
+        "admin_generation_001"
+      ).user_id,
+      "internal_user_001"
+    );
+  });
+});


### PR DESCRIPTION
## BG-AUTH-002B

Integrates verified Supabase customer-token authentication and tenant/project/Brand Brain authorization onto the current canonical main while preserving the existing administrator generation routes and merged Billing/Video foundations.

### Verified release evidence
- Head commit: `8ec3d9c`
- Expected integrated tree: `dbed587daebf3ce6d9560e2878a86c1acd6894c2`
- Runtime: Node `22.23.2`
- Full integrated suite: **214/214 passed**, 49 suites, 0 failures/skips/cancellations
- `git diff --cached --check`: PASS
- Body `user_id` is not trusted as customer identity
- Customer JWTs do not reach Make/model providers
- Existing `ADMIN_KEY` paths preserved
- No production database mutation, deployment, credentials, or Auth activation performed

### Scope
Adds the customer authentication boundary, Supabase claims verification, customer generation middleware/routes, documentation and adversarial customer/tenant generation tests.

This PR is an integration/release gate only. Production activation remains separate.