### PR TITLE
BG-AUTH-002C: fail-closed generation job authorization

### DIFF
--- a/docs/security/GENERATION_JOB_SERVICE_BOUNDARY.md
+++ b/docs/security/GENERATION_JOB_SERVICE_BOUNDARY.md
@@ -1,0 +1,55 @@
+# Generation-job service boundary
+
+BG-AUTH-002C uses one global BizGenie internal execution principal. The
+principal represents the trusted internal worker, not a customer tenant. Its
+strict actor contract contains only:
+
+- `kind: "service"`;
+- an immutable server-configured `service_id`;
+- immutable server-configured bounded `scopes`.
+
+It deliberately has no tenant, project, brand, customer, execution-class, or
+billing authority. The credential and actor are constructed only from server
+environment/secrets; request headers, query values, and bodies cannot add
+authority to them.
+
+## Ownership authority
+
+Tenant ownership is established before the service boundary. The verified
+customer authorization chain creates one immutable generation job binding the
+tenant, project, optional brand, customer actor correlation, execution class,
+idempotency identity, and allowed downstream scope.
+
+The service route accepts only a verified global worker, the server-configured
+required scope, and an opaque existing `job_id`. It does not accept a tenant,
+project, brand, actor, or execution class as route authority. A request that
+supplies those values in a header, query, or body cannot reinterpret or mutate
+the selected job. The response remains limited to:
+
+- `job_id`;
+- the job's immutable `execution_class`;
+- sanitized `execution_input`.
+
+## Cross-tenant interpretation
+
+The global worker is neither Tenant A nor Tenant B. When it retrieves a valid
+Tenant B job by opaque identity, it executes the authority already fixed in
+that Tenant B job; it does not cross from a Tenant A service context because
+no such service context exists.
+
+For Issue #32, a cross-tenant service-boundary attempt is an attempt to inject,
+replace, or reinterpret a job's tenant/project/brand/customer/execution-class
+authority. Such request data is ignored and never appears in the bounded
+payload. Customer attempts to create or access another tenant's job remain
+denied by the existing customer authorization boundary.
+
+Unknown jobs, wrong service credentials, missing service scope, and jobs that
+do not authorize the required scope all return the same `403 Forbidden`
+response, without resource enumeration.
+
+## Execution status
+
+This route is a future server-to-server execution seam. BG-AUTH-002C does not
+activate Make or any provider dispatch. Existing in-process Text/Image
+generation remains the active adapter and may run only after the authoritative
+generation job has been persisted successfully.

--- a/index.js
+++ b/index.js
@@ -48,6 +48,24 @@ const {
   GenerationIncompleteError,
   generateScriptWithVertex,
 } = require("./src/generation");
+const {
+  GenerationJobService,
+  InMemoryGenerationJobRepository,
+  PostgresGenerationJobRepository,
+  createGenerationJobRecorder,
+} = require("./src/generation-jobs");
+const {
+  UnconfiguredServiceCredentialVerifier,
+  createServiceCredentialVerifierFromEnv,
+} = require("./src/service-principal");
+const {
+  createServiceExecutionRouter,
+} = require("./src/service-execution");
+
+// The single scope this task defines. A future task may add narrower,
+// per-execution-class scopes; for now every generation job authorizes
+// exactly this one bounded downstream capability.
+const GENERATION_EXECUTE_SCOPE = "generation:execute";
 
 function requireAdmin(req, res, next) {
   const adminKey = process.env.ADMIN_KEY;
@@ -190,6 +208,9 @@ function createApp({
   authorizationRepository = new InMemoryAuthorizationRepository(),
   authorizationService,
   customerTokenVerifier = new UnconfiguredCustomerTokenVerifier(),
+  generationJobRepository = new InMemoryGenerationJobRepository(),
+  generationJobService,
+  servicePrincipalVerifier = new UnconfiguredServiceCredentialVerifier(),
   logger = console,
 } = {}) {
   const resolvedBranding = BrandingConfigSchema.parse(branding);
@@ -197,6 +218,9 @@ function createApp({
     authorizationService || new AuthorizationService({
       repository: authorizationRepository,
     });
+  const resolvedGenerationJobService =
+    generationJobService ||
+    new GenerationJobService({ repository: generationJobRepository });
   const imageGenerationService = new ImageGenerationService({
     repository: imageGenerationRepository,
     provider: imageProvider,
@@ -226,6 +250,20 @@ function createApp({
   const customerImageBoundary = createCustomerGenerationBoundary({
     tokenVerifier: customerTokenVerifier,
     authorizationService: resolvedAuthorizationService,
+    kind: "image",
+    logger,
+  });
+  const recordScriptGenerationJob = createGenerationJobRecorder({
+    generationJobService: resolvedGenerationJobService,
+    executionClass: "text.standard",
+    allowedScopes: [GENERATION_EXECUTE_SCOPE],
+    kind: "script",
+    logger,
+  });
+  const recordImageGenerationJob = createGenerationJobRecorder({
+    generationJobService: resolvedGenerationJobService,
+    executionClass: "image.normal",
+    allowedScopes: [GENERATION_EXECUTE_SCOPE],
     kind: "image",
     logger,
   });
@@ -267,13 +305,28 @@ function createApp({
   app.post(
     "/customer/generate-script",
     customerScriptBoundary,
+    recordScriptGenerationJob,
     scriptHandler
   );
 
   app.use(
     "/customer/generate-image",
     customerImageBoundary,
+    recordImageGenerationJob,
     createImageGenerationRouter({ service: imageGenerationService, logger })
+  );
+
+  // Future bounded server-to-server execution seam. Customer generation is
+  // currently executed in-process only after the mandatory job recorder
+  // above succeeds; this route does not dispatch to Make or a provider.
+  app.use(
+    "/_service/generation-jobs",
+    createServiceExecutionRouter({
+      jobRepository: generationJobRepository,
+      servicePrincipalVerifier,
+      requiredScope: GENERATION_EXECUTE_SCOPE,
+      logger,
+    })
   );
 
   app.use((error, req, res, next) => {
@@ -366,16 +419,26 @@ async function createProductionApp({ env = process.env, logger = console } = {})
   const customerTokenVerifier = createSupabaseCustomerTokenVerifierFromEnv({
     env,
   });
+  const generationJobRepository = new PostgresGenerationJobRepository({
+    pool: brandBrainRepository.pool,
+  });
+  const servicePrincipalVerifier = createServiceCredentialVerifierFromEnv({
+    env,
+  });
   return {
     app: createApp({
       authorizationRepository,
       brandBrainRepository,
       customerTokenVerifier,
+      generationJobRepository,
+      servicePrincipalVerifier,
       logger,
     }),
     authorizationRepository,
     brandBrainRepository,
     customerTokenVerifier,
+    generationJobRepository,
+    servicePrincipalVerifier,
   };
 }
 

--- a/src/generation-jobs/errors.js
+++ b/src/generation-jobs/errors.js
@@ -1,0 +1,24 @@
+class GenerationJobConflictError extends Error {
+  constructor() {
+    super(
+      "An existing generation job with this idempotency key has different ownership"
+    );
+    this.name = "GenerationJobConflictError";
+    this.status = 409;
+    this.code = "GENERATION_JOB_CONFLICT";
+  }
+}
+
+class GenerationJobNotFoundError extends Error {
+  constructor() {
+    super("The requested generation job is not available");
+    this.name = "GenerationJobNotFoundError";
+    this.status = 404;
+    this.code = "GENERATION_JOB_NOT_FOUND";
+  }
+}
+
+module.exports = {
+  GenerationJobConflictError,
+  GenerationJobNotFoundError,
+};

--- a/src/generation-jobs/executionInput.js
+++ b/src/generation-jobs/executionInput.js
@@ -1,0 +1,60 @@
+// The narrow, explicit allow-list of generation content fields a job may
+// carry downstream. Everything else supplied by a customer request is
+// dropped here, before it ever reaches a job record or the service
+// execution boundary. In particular this list deliberately excludes any
+// field that could carry provider, model, price, cost, secret, callback, or
+// asset-location authority, and it excludes tenant/project/brand/user
+// identity, all of which stay server-side and are never forwarded.
+const EXECUTION_INPUT_ALLOWED_KEYS = Object.freeze([
+  "compiled_prompt",
+  "platform",
+  "script_type",
+  "audience",
+  "intent_stage",
+  "voice_style",
+  "topic",
+  "goal",
+  "image_purpose",
+  "aspect_ratio",
+  "additional_context",
+  "product_service_context",
+]);
+
+const MAX_VALUE_LENGTH = 8_000;
+
+function sanitizedScalar(value) {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? trimmed.slice(0, MAX_VALUE_LENGTH) : undefined;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "boolean") {
+    return value;
+  }
+  // Objects, arrays, functions, and anything else are rejected outright:
+  // this keeps the payload flat and prevents nested structures (for
+  // example a reference asset carrying a storage location, or a callback
+  // object) from riding along inside an otherwise-innocent-looking field.
+  return undefined;
+}
+
+function sanitizeExecutionInput(rawInput) {
+  const input = rawInput && typeof rawInput === "object" ? rawInput : {};
+  const sanitized = {};
+
+  for (const key of EXECUTION_INPUT_ALLOWED_KEYS) {
+    const value = sanitizedScalar(input[key]);
+    if (value !== undefined) {
+      sanitized[key] = value;
+    }
+  }
+
+  return sanitized;
+}
+
+module.exports = {
+  EXECUTION_INPUT_ALLOWED_KEYS,
+  sanitizeExecutionInput,
+};

--- a/src/generation-jobs/index.js
+++ b/src/generation-jobs/index.js
@@ -1,0 +1,17 @@
+const errors = require("./errors");
+const executionInput = require("./executionInput");
+const middleware = require("./middleware");
+const repository = require("./repository");
+const { PostgresGenerationJobRepository } = require("./postgresRepository");
+const schema = require("./schema");
+const { GenerationJobService } = require("./service");
+
+module.exports = {
+  ...errors,
+  ...executionInput,
+  ...middleware,
+  ...repository,
+  ...schema,
+  GenerationJobService,
+  PostgresGenerationJobRepository,
+};

--- a/src/generation-jobs/middleware.js
+++ b/src/generation-jobs/middleware.js
@@ -1,0 +1,94 @@
+const { randomUUID } = require("node:crypto");
+
+const GENERATION_JOB_UNAVAILABLE_ERROR = Object.freeze({
+  code: "GENERATION_JOB_UNAVAILABLE",
+  message: "Generation authorization is temporarily unavailable",
+});
+
+function failureBody(kind) {
+  if (kind === "script") {
+    return {
+      status: "failed",
+      error: GENERATION_JOB_UNAVAILABLE_ERROR,
+      script_body: "",
+    };
+  }
+  return {
+    status: "failed",
+    error: GENERATION_JOB_UNAVAILABLE_ERROR,
+    media: null,
+  };
+}
+
+// Mounted after the existing customer generation boundary
+// (createCustomerGenerationBoundary), which already performed the real
+// security decision: verified customer -> membership -> tenant -> project
+// -> optional Brand Brain -> generation:create. This middleware only
+// records that authorized transition as one immutable internal generation
+// job. Establishing that job is mandatory: the existing in-process
+// Text/Image handler is the active execution adapter at this foundation
+// stage, but it may run only after authoritative persistence succeeds.
+function createGenerationJobRecorder({
+  generationJobService,
+  executionClass,
+  allowedScopes,
+  kind,
+  logger = console,
+}) {
+  if (!generationJobService) {
+    throw new TypeError("A generation job service is required");
+  }
+  if (typeof executionClass !== "string" || !executionClass.trim()) {
+    throw new TypeError("An execution class is required");
+  }
+  if (!Array.isArray(allowedScopes) || allowedScopes.length === 0) {
+    throw new TypeError("At least one allowed scope is required");
+  }
+  if (!new Set(["script", "image"]).has(kind)) {
+    throw new TypeError("Generation job response kind must be script or image");
+  }
+
+  return async function recordGenerationJob(req, res, next) {
+    const authorization = res.locals.customerAuthorization;
+
+    if (!authorization) {
+      logger.error?.("generation job authorization missing", {
+        path: req.path,
+        code: GENERATION_JOB_UNAVAILABLE_ERROR.code,
+      });
+      return res.status(503).json(failureBody(kind));
+    }
+
+    try {
+      const body = req.body && typeof req.body === "object" ? req.body : {};
+      const requestCorrelationId =
+        typeof body.execution_id === "string" && body.execution_id.trim()
+          ? body.execution_id
+          : randomUUID();
+
+      const job = await generationJobService.authorizeAndCreateJob({
+        authorization,
+        executionClass,
+        requestCorrelationId,
+        idempotencyKey: requestCorrelationId,
+        allowedScopes,
+        executionInput: body,
+      });
+
+      res.locals.generationJob = job;
+    } catch (error) {
+      logger.error?.("generation job establishment failed", {
+        path: req.path,
+        code: error?.code || error?.name || "GENERATION_JOB_ERROR",
+      });
+      return res.status(503).json(failureBody(kind));
+    }
+
+    return next();
+  };
+}
+
+module.exports = {
+  GENERATION_JOB_UNAVAILABLE_ERROR,
+  createGenerationJobRecorder,
+};

--- a/src/generation-jobs/postgresRepository.js
+++ b/src/generation-jobs/postgresRepository.js
@@ -1,0 +1,108 @@
+const { GenerationJobRepository } = require("./repository");
+const { freezeGenerationJob } = require("./schema");
+
+// Mirrors PostgresAuthorizationRepository's shape. createProductionApp uses
+// this repository, but the accompanying migration remains deliberately
+// unapplied in this task. Production rollout is a separate, reviewed gate.
+class PostgresGenerationJobRepository extends GenerationJobRepository {
+  constructor({ pool }) {
+    super();
+    if (!pool || typeof pool.query !== "function") {
+      throw new TypeError("A PostgreSQL connection pool is required");
+    }
+    this.pool = pool;
+  }
+
+  async findByIdempotencyKey(tenantId, projectId, idempotencyKey) {
+    const result = await this.pool.query(
+      `SELECT job_id, tenant_id, project_id, brand_id, execution_class,
+              auth_user_id, request_correlation_id, idempotency_key,
+              allowed_scopes, created_at
+         FROM public.generation_jobs
+        WHERE tenant_id = $1
+          AND project_id = $2
+          AND idempotency_key = $3`,
+      [tenantId, projectId, idempotencyKey]
+    );
+    return result.rows[0] ? this.toJob(result.rows[0]) : null;
+  }
+
+  async create(job, { executionContent = {} } = {}) {
+    await this.pool.query(
+      `INSERT INTO public.generation_jobs
+         (job_id, tenant_id, project_id, brand_id, execution_class,
+          auth_user_id, request_correlation_id, idempotency_key,
+          allowed_scopes, execution_content, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+      [
+        job.job_id,
+        job.tenant_id,
+        job.project_id,
+        job.brand_id || null,
+        job.execution_class,
+        job.actor_correlation.auth_user_id,
+        job.request_correlation_id,
+        job.idempotency_key,
+        JSON.stringify(job.allowed_scopes),
+        JSON.stringify(executionContent),
+        job.created_at,
+      ]
+    );
+    return job;
+  }
+
+  async getById(jobId) {
+    const result = await this.pool.query(
+      `SELECT job_id, tenant_id, project_id, brand_id, execution_class,
+              auth_user_id, request_correlation_id, idempotency_key,
+              allowed_scopes, created_at
+         FROM public.generation_jobs
+        WHERE job_id = $1`,
+      [jobId]
+    );
+    return result.rows[0] ? this.toJob(result.rows[0]) : null;
+  }
+
+  async getExecutionContent(jobId) {
+    const result = await this.pool.query(
+      `SELECT execution_content FROM public.generation_jobs WHERE job_id = $1`,
+      [jobId]
+    );
+    return result.rows[0] ? result.rows[0].execution_content : null;
+  }
+
+  async recordAttempt(_jobId) {
+    // Attempt counts are an observability aid only, never an ownership
+    // field, and are intentionally not persisted server-side here to avoid
+    // adding a mutable column to an otherwise append-only table. A future
+    // task may add a separate, non-authoritative attempts log if needed.
+    return 0;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  toJob(row) {
+    return freezeGenerationJob({
+      job_id: row.job_id,
+      tenant_id: row.tenant_id,
+      project_id: row.project_id,
+      brand_id: row.brand_id || undefined,
+      execution_class: row.execution_class,
+      actor_correlation: {
+        kind: "customer",
+        auth_user_id: row.auth_user_id,
+      },
+      request_correlation_id: row.request_correlation_id,
+      idempotency_key: row.idempotency_key,
+      created_at:
+        row.created_at instanceof Date
+          ? row.created_at.toISOString()
+          : row.created_at,
+      allowed_scopes:
+        typeof row.allowed_scopes === "string"
+          ? JSON.parse(row.allowed_scopes)
+          : row.allowed_scopes,
+    });
+  }
+}
+
+module.exports = { PostgresGenerationJobRepository };

--- a/src/generation-jobs/repository.js
+++ b/src/generation-jobs/repository.js
@@ -1,0 +1,138 @@
+const {
+  freezeGenerationJob,
+} = require("./schema");
+
+const IDEMPOTENCY_CONSTRAINT = "generation_jobs_idempotency_unique";
+
+function idempotencyConflictError() {
+  const error = new Error(
+    "A generation job with this idempotency identity already exists"
+  );
+  error.code = "23505";
+  error.constraint = IDEMPOTENCY_CONSTRAINT;
+  return error;
+}
+
+function isIdempotencyConflict(error) {
+  return (
+    error?.code === "23505" &&
+    error?.constraint === IDEMPOTENCY_CONSTRAINT
+  );
+}
+
+class GenerationJobRepository {
+  findByIdempotencyKey(_tenantId, _projectId, _idempotencyKey) {
+    throw new Error(
+      "GenerationJobRepository.findByIdempotencyKey is not implemented"
+    );
+  }
+
+  create(_job, _options) {
+    throw new Error("GenerationJobRepository.create is not implemented");
+  }
+
+  getById(_jobId) {
+    throw new Error("GenerationJobRepository.getById is not implemented");
+  }
+
+  getExecutionContent(_jobId) {
+    throw new Error(
+      "GenerationJobRepository.getExecutionContent is not implemented"
+    );
+  }
+
+  recordAttempt(_jobId) {
+    throw new Error("GenerationJobRepository.recordAttempt is not implemented");
+  }
+}
+
+function idempotencyMapKey(tenantId, projectId, idempotencyKey) {
+  return `${tenantId}\u0000${projectId}\u0000${idempotencyKey}`;
+}
+
+// Process-local reference implementation. A generation job, once created, is
+// never mutated: retries either return the exact same frozen record (after
+// recording an attempt for observability) or are rejected outright as a
+// conflict. There is no update path at all, by design.
+class InMemoryGenerationJobRepository extends GenerationJobRepository {
+  constructor() {
+    super();
+    this.jobsById = new Map();
+    this.jobIdByIdempotencyKey = new Map();
+    this.executionContentByJobId = new Map();
+    this.attemptCountByJobId = new Map();
+  }
+
+  findByIdempotencyKey(tenantId, projectId, idempotencyKey) {
+    const jobId = this.jobIdByIdempotencyKey.get(
+      idempotencyMapKey(tenantId, projectId, idempotencyKey)
+    );
+    return jobId ? this.jobsById.get(jobId) || null : null;
+  }
+
+  create(job, { executionContent = {} } = {}) {
+    const storedJob = freezeGenerationJob(job);
+    if (this.jobsById.has(storedJob.job_id)) {
+      // Defense in depth: job_id is server-generated (randomUUID), so this
+      // should be unreachable, but a duplicate id must never silently
+      // overwrite an existing immutable job.
+      throw new Error("A generation job with this job_id already exists");
+    }
+
+    const logicalKey = idempotencyMapKey(
+      storedJob.tenant_id,
+      storedJob.project_id,
+      storedJob.idempotency_key
+    );
+    if (this.jobIdByIdempotencyKey.has(logicalKey)) {
+      throw idempotencyConflictError();
+    }
+
+    this.jobsById.set(storedJob.job_id, storedJob);
+    this.jobIdByIdempotencyKey.set(
+      logicalKey,
+      storedJob.job_id
+    );
+    this.executionContentByJobId.set(
+      storedJob.job_id,
+      Object.freeze({ ...executionContent })
+    );
+    this.attemptCountByJobId.set(storedJob.job_id, 1);
+    return storedJob;
+  }
+
+  getById(jobId) {
+    return this.jobsById.get(jobId) || null;
+  }
+
+  getExecutionContent(jobId) {
+    return this.executionContentByJobId.get(jobId) || null;
+  }
+
+  recordAttempt(jobId) {
+    if (!this.jobsById.has(jobId)) {
+      return 0;
+    }
+    const next = (this.attemptCountByJobId.get(jobId) || 0) + 1;
+    this.attemptCountByJobId.set(jobId, next);
+    return next;
+  }
+
+  getAttemptCount(jobId) {
+    return this.attemptCountByJobId.get(jobId) || 0;
+  }
+
+  // Test/operational convenience: the number of distinct logical jobs held
+  // by this repository, independent of how many times each was retried.
+  size() {
+    return this.jobsById.size;
+  }
+}
+
+module.exports = {
+  GenerationJobRepository,
+  IDEMPOTENCY_CONSTRAINT,
+  InMemoryGenerationJobRepository,
+  idempotencyMapKey,
+  isIdempotencyConflict,
+};

--- a/src/generation-jobs/schema.js
+++ b/src/generation-jobs/schema.js
@@ -1,0 +1,80 @@
+const { z } = require("zod");
+const { identifier, executionClass } = require("../billing/schema");
+const { CustomerActorSchema } = require("../authorization/schema");
+
+const IDENTIFIER_MAX_LENGTH = 128;
+const MAX_ALLOWED_SCOPES = 5;
+const timestamp = z.string().datetime({ offset: true });
+
+// The scope grammar matches the identifier grammar used for every other
+// bounded identifier in this codebase (billing execution classes, tenant and
+// project ids, and so on).
+const scope = identifier;
+
+// This is the one canonical, immutable internal generation-job contract.
+// It binds generation identity, tenant/project/optional-brand ownership, a
+// safe customer actor correlation, the execution/media class, request
+// correlation/idempotency, a creation timestamp, and the bounded downstream
+// scope(s) this job authorizes for service-principal execution.
+//
+// Deliberately absent, by design, from this schema: user_id (the actor
+// correlation below is the only permitted identity reference and it is
+// never caller-supplied), provider, model, price, cost, any secret, any
+// callback URL, and any asset location. None of those may ever gain
+// authority through this contract.
+const GenerationJobSchema = z
+  .object({
+    job_id: identifier,
+    tenant_id: identifier,
+    project_id: identifier,
+    brand_id: identifier.optional(),
+    execution_class: executionClass,
+    actor_correlation: CustomerActorSchema,
+    request_correlation_id: identifier,
+    idempotency_key: identifier,
+    created_at: timestamp,
+    allowed_scopes: z.array(scope).min(1).max(MAX_ALLOWED_SCOPES),
+  })
+  .strict();
+
+// The fields that define a job's identity and ownership. Two creation
+// attempts that share (tenant_id, project_id, idempotency_key) must agree on
+// every one of these fields, or the second attempt is a conflict rather than
+// a retry of the same logical job.
+const OWNERSHIP_FIELDS = Object.freeze([
+  "tenant_id",
+  "project_id",
+  "brand_id",
+  "execution_class",
+  "request_correlation_id",
+]);
+
+function ownershipFingerprint(job) {
+  return JSON.stringify({
+    tenant_id: job.tenant_id,
+    project_id: job.project_id,
+    brand_id: job.brand_id ?? null,
+    execution_class: job.execution_class,
+    request_correlation_id: job.request_correlation_id,
+    auth_user_id: job.actor_correlation.auth_user_id,
+    allowed_scopes: [...job.allowed_scopes].sort(),
+  });
+}
+
+function freezeGenerationJob(value) {
+  const parsed = GenerationJobSchema.parse(value);
+  return Object.freeze({
+    ...parsed,
+    actor_correlation: Object.freeze({ ...parsed.actor_correlation }),
+    allowed_scopes: Object.freeze([...parsed.allowed_scopes]),
+  });
+}
+
+module.exports = {
+  GenerationJobSchema,
+  IDENTIFIER_MAX_LENGTH,
+  MAX_ALLOWED_SCOPES,
+  OWNERSHIP_FIELDS,
+  freezeGenerationJob,
+  ownershipFingerprint,
+};

--- a/src/generation-jobs/service.js
+++ b/src/generation-jobs/service.js
@@ -1,0 +1,138 @@
+const { randomUUID } = require("node:crypto");
+const { freezeGenerationJob, ownershipFingerprint } = require("./schema");
+const { GenerationJobConflictError } = require("./errors");
+const { sanitizeExecutionInput } = require("./executionInput");
+const { isIdempotencyConflict } = require("./repository");
+
+// Builds the minimal shape ownershipFingerprint needs from a not-yet-created
+// candidate, so a prospective retry can be compared against an existing job
+// without first constructing (and validating) a full job record.
+function prospectiveOwnership({
+  tenantId,
+  projectId,
+  brandId,
+  executionClass,
+  requestCorrelationId,
+  actor,
+  allowedScopes,
+}) {
+  return {
+    tenant_id: tenantId,
+    project_id: projectId,
+    brand_id: brandId,
+    execution_class: executionClass,
+    request_correlation_id: requestCorrelationId,
+    actor_correlation: actor,
+    allowed_scopes: allowedScopes,
+  };
+}
+
+function requireSameLogicalJob(existing, prospective) {
+  if (ownershipFingerprint(existing) !== ownershipFingerprint(prospective)) {
+    throw new GenerationJobConflictError();
+  }
+}
+
+class GenerationJobService {
+  constructor({ repository, now = () => new Date() }) {
+    if (!repository) {
+      throw new TypeError("A generation job repository is required");
+    }
+    this.repository = repository;
+    this.now = now;
+  }
+
+  // The only entry point into this module. It accepts the authorization
+  // object already produced by AuthorizationService.authorizeProject /
+  // authorizeProjectBrand (verified customer, verified tenant/project/brand
+  // membership, action === "generation:create") and transitions it into one
+  // immutable internal generation job. There is no path here that accepts a
+  // caller-supplied tenant_id, project_id, brand_id, or user_id directly:
+  // every ownership field comes from the trusted authorization object.
+  async authorizeAndCreateJob({
+    authorization,
+    executionClass,
+    requestCorrelationId,
+    idempotencyKey,
+    allowedScopes,
+    executionInput = {},
+  }) {
+    if (
+      !authorization ||
+      !authorization.actor ||
+      authorization.actor.kind !== "customer" ||
+      authorization.action !== "generation:create" ||
+      typeof authorization.tenant_id !== "string" ||
+      typeof authorization.project_id !== "string"
+    ) {
+      throw new TypeError(
+        "A generation job may only be created from a verified customer generation:create authorization"
+      );
+    }
+
+    const prospective = prospectiveOwnership({
+      tenantId: authorization.tenant_id,
+      projectId: authorization.project_id,
+      brandId: authorization.brand_id,
+      executionClass,
+      requestCorrelationId,
+      actor: authorization.actor,
+      allowedScopes,
+    });
+
+    const existing = await this.repository.findByIdempotencyKey(
+      authorization.tenant_id,
+      authorization.project_id,
+      idempotencyKey
+    );
+
+    if (existing) {
+      requireSameLogicalJob(existing, prospective);
+      await this.repository.recordAttempt(existing.job_id);
+      return existing;
+    }
+
+    const job = freezeGenerationJob({
+      job_id: randomUUID(),
+      tenant_id: authorization.tenant_id,
+      project_id: authorization.project_id,
+      brand_id: authorization.brand_id,
+      execution_class: executionClass,
+      actor_correlation: authorization.actor,
+      request_correlation_id: requestCorrelationId,
+      idempotency_key: idempotencyKey,
+      created_at: this.now().toISOString(),
+      allowed_scopes: allowedScopes,
+    });
+
+    try {
+      await this.repository.create(job, {
+        executionContent: sanitizeExecutionInput(executionInput),
+      });
+    } catch (error) {
+      if (!isIdempotencyConflict(error)) {
+        throw error;
+      }
+
+      // Two asynchronous requests may both observe no row before the first
+      // INSERT commits. The database uniqueness guard decides the winner;
+      // the loser resolves the committed row and treats it as a retry only
+      // when every immutable authority field is identical.
+      const racedExisting = await this.repository.findByIdempotencyKey(
+        authorization.tenant_id,
+        authorization.project_id,
+        idempotencyKey
+      );
+      if (!racedExisting) {
+        throw error;
+      }
+      requireSameLogicalJob(racedExisting, prospective);
+      await this.repository.recordAttempt(racedExisting.job_id);
+      return racedExisting;
+    }
+
+    return job;
+  }
+}
+
+module.exports = { GenerationJobService };

--- a/src/service-execution/index.js
+++ b/src/service-execution/index.js
@@ -1,0 +1,8 @@
+const { buildMakeExecutionPayload } = require("./makePayload");
+const { DEFAULT_SCOPE, createServiceExecutionRouter } = require("./router");
+
+module.exports = {
+  DEFAULT_SCOPE,
+  buildMakeExecutionPayload,
+  createServiceExecutionRouter,
+};

--- a/src/service-execution/makePayload.js
+++ b/src/service-execution/makePayload.js
@@ -1,0 +1,19 @@
+const { sanitizeExecutionInput } = require("../generation-jobs/executionInput");
+
+// Builds exactly what may cross the Make boundary: an opaque job identity
+// and a bounded execution payload. This function never receives, and could
+// not forward even by accident, a customer JWT, ADMIN_KEY, provider secret,
+// tenant/project/brand identity, or any billing authority — none of those
+// are parameters, and job.job_id is the only identity value included.
+function buildMakeExecutionPayload(job, executionContent = {}) {
+  return Object.freeze({
+    job_id: job.job_id,
+    execution_class: job.execution_class,
+    // Reapply the allow-list at the final boundary. Creation already stores
+    // sanitized content, but a corrupted or legacy row must not be able to
+    // smuggle authority or secrets into a downstream request.
+    execution_input: Object.freeze(sanitizeExecutionInput(executionContent)),
+  });
+}
+
+module.exports = { buildMakeExecutionPayload };

--- a/src/service-execution/router.js
+++ b/src/service-execution/router.js
@@ -8,12 +8,14 @@ const { buildMakeExecutionPayload } = require("./makePayload");
 const DEFAULT_SCOPE = "generation:execute";
 
 // This is the bounded seam a future Make/worker adapter may call. It is not
-// an active dispatcher in BG-AUTH-002C. It accepts only a verified service
-// credential with the required scope and an existing, already-authorized
-// job id; it returns nothing but the opaque job identity and bounded
-// execution payload for that job. No customer JWT, no ADMIN_KEY, no
-// tenant/project/brand identity, and no billing authority is reachable
-// through this router.
+// an active dispatcher in BG-AUTH-002C. The verified service principal is a
+// global BizGenie worker, not a tenant actor. Tenant/project/brand/customer
+// authority is already fixed in the immutable job and cannot be supplied or
+// replaced by service request data. The route accepts only that worker, the
+// server-configured required scope, and an existing authorized job id; it
+// returns nothing but the opaque job identity and bounded execution payload.
+// No customer JWT, ADMIN_KEY, ownership identity, or billing authority is
+// reachable through this router.
 function createServiceExecutionRouter({
   jobRepository,
   servicePrincipalVerifier,

--- a/src/service-execution/router.js
+++ b/src/service-execution/router.js
@@ -1,0 +1,78 @@
+const express = require("express");
+const {
+  FORBIDDEN_RESPONSE,
+  createRequireServicePrincipal,
+} = require("../service-principal");
+const { buildMakeExecutionPayload } = require("./makePayload");
+
+const DEFAULT_SCOPE = "generation:execute";
+
+// This is the bounded seam a future Make/worker adapter may call. It is not
+// an active dispatcher in BG-AUTH-002C. It accepts only a verified service
+// credential with the required scope and an existing, already-authorized
+// job id; it returns nothing but the opaque job identity and bounded
+// execution payload for that job. No customer JWT, no ADMIN_KEY, no
+// tenant/project/brand identity, and no billing authority is reachable
+// through this router.
+function createServiceExecutionRouter({
+  jobRepository,
+  servicePrincipalVerifier,
+  requiredScope = DEFAULT_SCOPE,
+  logger = console,
+}) {
+  if (!jobRepository) {
+    throw new TypeError("A generation job repository is required");
+  }
+  if (!servicePrincipalVerifier) {
+    throw new TypeError("A service principal verifier is required");
+  }
+
+  const router = express.Router();
+  const requireServicePrincipal = createRequireServicePrincipal({
+    verifier: servicePrincipalVerifier,
+    scope: requiredScope,
+    logger,
+  });
+
+  router.get(
+    "/jobs/:job_id/execution-payload",
+    requireServicePrincipal,
+    async (req, res) => {
+      try {
+        const job = await jobRepository.getById(req.params.job_id);
+
+        // A missing job and an out-of-scope job return the identical
+        // denial as a wrong credential above: this boundary never
+        // discloses whether a job id exists, only whether this exact
+        // request is authorized end to end.
+        if (
+          !job ||
+          !Array.isArray(job.allowed_scopes) ||
+          !job.allowed_scopes.includes(requiredScope)
+        ) {
+          logger.warn?.("service execution denied", {
+            required_scope: requiredScope,
+          });
+          return res.status(403).json(FORBIDDEN_RESPONSE);
+        }
+
+        const executionContent =
+          (await jobRepository.getExecutionContent(job.job_id)) || {};
+
+        return res
+          .status(200)
+          .json(buildMakeExecutionPayload(job, executionContent));
+      } catch (error) {
+        logger.error?.("service execution boundary error", {
+          name: error?.name || "Error",
+          code: error?.code || null,
+        });
+        return res.status(403).json(FORBIDDEN_RESPONSE);
+      }
+    }
+  );
+
+  return router;
+}
+
+module.exports = { DEFAULT_SCOPE, createServiceExecutionRouter };

--- a/src/service-principal/credential.js
+++ b/src/service-principal/credential.js
@@ -44,11 +44,13 @@ class UnconfiguredServiceCredentialVerifier extends ServiceCredentialVerifier {
   }
 }
 
-// Verifies a single, narrowly scoped service principal read directly from
-// server configuration. This is intentionally independent of ADMIN_KEY and
-// of customer JWT verification: it has its own secret, its own identifier,
-// and its own bounded scope set, so neither of the other two credentials can
-// ever satisfy it and it can never satisfy either of them.
+// Verifies a single, narrowly scoped global BizGenie worker read directly
+// from server configuration. It is not a tenant principal: tenant/project/
+// brand authority belongs only to the immutable generation job selected at
+// the execution boundary. This is intentionally independent of ADMIN_KEY and
+// customer JWT verification: it has its own secret, identifier, and bounded
+// scope set, so neither of the other two credentials can ever satisfy it and
+// it can never satisfy either of them.
 class StaticServiceCredentialVerifier extends ServiceCredentialVerifier {
   constructor({ serviceId, credential, scopes }) {
     super();

--- a/src/service-principal/credential.js
+++ b/src/service-principal/credential.js
@@ -1,0 +1,160 @@
+const { createHash, timingSafeEqual } = require("node:crypto");
+const { ServiceActorSchema } = require("../authorization");
+const {
+  ServicePrincipalConfigurationError,
+  ServicePrincipalDeniedError,
+} = require("./errors");
+
+const MAX_SCOPES = 20;
+
+function denied() {
+  return new ServicePrincipalDeniedError();
+}
+
+// Compares two secrets in constant time regardless of their length by
+// comparing fixed-length digests instead of the raw values. This avoids
+// leaking credential length through timing while still being safe for
+// arbitrary-length operator-configured secrets.
+function constantTimeEquals(a, b) {
+  if (typeof a !== "string" || typeof b !== "string" || !a || !b) {
+    return false;
+  }
+  const digestA = createHash("sha256").update(a, "utf8").digest();
+  const digestB = createHash("sha256").update(b, "utf8").digest();
+  return timingSafeEqual(digestA, digestB);
+}
+
+class ServiceCredentialVerifier {
+  // eslint-disable-next-line class-methods-use-this
+  verifyCredential(_providedCredential) {
+    throw new Error(
+      "ServiceCredentialVerifier.verifyCredential is not implemented"
+    );
+  }
+}
+
+// Fail-closed default used whenever no service principal has been
+// configured. Every credential is rejected; this mirrors
+// UnconfiguredCustomerTokenVerifier and UnconfiguredImageGenerationProvider
+// elsewhere in this codebase.
+class UnconfiguredServiceCredentialVerifier extends ServiceCredentialVerifier {
+  // eslint-disable-next-line class-methods-use-this
+  verifyCredential() {
+    throw denied();
+  }
+}
+
+// Verifies a single, narrowly scoped service principal read directly from
+// server configuration. This is intentionally independent of ADMIN_KEY and
+// of customer JWT verification: it has its own secret, its own identifier,
+// and its own bounded scope set, so neither of the other two credentials can
+// ever satisfy it and it can never satisfy either of them.
+class StaticServiceCredentialVerifier extends ServiceCredentialVerifier {
+  constructor({ serviceId, credential, scopes }) {
+    super();
+    if (typeof serviceId !== "string" || !serviceId.trim()) {
+      throw new ServicePrincipalConfigurationError(
+        "A service_id is required to configure a service principal"
+      );
+    }
+    if (typeof credential !== "string" || credential.trim().length < 16) {
+      throw new ServicePrincipalConfigurationError(
+        "SERVICE_PRINCIPAL_CREDENTIAL must be configured with a value of at least 16 characters"
+      );
+    }
+    if (!Array.isArray(scopes) || scopes.length === 0) {
+      throw new ServicePrincipalConfigurationError(
+        "At least one bounded scope is required to configure a service principal"
+      );
+    }
+    if (scopes.length > MAX_SCOPES) {
+      throw new ServicePrincipalConfigurationError(
+        `A service principal may not be configured with more than ${MAX_SCOPES} scopes`
+      );
+    }
+
+    // Freezing the actor shape at construction time means the verifier can
+    // only ever return this exact, already-validated identity: nothing about
+    // a request can change service_id or widen scopes at verification time.
+    const parsedActor = ServiceActorSchema.safeParse({
+      kind: "service",
+      service_id: serviceId,
+      scopes,
+    });
+    if (!parsedActor.success) {
+      throw new ServicePrincipalConfigurationError(
+        "The configured service principal does not satisfy the service actor contract"
+      );
+    }
+
+    this.credential = credential;
+    this.actor = Object.freeze({
+      ...parsedActor.data,
+      scopes: Object.freeze([...parsedActor.data.scopes]),
+    });
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  verifyCredential(providedCredential) {
+    if (typeof providedCredential !== "string" || !providedCredential) {
+      throw denied();
+    }
+    if (!constantTimeEquals(providedCredential, this.credential)) {
+      throw denied();
+    }
+    return this.actor;
+  }
+}
+
+function parseScopesFromEnvValue(value) {
+  if (typeof value !== "string" || !value.trim()) {
+    return [];
+  }
+  return value
+    .split(",")
+    .map((scope) => scope.trim())
+    .filter(Boolean);
+}
+
+// Builds the service principal verifier strictly from server
+// environment/secrets, never from a request. Returns a fail-closed verifier
+// when unconfigured so startup and existing behavior are unaffected until an
+// operator deliberately configures the service boundary.
+//
+// Hard separation from ADMIN_KEY: if SERVICE_PRINCIPAL_CREDENTIAL is ever
+// configured to the same value as ADMIN_KEY, construction fails closed
+// instead of silently allowing ADMIN_KEY to authenticate as the service
+// principal.
+function createServiceCredentialVerifierFromEnv({ env = process.env } = {}) {
+  const serviceId = env.SERVICE_PRINCIPAL_ID;
+  const credential = env.SERVICE_PRINCIPAL_CREDENTIAL;
+  const scopes = parseScopesFromEnvValue(env.SERVICE_PRINCIPAL_SCOPES);
+
+  if (!serviceId && !credential && scopes.length === 0) {
+    return new UnconfiguredServiceCredentialVerifier();
+  }
+  if (!serviceId || !credential || scopes.length === 0) {
+    throw new ServicePrincipalConfigurationError(
+      "SERVICE_PRINCIPAL_ID, SERVICE_PRINCIPAL_CREDENTIAL, and SERVICE_PRINCIPAL_SCOPES must be configured together"
+    );
+  }
+  if (
+    typeof env.ADMIN_KEY === "string" &&
+    env.ADMIN_KEY &&
+    constantTimeEquals(env.ADMIN_KEY, credential)
+  ) {
+    throw new ServicePrincipalConfigurationError(
+      "SERVICE_PRINCIPAL_CREDENTIAL must not equal ADMIN_KEY"
+    );
+  }
+
+  return new StaticServiceCredentialVerifier({ serviceId, credential, scopes });
+}
+
+module.exports = {
+  ServiceCredentialVerifier,
+  StaticServiceCredentialVerifier,
+  UnconfiguredServiceCredentialVerifier,
+  constantTimeEquals,
+  createServiceCredentialVerifierFromEnv,
+};

--- a/src/service-principal/errors.js
+++ b/src/service-principal/errors.js
@@ -1,0 +1,26 @@
+class ServicePrincipalConfigurationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ServicePrincipalConfigurationError";
+    this.code = "SERVICE_PRINCIPAL_CONFIGURATION_ERROR";
+  }
+}
+
+// A single fail-closed denial for every service-boundary failure mode
+// (missing credential, wrong credential, unknown scope, missing job, or
+// out-of-scope job). The boundary intentionally does not distinguish these
+// cases in its response so it cannot be used to enumerate valid job ids,
+// scopes, or credentials.
+class ServicePrincipalDeniedError extends Error {
+  constructor() {
+    super("The service execution boundary denied this request");
+    this.name = "ServicePrincipalDeniedError";
+    this.status = 403;
+    this.code = "SERVICE_PRINCIPAL_FORBIDDEN";
+  }
+}
+
+module.exports = {
+  ServicePrincipalConfigurationError,
+  ServicePrincipalDeniedError,
+};

--- a/src/service-principal/index.js
+++ b/src/service-principal/index.js
@@ -1,0 +1,9 @@
+const errors = require("./errors");
+const credential = require("./credential");
+const middleware = require("./middleware");
+
+module.exports = {
+  ...errors,
+  ...credential,
+  ...middleware,
+};

--- a/src/service-principal/middleware.js
+++ b/src/service-principal/middleware.js
@@ -1,0 +1,54 @@
+const SERVICE_CREDENTIAL_HEADER = "x-service-credential";
+
+// Every denial reason (missing header, unknown credential, and insufficient
+// scope) renders as this same fail-closed body. This mirrors the existing
+// requireAdmin contract in index.js and deliberately does not enumerate
+// which check failed.
+const FORBIDDEN_RESPONSE = Object.freeze({ error: "Forbidden" });
+
+function createRequireServicePrincipal({
+  verifier,
+  scope,
+  logger = console,
+}) {
+  if (!verifier || typeof verifier.verifyCredential !== "function") {
+    throw new TypeError(
+      "requireServicePrincipal requires a service credential verifier"
+    );
+  }
+  if (typeof scope !== "string" || !scope.trim()) {
+    throw new TypeError(
+      "requireServicePrincipal requires the scope this route needs"
+    );
+  }
+
+  return function requireServicePrincipal(req, res, next) {
+    try {
+      const providedCredential = req.header(SERVICE_CREDENTIAL_HEADER);
+      const actor = verifier.verifyCredential(providedCredential);
+
+      if (!actor || actor.kind !== "service" || !actor.scopes.includes(scope)) {
+        logger.warn?.("service principal denied", {
+          path: req.path,
+          required_scope: scope,
+        });
+        return res.status(403).json(FORBIDDEN_RESPONSE);
+      }
+
+      req.serviceActor = actor;
+      return next();
+    } catch {
+      logger.warn?.("service principal denied", {
+        path: req.path,
+        required_scope: scope,
+      });
+      return res.status(403).json(FORBIDDEN_RESPONSE);
+    }
+  };
+}
+
+module.exports = {
+  FORBIDDEN_RESPONSE,
+  SERVICE_CREDENTIAL_HEADER,
+  createRequireServicePrincipal,
+};

--- a/supabase/migrations/20260821000000_create_generation_jobs.sql
+++ b/supabase/migrations/20260821000000_create_generation_jobs.sql
@@ -1,0 +1,169 @@
+-- BG-AUTH-002C: authorized generation-job and service-principal boundary.
+-- This migration is version-controlled but has NOT been applied to any
+-- database by this task. It documents the immutable internal
+-- generation-job contract so a future authorized rollout has a reviewed
+-- starting point.
+--
+-- Deliberately absent from this table, matching the application-layer
+-- contract: any column for provider, model, price, cost, secret, callback
+-- URL, or asset location. A generation job never gains any of that
+-- authority.
+
+create table if not exists public.generation_jobs (
+  job_id text primary key,
+  tenant_id text not null
+    references public.tenants (tenant_id) on delete restrict,
+  project_id text not null,
+  brand_id text,
+  execution_class text not null,
+  auth_user_id uuid not null
+    references public.customer_profiles (auth_user_id) on delete restrict,
+  request_correlation_id text not null,
+  idempotency_key text not null,
+  allowed_scopes jsonb not null,
+  execution_content jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  constraint generation_jobs_job_id_format check (
+    length(job_id) between 1 and 128
+    and job_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]*$'
+  ),
+  constraint generation_jobs_tenant_id_format check (
+    length(tenant_id) between 1 and 128
+    and tenant_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]*$'
+  ),
+  constraint generation_jobs_project_id_format check (
+    length(project_id) between 1 and 128
+    and project_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]*$'
+  ),
+  constraint generation_jobs_brand_id_format check (
+    brand_id is null
+    or (length(brand_id) between 1 and 128
+        and brand_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]*$')
+  ),
+  constraint generation_jobs_execution_class_format check (
+    execution_class ~ '^[a-z][a-z0-9_-]*(\.[a-z][a-z0-9_-]*)+$'
+  ),
+  constraint generation_jobs_request_correlation_id_format check (
+    length(request_correlation_id) between 1 and 128
+    and request_correlation_id ~ '^[A-Za-z0-9][A-Za-z0-9._:-]*$'
+  ),
+  constraint generation_jobs_idempotency_key_format check (
+    length(idempotency_key) between 1 and 128
+    and idempotency_key ~ '^[A-Za-z0-9][A-Za-z0-9._:-]*$'
+  ),
+  constraint generation_jobs_allowed_scopes_array check (
+    jsonb_typeof(allowed_scopes) = 'array'
+    and jsonb_array_length(allowed_scopes) between 1 and 5
+  ),
+  constraint generation_jobs_execution_content_object check (
+    jsonb_typeof(execution_content) = 'object'
+  )
+);
+
+-- A job's ownership is tenant/project/brand/execution-class/actor/request
+-- correlation, established once at authorization time. This foreign key
+-- reuses the (project_id, tenant_id) uniqueness introduced for billing so a
+-- job can never reference a project outside its own tenant.
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+     where conname = 'generation_jobs_project_tenant_fkey'
+       and conrelid = 'public.generation_jobs'::regclass
+  ) then
+    alter table public.generation_jobs
+      add constraint generation_jobs_project_tenant_fkey
+      foreign key (project_id, tenant_id)
+      references public.projects (project_id, tenant_id)
+      on delete restrict;
+  end if;
+end $$;
+
+-- PostgreSQL requires an exact unique key for the composite ownership
+-- reference below. brand_id remains the canonical primary key; this
+-- redundant composite constraint exists only to prove that an optional
+-- brand belongs to the same project already bound to the job.
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+     where conname = 'brand_brains_project_brand_unique'
+       and conrelid = 'public.brand_brains'::regclass
+  ) then
+    alter table public.brand_brains
+      add constraint brand_brains_project_brand_unique
+      unique (project_id, brand_id);
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+     where conname = 'generation_jobs_project_brand_fkey'
+       and conrelid = 'public.generation_jobs'::regclass
+  ) then
+    alter table public.generation_jobs
+      add constraint generation_jobs_project_brand_fkey
+      foreign key (project_id, brand_id)
+      references public.brand_brains (project_id, brand_id)
+      on delete restrict;
+  end if;
+end $$;
+
+-- Retries of the same logical customer request (same tenant, project, and
+-- caller-supplied idempotency key) must resolve to the same job row. The
+-- application layer additionally verifies the retry's other ownership
+-- fields agree before treating a hit as the same logical job; a mismatch is
+-- rejected in application code before any insert is attempted here.
+create unique index if not exists generation_jobs_idempotency_unique
+  on public.generation_jobs (tenant_id, project_id, idempotency_key);
+
+create index if not exists generation_jobs_tenant_id_idx
+  on public.generation_jobs (tenant_id);
+
+-- Immutability: a generation job may never be updated or deleted once
+-- created. This is an append-only authorization log.
+create schema if not exists generation_jobs_private;
+revoke all on schema generation_jobs_private from public;
+
+create or replace function generation_jobs_private.reject_generation_job_mutation()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  raise exception 'generation jobs are immutable and cannot be updated or deleted'
+    using errcode = '55000';
+end;
+$$;
+
+drop trigger if exists generation_jobs_reject_update on public.generation_jobs;
+create trigger generation_jobs_reject_update
+  before update on public.generation_jobs
+  for each row execute function generation_jobs_private.reject_generation_job_mutation();
+
+drop trigger if exists generation_jobs_reject_delete on public.generation_jobs;
+create trigger generation_jobs_reject_delete
+  before delete on public.generation_jobs
+  for each row execute function generation_jobs_private.reject_generation_job_mutation();
+
+alter table public.generation_jobs enable row level security;
+
+do $$
+declare
+  grantee text;
+begin
+  foreach grantee in array['anon', 'authenticated', 'service_role'] loop
+    if exists (select 1 from pg_roles where rolname = grantee) then
+      execute format(
+        'revoke all on table public.generation_jobs from %I',
+        grantee
+      );
+    end if;
+  end loop;
+end $$;
+
+revoke all on function
+  generation_jobs_private.reject_generation_job_mutation()
+  from public;

--- a/test/customer-generation-job-boundary.test.js
+++ b/test/customer-generation-job-boundary.test.js
@@ -1,0 +1,437 @@
+const assert = require("node:assert/strict");
+const { beforeEach, describe, it } = require("node:test");
+const request = require("supertest");
+
+const {
+  AuthenticationRequiredError,
+  InMemoryAuthorizationRepository,
+  createCustomerActorFromVerifiedIdentity,
+} = require("../src/authorization");
+const { InMemoryBrandBrainRepository } = require("../src/brand-brain");
+const { InMemoryImageGenerationRepository } = require("../src/image-generation");
+const {
+  GENERATION_JOB_UNAVAILABLE_ERROR,
+  GenerationJobService,
+  InMemoryGenerationJobRepository,
+} = require("../src/generation-jobs");
+const {
+  SERVICE_CREDENTIAL_HEADER,
+  StaticServiceCredentialVerifier,
+} = require("../src/service-principal");
+const { createApp } = require("../index");
+
+const ADMIN_KEY = "job-boundary-admin-key";
+const SERVICE_CREDENTIAL = "job-boundary-service-principal-credential";
+const USER_A = "11111111-1111-4111-8111-111111111111";
+const USER_B = "22222222-2222-4222-8222-222222222222";
+const COMPLETE_OUTPUT = [
+  "Hook: Stop scrolling and make planning work for you.",
+  "Concept: Show a simple plan becoming a finished post.",
+  "Script: Start with one clear goal, choose the next action, and publish consistently.",
+  "CTA: Try the planning workflow today.",
+  "Caption: A practical plan turns ideas into progress.",
+  "Hashtags: #Planning #Content #SmallBusiness",
+  "Filming instructions:",
+  "- Open on a close-up of the written plan.",
+].join("\n");
+
+function authorizationRepository() {
+  return new InMemoryAuthorizationRepository({
+    customerProfiles: [
+      { auth_user_id: USER_A, display_name: "Customer A" },
+      { auth_user_id: USER_B, display_name: "Customer B" },
+    ],
+    tenants: [
+      { tenant_id: "tenant_a", name: "Tenant A", created_by: USER_A },
+      { tenant_id: "tenant_b", name: "Tenant B", created_by: USER_B },
+    ],
+    memberships: [
+      { tenant_id: "tenant_a", auth_user_id: USER_A, role: "owner" },
+      { tenant_id: "tenant_b", auth_user_id: USER_B, role: "owner" },
+    ],
+    projects: [
+      { project_id: "project_a", tenant_id: "tenant_a", name: "Project A" },
+      { project_id: "project_b", tenant_id: "tenant_b", name: "Project B" },
+    ],
+    brands: [
+      { brand_id: "brand_a", project_id: "project_a", name: "Brand A" },
+      { brand_id: "brand_b", project_id: "project_b", name: "Brand B" },
+    ],
+  });
+}
+
+function brandBrainRecord({
+  brandId = "brand_a",
+  projectId = "project_a",
+  name = "Tenant A Brand",
+} = {}) {
+  return {
+    brand_id: brandId,
+    project_id: projectId,
+    name,
+    identity: { positioning: `${name} private positioning` },
+    metadata: {
+      version: 1,
+      status: "approved",
+      created_at: "2026-08-19T09:00:00.000Z",
+      updated_at: "2026-08-19T09:00:00.000Z",
+    },
+  };
+}
+
+function brandBrainRepository() {
+  const repository = new InMemoryBrandBrainRepository();
+  repository.upsert(brandBrainRecord());
+  repository.upsert(
+    brandBrainRecord({ brandId: "brand_b", projectId: "project_b", name: "Tenant B Brand" })
+  );
+  return repository;
+}
+
+class FixtureTokenVerifier {
+  async verifyAccessToken(token) {
+    if (token === "token-a") {
+      return createCustomerActorFromVerifiedIdentity({ verifiedAuthUserId: USER_A });
+    }
+    if (token === "token-b") {
+      return createCustomerActorFromVerifiedIdentity({ verifiedAuthUserId: USER_B });
+    }
+    throw new AuthenticationRequiredError();
+  }
+}
+
+function scriptRequest(overrides = {}) {
+  return {
+    execution_id: "execution_customer_001",
+    tenant_id: "tenant_a",
+    project_id: "project_a",
+    brand_id: "brand_a",
+    compiled_prompt: "Create a customer-authorized script",
+    ...overrides,
+  };
+}
+
+function customer(client, token = "token-a") {
+  return client.set("authorization", `Bearer ${token}`);
+}
+
+function appFixture(overrides = {}) {
+  const generationJobRepository = new InMemoryGenerationJobRepository();
+  const servicePrincipalVerifier = new StaticServiceCredentialVerifier({
+    serviceId: "make",
+    credential: SERVICE_CREDENTIAL,
+    scopes: ["generation:execute"],
+  });
+  const logs = [];
+  const logger = {
+    info(message, details) {
+      logs.push({ level: "info", message, details });
+    },
+    warn(message, details) {
+      logs.push({ level: "warn", message, details });
+    },
+    error(message, details) {
+      logs.push({ level: "error", message, details });
+    },
+  };
+  const app = createApp({
+    authorizationRepository: authorizationRepository(),
+    brandBrainRepository: brandBrainRepository(),
+    customerTokenVerifier: new FixtureTokenVerifier(),
+    imageGenerationRepository: new InMemoryImageGenerationRepository(),
+    generationJobRepository,
+    servicePrincipalVerifier,
+    scriptGenerator: async () => ({
+      text: COMPLETE_OUTPUT,
+      metadata: { provider: "fixture" },
+    }),
+    logger,
+    ...overrides,
+  });
+  return { app, generationJobRepository, logs };
+}
+
+beforeEach(() => {
+  process.env.ADMIN_KEY = ADMIN_KEY;
+});
+
+describe("customer -> immutable generation job -> service execution boundary", () => {
+  it("creates one authorized job after the existing customer script authorization succeeds", async () => {
+    const fixture = appFixture();
+    const response = await customer(
+      request(fixture.app).post("/customer/generate-script")
+    ).send(scriptRequest());
+
+    assert.equal(response.status, 200);
+    assert.equal(fixture.generationJobRepository.size(), 1);
+
+    const [job] = [...fixture.generationJobRepository.jobsById.values()];
+    assert.equal(job.tenant_id, "tenant_a");
+    assert.equal(job.project_id, "project_a");
+    assert.equal(job.brand_id, "brand_a");
+    assert.equal(job.execution_class, "text.standard");
+    assert.equal(job.actor_correlation.auth_user_id, USER_A);
+    assert.deepEqual(job.allowed_scopes, ["generation:execute"]);
+  });
+
+  it("derives job ownership from the verified actor, never from a spoofed body user_id", async () => {
+    const fixture = appFixture();
+    await customer(request(fixture.app).post("/customer/generate-script")).send(
+      scriptRequest({ user_id: USER_B })
+    );
+
+    const [job] = [...fixture.generationJobRepository.jobsById.values()];
+    assert.equal(job.actor_correlation.auth_user_id, USER_A);
+  });
+
+  it("preserves one logical job across an HTTP retry with the same execution_id", async () => {
+    const fixture = appFixture();
+    await customer(request(fixture.app).post("/customer/generate-script")).send(
+      scriptRequest()
+    );
+    await customer(request(fixture.app).post("/customer/generate-script")).send(
+      scriptRequest()
+    );
+
+    assert.equal(fixture.generationJobRepository.size(), 1);
+  });
+
+  it("fails Text closed and never calls the generator when async job persistence rejects", async () => {
+    let generatorCalls = 0;
+    const generationJobService = new GenerationJobService({
+      repository: {
+        async findByIdempotencyKey() {
+          return null;
+        },
+        async create() {
+          throw new Error("database unavailable");
+        },
+        async recordAttempt() {
+          throw new Error("recordAttempt should not be called");
+        },
+      },
+    });
+    const fixture = appFixture({
+      generationJobService,
+      scriptGenerator: async () => {
+        generatorCalls += 1;
+        throw new Error("generator must not run");
+      },
+    });
+
+    const response = await customer(
+      request(fixture.app).post("/customer/generate-script")
+    ).send(scriptRequest());
+
+    assert.equal(response.status, 503);
+    assert.deepEqual(response.body, {
+      status: "failed",
+      error: GENERATION_JOB_UNAVAILABLE_ERROR,
+      script_body: "",
+    });
+    assert.equal(generatorCalls, 0);
+    assert.equal(fixture.generationJobRepository.size(), 0);
+  });
+
+  it("fails Image closed and never calls the provider when job persistence rejects", async () => {
+    let providerCalls = 0;
+    const generationJobService = new GenerationJobService({
+      repository: {
+        async findByIdempotencyKey() {
+          return null;
+        },
+        async create() {
+          throw new Error("database unavailable");
+        },
+        async recordAttempt() {
+          throw new Error("recordAttempt should not be called");
+        },
+      },
+    });
+    const fixture = appFixture({
+      generationJobService,
+      imageProvider: {
+        async generate() {
+          providerCalls += 1;
+          throw new Error("provider must not run");
+        },
+      },
+    });
+
+    const response = await customer(
+      request(fixture.app).post("/customer/generate-image")
+    ).send({
+      execution_id: "execution_image_001",
+      generation_id: "generation_image_001",
+      tenant_id: "tenant_a",
+      project_id: "project_a",
+      brand_id: "brand_a",
+      topic: "Planning workflow",
+      image_purpose: "social post",
+      aspect_ratio: "1:1",
+    });
+
+    assert.equal(response.status, 503);
+    assert.deepEqual(response.body, {
+      status: "failed",
+      error: GENERATION_JOB_UNAVAILABLE_ERROR,
+      media: null,
+    });
+    assert.equal(providerCalls, 0);
+  });
+
+  it("does not create a job for a denied cross-tenant customer request", async () => {
+    const fixture = appFixture();
+    const response = await customer(
+      request(fixture.app).post("/customer/generate-script")
+    ).send(
+      scriptRequest({ tenant_id: "tenant_b", project_id: "project_b", brand_id: "brand_b" })
+    );
+
+    assert.equal(response.status, 404);
+    assert.equal(fixture.generationJobRepository.size(), 0);
+  });
+
+  it("lets a correctly scoped service principal retrieve the bounded payload for that job", async () => {
+    const fixture = appFixture();
+    await customer(request(fixture.app).post("/customer/generate-script")).send(
+      scriptRequest()
+    );
+    const [job] = [...fixture.generationJobRepository.jobsById.values()];
+
+    const response = await request(fixture.app)
+      .get(`/_service/generation-jobs/jobs/${job.job_id}/execution-payload`)
+      .set(SERVICE_CREDENTIAL_HEADER, SERVICE_CREDENTIAL);
+
+    assert.equal(response.status, 200);
+    assert.equal(response.body.job_id, job.job_id);
+    assert.equal(response.body.execution_class, "text.standard");
+    assert.equal(
+      response.body.execution_input.compiled_prompt,
+      "Create a customer-authorized script"
+    );
+  });
+
+  it("never lets the customer JWT authenticate the service execution boundary", async () => {
+    const fixture = appFixture();
+    await customer(request(fixture.app).post("/customer/generate-script")).send(
+      scriptRequest()
+    );
+    const [job] = [...fixture.generationJobRepository.jobsById.values()];
+
+    const response = await request(fixture.app)
+      .get(`/_service/generation-jobs/jobs/${job.job_id}/execution-payload`)
+      .set(SERVICE_CREDENTIAL_HEADER, "Bearer token-a");
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(response.body, { error: "Forbidden" });
+  });
+
+  it("does not let Tenant A's customer credential access Tenant B's job", async () => {
+    const fixture = appFixture();
+    await customer(
+      request(fixture.app).post("/customer/generate-script"),
+      "token-b"
+    ).send(
+      scriptRequest({
+        execution_id: "execution_tenant_b_001",
+        tenant_id: "tenant_b",
+        project_id: "project_b",
+        brand_id: "brand_b",
+      })
+    );
+    const tenantBJob = [...fixture.generationJobRepository.jobsById.values()]
+      .find((job) => job.tenant_id === "tenant_b");
+
+    const response = await request(fixture.app)
+      .get(
+        `/_service/generation-jobs/jobs/${tenantBJob.job_id}/execution-payload`
+      )
+      .set("authorization", "Bearer token-a");
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(response.body, { error: "Forbidden" });
+  });
+
+  it("never lets ADMIN_KEY authenticate the service execution boundary", async () => {
+    const fixture = appFixture();
+    await customer(request(fixture.app).post("/customer/generate-script")).send(
+      scriptRequest()
+    );
+    const [job] = [...fixture.generationJobRepository.jobsById.values()];
+
+    const response = await request(fixture.app)
+      .get(`/_service/generation-jobs/jobs/${job.job_id}/execution-payload`)
+      .set(SERVICE_CREDENTIAL_HEADER, ADMIN_KEY);
+
+    assert.equal(response.status, 403);
+  });
+
+  it("never lets the service principal credential authenticate customer or admin routes", async () => {
+    const fixture = appFixture();
+
+    const asAdmin = await request(fixture.app)
+      .get("/_admin/ping")
+      .set("x-admin-key", SERVICE_CREDENTIAL);
+    assert.equal(asAdmin.status, 403);
+
+    const asCustomer = await request(fixture.app)
+      .post("/customer/generate-script")
+      .set("authorization", `Bearer ${SERVICE_CREDENTIAL}`)
+      .send(scriptRequest());
+    assert.equal(asCustomer.status, 401);
+  });
+
+  it("never forwards the customer JWT, ADMIN_KEY, or SERVICE credential in the Make payload or logs", async () => {
+    const fixture = appFixture();
+    await customer(request(fixture.app).post("/customer/generate-script")).send(
+      scriptRequest()
+    );
+    const [job] = [...fixture.generationJobRepository.jobsById.values()];
+
+    const response = await request(fixture.app)
+      .get(`/_service/generation-jobs/jobs/${job.job_id}/execution-payload`)
+      .set(SERVICE_CREDENTIAL_HEADER, SERVICE_CREDENTIAL);
+
+    const observable = JSON.stringify({ body: response.body, logs: fixture.logs });
+    assert.doesNotMatch(observable, /token-a/);
+    assert.doesNotMatch(observable, new RegExp(ADMIN_KEY));
+    assert.doesNotMatch(observable, new RegExp(SERVICE_CREDENTIAL));
+    assert.doesNotMatch(observable, /tenant_a/);
+    assert.doesNotMatch(observable, /project_a/);
+    assert.doesNotMatch(observable, /brand_a/);
+    assert.doesNotMatch(observable, new RegExp(USER_A));
+  });
+
+  it("does not change the existing customer script response contract", async () => {
+    const fixture = appFixture();
+    const response = await customer(
+      request(fixture.app).post("/customer/generate-script")
+    ).send(scriptRequest());
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(response.body, {
+      status: "completed",
+      execution_id: "execution_customer_001",
+      script_body: COMPLETE_OUTPUT,
+    });
+  });
+
+  it("does not change the existing ADMIN_KEY script/image contract", async () => {
+    const fixture = appFixture();
+    const script = await request(fixture.app)
+      .post("/generate-script")
+      .set("x-admin-key", ADMIN_KEY)
+      .send({
+        execution_id: "admin_execution_001",
+        user_id: "internal_user_001",
+        project_id: "project_a",
+        compiled_prompt: "Preserve the internal contract",
+      });
+
+    assert.equal(script.status, 200);
+    // The admin-authenticated path never touches the customer generation
+    // job boundary at all.
+    assert.equal(fixture.generationJobRepository.size(), 0);
+  });
+});

--- a/test/generation-jobs-async-persistence.test.js
+++ b/test/generation-jobs-async-persistence.test.js
@@ -1,0 +1,196 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+
+const {
+  GenerationJobConflictError,
+  GenerationJobService,
+  InMemoryGenerationJobRepository,
+} = require("../src/generation-jobs");
+
+const AUTH_USER = "11111111-1111-4111-8111-111111111111";
+
+function authorization(overrides = {}) {
+  return {
+    actor: { kind: "customer", auth_user_id: AUTH_USER },
+    tenant_id: "tenant_a",
+    project_id: "project_a",
+    brand_id: "brand_a",
+    action: "generation:create",
+    ...overrides,
+  };
+}
+
+function input(overrides = {}) {
+  return {
+    authorization: authorization(),
+    executionClass: "text.standard",
+    requestCorrelationId: "execution_001",
+    idempotencyKey: "execution_001",
+    allowedScopes: ["generation:execute"],
+    executionInput: { compiled_prompt: "Write a hook" },
+    ...overrides,
+  };
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+class AsyncRaceRepository {
+  constructor() {
+    this.job = null;
+    this.executionContent = null;
+    this.attempts = 0;
+    this.initialFinds = 0;
+    this.releaseFirstFind = null;
+  }
+
+  async findByIdempotencyKey() {
+    if (this.job) {
+      return this.job;
+    }
+
+    this.initialFinds += 1;
+    if (this.initialFinds === 1) {
+      await new Promise((resolve) => {
+        this.releaseFirstFind = resolve;
+      });
+    } else if (this.initialFinds === 2) {
+      this.releaseFirstFind();
+      await Promise.resolve();
+    }
+    return null;
+  }
+
+  async create(job, { executionContent }) {
+    await new Promise((resolve) => setImmediate(resolve));
+    if (this.job) {
+      const error = new Error("duplicate idempotency identity");
+      error.code = "23505";
+      error.constraint = "generation_jobs_idempotency_unique";
+      throw error;
+    }
+    this.job = job;
+    this.executionContent = executionContent;
+    this.attempts = 1;
+    return job;
+  }
+
+  async recordAttempt() {
+    await Promise.resolve();
+    this.attempts += 1;
+    return this.attempts;
+  }
+}
+
+describe("GenerationJobService asynchronous persistence", () => {
+  it("does not establish a job until asynchronous create persistence completes", async () => {
+    const create = deferred();
+    const repository = {
+      async findByIdempotencyKey() {
+        return null;
+      },
+      create() {
+        return create.promise;
+      },
+      async recordAttempt() {
+        throw new Error("recordAttempt should not be called");
+      },
+    };
+    const service = new GenerationJobService({ repository });
+    let settled = false;
+    const pending = service.authorizeAndCreateJob(input()).then((job) => {
+      settled = true;
+      return job;
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(settled, false);
+
+    create.resolve();
+    const job = await pending;
+    assert.equal(settled, true);
+    assert.equal(job.request_correlation_id, "execution_001");
+  });
+
+  it("propagates asynchronous persistence rejection", async () => {
+    const persistenceError = new Error("database unavailable");
+    const repository = {
+      async findByIdempotencyKey() {
+        return null;
+      },
+      async create() {
+        throw persistenceError;
+      },
+      async recordAttempt() {
+        throw new Error("recordAttempt should not be called");
+      },
+    };
+    const service = new GenerationJobService({ repository });
+
+    await assert.rejects(
+      service.authorizeAndCreateJob(input()),
+      (error) => error === persistenceError
+    );
+  });
+
+  it("awaits asynchronous retry-attempt persistence", async () => {
+    const raceRepository = new InMemoryGenerationJobRepository();
+    const firstService = new GenerationJobService({
+      repository: raceRepository,
+    });
+    const existing = await firstService.authorizeAndCreateJob(input());
+    const attempt = deferred();
+    raceRepository.recordAttempt = () => attempt.promise;
+
+    let settled = false;
+    const pending = firstService.authorizeAndCreateJob(input()).then((job) => {
+      settled = true;
+      return job;
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(settled, false);
+    attempt.resolve(2);
+    const replay = await pending;
+    assert.equal(replay.job_id, existing.job_id);
+  });
+
+  it("resolves concurrent identical requests to one logical persisted job", async () => {
+    const repository = new AsyncRaceRepository();
+    const service = new GenerationJobService({ repository });
+
+    const [left, right] = await Promise.all([
+      service.authorizeAndCreateJob(input()),
+      service.authorizeAndCreateJob(input()),
+    ]);
+
+    assert.equal(left.job_id, right.job_id);
+    assert.equal(repository.initialFinds, 2);
+    assert.equal(repository.attempts, 2);
+    assert.equal(repository.job.job_id, left.job_id);
+  });
+
+  it("rejects a concurrent replay that changes immutable authority", async () => {
+    const repository = new AsyncRaceRepository();
+    const service = new GenerationJobService({ repository });
+
+    const results = await Promise.allSettled([
+      service.authorizeAndCreateJob(input()),
+      service.authorizeAndCreateJob(
+        input({ executionClass: "image.normal" })
+      ),
+    ]);
+
+    assert.equal(results.filter((result) => result.status === "fulfilled").length, 1);
+    const rejection = results.find((result) => result.status === "rejected");
+    assert.ok(rejection.reason instanceof GenerationJobConflictError);
+    assert.equal(repository.job !== null, true);
+  });
+});

--- a/test/generation-jobs-execution-input.test.js
+++ b/test/generation-jobs-execution-input.test.js
@@ -1,0 +1,102 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+
+const {
+  EXECUTION_INPUT_ALLOWED_KEYS,
+  sanitizeExecutionInput,
+} = require("../src/generation-jobs/executionInput");
+
+describe("sanitizeExecutionInput", () => {
+  it("keeps only allow-listed scalar fields", () => {
+    const result = sanitizeExecutionInput({
+      compiled_prompt: "Write a hook",
+      platform: "tiktok",
+      topic: "planning workflow",
+      unrelated_field: "should be dropped",
+    });
+
+    assert.deepEqual(result, {
+      compiled_prompt: "Write a hook",
+      platform: "tiktok",
+      topic: "planning workflow",
+    });
+  });
+
+  it("strips provider, model, price, cost, secret, callback, and asset-location smuggling attempts", () => {
+    const result = sanitizeExecutionInput({
+      compiled_prompt: "Write a hook",
+      provider: "openai",
+      model: "gpt-x",
+      price: 999,
+      cost: 999,
+      admin_key: "should-not-appear",
+      authorization: "Bearer some.jwt",
+      callback_url: "https://attacker.example/callback",
+      asset_location: "gs://bucket/secret.png",
+      reference_assets: [{ location: "gs://bucket/secret.png" }],
+      tenant_id: "tenant_a",
+      project_id: "project_a",
+      brand_id: "brand_a",
+      user_id: "user_a",
+    });
+
+    assert.deepEqual(result, { compiled_prompt: "Write a hook" });
+    for (const forbidden of [
+      "provider",
+      "model",
+      "price",
+      "cost",
+      "admin_key",
+      "authorization",
+      "callback_url",
+      "asset_location",
+      "reference_assets",
+      "tenant_id",
+      "project_id",
+      "brand_id",
+      "user_id",
+    ]) {
+      assert.equal(forbidden in result, false);
+    }
+  });
+
+  it("drops nested objects and arrays even under an allow-listed key name", () => {
+    const result = sanitizeExecutionInput({
+      // additional_context is allow-listed, but only as a scalar string.
+      additional_context: { nested: "gs://bucket/secret.png" },
+      platform: ["tiktok"],
+    });
+
+    assert.deepEqual(result, {});
+  });
+
+  it("trims and bounds string length", () => {
+    const result = sanitizeExecutionInput({
+      platform: "  tiktok  ",
+      topic: "x".repeat(9_000),
+    });
+
+    assert.equal(result.platform, "tiktok");
+    assert.equal(result.topic.length, 8_000);
+  });
+
+  it("tolerates missing or non-object input", () => {
+    assert.deepEqual(sanitizeExecutionInput(undefined), {});
+    assert.deepEqual(sanitizeExecutionInput(null), {});
+    assert.deepEqual(sanitizeExecutionInput("not an object"), {});
+  });
+
+  it("never exposes a key outside the published allow-list", () => {
+    const result = sanitizeExecutionInput(
+      Object.fromEntries(
+        [...EXECUTION_INPUT_ALLOWED_KEYS, "provider", "model", "callback_url"].map(
+          (key) => [key, `value-${key}`]
+        )
+      )
+    );
+
+    for (const key of Object.keys(result)) {
+      assert.equal(EXECUTION_INPUT_ALLOWED_KEYS.includes(key), true);
+    }
+  });
+});

--- a/test/generation-jobs-migration.test.js
+++ b/test/generation-jobs-migration.test.js
@@ -1,0 +1,82 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { describe, it } = require("node:test");
+
+const migration = fs.readFileSync(
+  path.join(
+    __dirname,
+    "..",
+    "supabase",
+    "migrations",
+    "20260821000000_create_generation_jobs.sql"
+  ),
+  "utf8"
+);
+
+describe("generation jobs migration", () => {
+  it("creates a provider/price/secret-free immutable job table", () => {
+    assert.match(migration, /create table if not exists public\.generation_jobs/i);
+    const tableDefinition = migration.slice(
+      migration.indexOf("create table if not exists public.generation_jobs"),
+      migration.indexOf("-- A job's ownership is tenant/project/brand")
+    );
+    assert.doesNotMatch(
+      tableDefinition,
+      /provider|model|\bprice\b|\bcost\b|secret|callback|asset_location/i
+    );
+  });
+
+  it("binds every job to its owning tenant, project, brand, and customer actor", () => {
+    assert.match(
+      migration,
+      /generation_jobs_project_tenant_fkey[\s\S]*foreign key \(project_id, tenant_id\)[\s\S]*references public\.projects \(project_id, tenant_id\)/i
+    );
+    assert.match(
+      migration,
+      /tenant_id text not null[\s\S]*references public\.tenants \(tenant_id\) on delete restrict/i
+    );
+    assert.match(
+      migration,
+      /generation_jobs_project_tenant_fkey[\s\S]*references public\.projects \(project_id, tenant_id\)[\s\S]*on delete restrict/i
+    );
+    assert.match(
+      migration,
+      /generation_jobs_project_brand_fkey[\s\S]*foreign key \(project_id, brand_id\)[\s\S]*references public\.brand_brains \(project_id, brand_id\)[\s\S]*on delete restrict/i
+    );
+    assert.match(
+      migration,
+      /auth_user_id uuid not null[\s\S]*references public\.customer_profiles \(auth_user_id\) on delete restrict/i
+    );
+  });
+
+  it("guards idempotent retries with one unique key per logical job", () => {
+    assert.match(
+      migration,
+      /generation_jobs_idempotency_unique[\s\S]*\(tenant_id, project_id, idempotency_key\)/i
+    );
+  });
+
+  it("makes the job table append-only", () => {
+    assert.match(migration, /reject_generation_job_mutation/i);
+    assert.match(migration, /before update on public\.generation_jobs/i);
+    assert.match(migration, /before delete on public\.generation_jobs/i);
+    assert.match(migration, /immutable and cannot be updated or deleted/i);
+  });
+
+  it("bounds allowed_scopes and keeps the table RLS-ready and server-only", () => {
+    assert.match(migration, /jsonb_typeof\(allowed_scopes\) = 'array'/i);
+    assert.match(migration, /jsonb_array_length\(allowed_scopes\) between 1 and 5/i);
+    assert.match(migration, /enable row level security/i);
+    assert.match(migration, /array\['anon', 'authenticated', 'service_role'\]/i);
+    assert.match(
+      migration,
+      /revoke all on schema generation_jobs_private from public/i
+    );
+    assert.match(
+      migration,
+      /revoke all on function[\s\S]*reject_generation_job_mutation\(\)[\s\S]*from public/i
+    );
+    assert.match(migration, /set search_path = ''/i);
+  });
+});

--- a/test/generation-jobs-repository.test.js
+++ b/test/generation-jobs-repository.test.js
@@ -1,0 +1,119 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+
+const {
+  InMemoryGenerationJobRepository,
+} = require("../src/generation-jobs/repository");
+
+function job(overrides = {}) {
+  return Object.freeze({
+    job_id: "job_1",
+    tenant_id: "tenant_a",
+    project_id: "project_a",
+    brand_id: "brand_a",
+    execution_class: "text.standard",
+    actor_correlation: Object.freeze({
+      kind: "customer",
+      auth_user_id: "11111111-1111-4111-8111-111111111111",
+    }),
+    request_correlation_id: "execution_001",
+    idempotency_key: "execution_001",
+    created_at: "2026-08-21T00:00:00.000Z",
+    allowed_scopes: ["generation:execute"],
+    ...overrides,
+  });
+}
+
+describe("InMemoryGenerationJobRepository", () => {
+  it("stores a new job and its execution content once", () => {
+    const repository = new InMemoryGenerationJobRepository();
+    const created = repository.create(job(), {
+      executionContent: { compiled_prompt: "hello" },
+    });
+
+    assert.equal(repository.size(), 1);
+    assert.deepEqual(repository.getById("job_1"), created);
+    assert.deepEqual(repository.getExecutionContent("job_1"), {
+      compiled_prompt: "hello",
+    });
+    assert.equal(repository.getAttemptCount("job_1"), 1);
+  });
+
+  it("finds an existing job by its logical (tenant, project, idempotency key)", () => {
+    const repository = new InMemoryGenerationJobRepository();
+    repository.create(job());
+
+    const found = repository.findByIdempotencyKey(
+      "tenant_a",
+      "project_a",
+      "execution_001"
+    );
+    assert.equal(found.job_id, "job_1");
+
+    assert.equal(
+      repository.findByIdempotencyKey("tenant_b", "project_a", "execution_001"),
+      null
+    );
+    assert.equal(
+      repository.findByIdempotencyKey("tenant_a", "project_a", "unknown"),
+      null
+    );
+  });
+
+  it("records repeated attempts without creating a second logical job", () => {
+    const repository = new InMemoryGenerationJobRepository();
+    repository.create(job());
+
+    repository.recordAttempt("job_1");
+    repository.recordAttempt("job_1");
+
+    assert.equal(repository.size(), 1);
+    assert.equal(repository.getAttemptCount("job_1"), 3);
+  });
+
+  it("refuses to silently overwrite an existing job_id", () => {
+    const repository = new InMemoryGenerationJobRepository();
+    repository.create(job());
+
+    assert.throws(() => repository.create(job({ tenant_id: "tenant_b" })));
+    assert.equal(repository.getById("job_1").tenant_id, "tenant_a");
+  });
+
+  it("refuses a second job for the same scoped idempotency identity", () => {
+    const repository = new InMemoryGenerationJobRepository();
+    repository.create(job());
+
+    assert.throws(
+      () => repository.create(job({ job_id: "job_2" })),
+      (error) =>
+        error.code === "23505" &&
+        error.constraint === "generation_jobs_idempotency_unique"
+    );
+    assert.equal(repository.size(), 1);
+  });
+
+  it("returns frozen job and execution-content records", () => {
+    const repository = new InMemoryGenerationJobRepository();
+    repository.create(job(), { executionContent: { topic: "hi" } });
+
+    const stored = repository.getById("job_1");
+    const content = repository.getExecutionContent("job_1");
+
+    assert.equal(Object.isFrozen(stored), true);
+    assert.equal(Object.isFrozen(stored.actor_correlation), true);
+    assert.equal(Object.isFrozen(stored.allowed_scopes), true);
+    assert.equal(Object.isFrozen(content), true);
+    assert.throws(() => {
+      "use strict";
+      stored.tenant_id = "tenant_b";
+    }, TypeError);
+  });
+
+  it("returns null for an unknown job id", () => {
+    const repository = new InMemoryGenerationJobRepository();
+    assert.equal(repository.getById("missing"), null);
+    assert.equal(repository.getExecutionContent("missing"), null);
+    assert.equal(repository.getAttemptCount("missing"), 0);
+    assert.equal(repository.recordAttempt("missing"), 0);
+  });
+});

--- a/test/generation-jobs.test.js
+++ b/test/generation-jobs.test.js
@@ -1,0 +1,260 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+
+const {
+  GenerationJobConflictError,
+  GenerationJobSchema,
+  GenerationJobService,
+  InMemoryGenerationJobRepository,
+} = require("../src/generation-jobs");
+const {
+  createCustomerActorFromVerifiedIdentity,
+} = require("../src/authorization");
+
+const USER_A = "11111111-1111-4111-8111-111111111111";
+const USER_B = "22222222-2222-4222-8222-222222222222";
+
+function actorA() {
+  return createCustomerActorFromVerifiedIdentity({ verifiedAuthUserId: USER_A });
+}
+
+function authorization(overrides = {}) {
+  return {
+    actor: actorA(),
+    tenant_id: "tenant_a",
+    project_id: "project_a",
+    brand_id: "brand_a",
+    membership_role: "owner",
+    action: "generation:create",
+    ...overrides,
+  };
+}
+
+function service() {
+  const repository = new InMemoryGenerationJobRepository();
+  return {
+    repository,
+    service: new GenerationJobService({
+      repository,
+      now: () => new Date("2026-08-21T00:00:00.000Z"),
+    }),
+  };
+}
+
+describe("GenerationJobSchema", () => {
+  it("has no field that grants provider, model, price, cost, secret, callback, or asset-location authority", () => {
+    const keys = Object.keys(GenerationJobSchema.shape);
+    for (const forbidden of [
+      "provider",
+      "model",
+      "price",
+      "cost",
+      "secret",
+      "callback",
+      "callback_url",
+      "asset_location",
+      "user_id",
+    ]) {
+      assert.equal(keys.includes(forbidden), false);
+    }
+  });
+
+  it("rejects an unknown field (no room for a caller to widen the contract)", () => {
+    const parsed = GenerationJobSchema.safeParse({
+      job_id: "job_1",
+      tenant_id: "tenant_a",
+      project_id: "project_a",
+      execution_class: "text.standard",
+      actor_correlation: { kind: "customer", auth_user_id: USER_A },
+      request_correlation_id: "execution_001",
+      idempotency_key: "execution_001",
+      created_at: "2026-08-21T00:00:00.000Z",
+      allowed_scopes: ["generation:execute"],
+      provider: "vertex-ai",
+    });
+    assert.equal(parsed.success, false);
+  });
+});
+
+describe("GenerationJobService.authorizeAndCreateJob", () => {
+  it("creates one immutable job from a verified customer authorization", async () => {
+    const { service: jobService } = service();
+    const job = await jobService.authorizeAndCreateJob({
+      authorization: authorization(),
+      executionClass: "text.standard",
+      requestCorrelationId: "execution_001",
+      idempotencyKey: "execution_001",
+      allowedScopes: ["generation:execute"],
+      executionInput: { compiled_prompt: "Write a hook" },
+    });
+
+    assert.equal(job.tenant_id, "tenant_a");
+    assert.equal(job.project_id, "project_a");
+    assert.equal(job.brand_id, "brand_a");
+    assert.equal(job.execution_class, "text.standard");
+    assert.equal(job.actor_correlation.auth_user_id, USER_A);
+    assert.equal(Object.isFrozen(job), true);
+    assert.equal(Object.isFrozen(job.actor_correlation), true);
+    assert.equal(Object.isFrozen(job.allowed_scopes), true);
+    assert.match(
+      job.job_id,
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+  });
+
+  it("never lets a client-supplied user_id or actor establish job ownership", async () => {
+    const { service: jobService } = service();
+    // authorization.actor always comes from AuthorizationService, which in
+    // turn only ever accepts createCustomerActorFromVerifiedIdentity output.
+    // This test asserts the job service does not accept an alternate actor
+    // field (e.g. a raw body actor) anywhere in its input shape.
+    const job = await jobService.authorizeAndCreateJob({
+      authorization: authorization(),
+      executionClass: "text.standard",
+      requestCorrelationId: "execution_001",
+      idempotencyKey: "execution_001",
+      allowedScopes: ["generation:execute"],
+      executionInput: { compiled_prompt: "x", user_id: USER_B },
+    });
+
+    assert.equal(job.actor_correlation.auth_user_id, USER_A);
+  });
+
+  it("rejects job creation from anything other than a customer generation:create authorization", async () => {
+    const { service: jobService } = service();
+    for (const badAuthorization of [
+      null,
+      { ...authorization(), actor: { kind: "administrator" } },
+      { ...authorization(), actor: { kind: "service", service_id: "make", scopes: [] } },
+      { ...authorization(), action: "project:read" },
+      { ...authorization(), tenant_id: undefined },
+    ]) {
+      await assert.rejects(
+        jobService.authorizeAndCreateJob({
+          authorization: badAuthorization,
+          executionClass: "text.standard",
+          requestCorrelationId: "execution_001",
+          idempotencyKey: "execution_001",
+          allowedScopes: ["generation:execute"],
+        }),
+        TypeError
+      );
+    }
+  });
+
+  it("preserves one logical job across a retry with the same idempotency key", async () => {
+    const { service: jobService, repository } = service();
+    const first = await jobService.authorizeAndCreateJob({
+      authorization: authorization(),
+      executionClass: "text.standard",
+      requestCorrelationId: "execution_001",
+      idempotencyKey: "execution_001",
+      allowedScopes: ["generation:execute"],
+      executionInput: { compiled_prompt: "Write a hook" },
+    });
+    const retry = await jobService.authorizeAndCreateJob({
+      authorization: authorization(),
+      executionClass: "text.standard",
+      requestCorrelationId: "execution_001",
+      idempotencyKey: "execution_001",
+      allowedScopes: ["generation:execute"],
+      executionInput: { compiled_prompt: "Write a hook" },
+    });
+
+    assert.equal(retry.job_id, first.job_id);
+    assert.equal(repository.size(), 1);
+    assert.equal(repository.getAttemptCount(first.job_id), 2);
+  });
+
+  it("rejects a replayed scoped idempotency key that changes immutable authority", async () => {
+    const { service: jobService } = service();
+    await jobService.authorizeAndCreateJob({
+      authorization: authorization(),
+      executionClass: "text.standard",
+      requestCorrelationId: "execution_001",
+      idempotencyKey: "execution_001",
+      allowedScopes: ["generation:execute"],
+    });
+
+    for (const mutated of [
+      authorization({ brand_id: "brand_b" }),
+      authorization({ brand_id: undefined }),
+      authorization({
+        actor: createCustomerActorFromVerifiedIdentity({
+          verifiedAuthUserId: USER_B,
+        }),
+      }),
+    ]) {
+      await assert.rejects(
+        jobService.authorizeAndCreateJob({
+          authorization: mutated,
+          executionClass: "text.standard",
+          requestCorrelationId: "execution_001",
+          idempotencyKey: "execution_001",
+          allowedScopes: ["generation:execute"],
+        }),
+        GenerationJobConflictError
+      );
+    }
+
+    await assert.rejects(
+      jobService.authorizeAndCreateJob({
+        authorization: authorization(),
+        executionClass: "image.normal",
+        requestCorrelationId: "execution_001",
+        idempotencyKey: "execution_001",
+        allowedScopes: ["generation:execute"],
+      }),
+      GenerationJobConflictError
+    );
+
+    await assert.rejects(
+      jobService.authorizeAndCreateJob({
+        authorization: authorization(),
+        executionClass: "text.standard",
+        requestCorrelationId: "execution_changed",
+        idempotencyKey: "execution_001",
+        allowedScopes: ["generation:execute"],
+      }),
+      GenerationJobConflictError
+    );
+
+    await assert.rejects(
+      jobService.authorizeAndCreateJob({
+        authorization: authorization(),
+        executionClass: "text.standard",
+        requestCorrelationId: "execution_001",
+        idempotencyKey: "execution_001",
+        allowedScopes: ["generation:other"],
+      }),
+      GenerationJobConflictError
+    );
+  });
+
+  it("does not let a different tenant's retry with the same idempotency key touch tenant A's job", async () => {
+    const { service: jobService, repository } = service();
+    await jobService.authorizeAndCreateJob({
+      authorization: authorization({ tenant_id: "tenant_a", project_id: "project_a" }),
+      executionClass: "text.standard",
+      requestCorrelationId: "execution_shared",
+      idempotencyKey: "execution_shared",
+      allowedScopes: ["generation:execute"],
+    });
+
+    const tenantBJob = await jobService.authorizeAndCreateJob({
+      authorization: authorization({
+        actor: createCustomerActorFromVerifiedIdentity({ verifiedAuthUserId: USER_B }),
+        tenant_id: "tenant_b",
+        project_id: "project_b",
+        brand_id: "brand_b",
+      }),
+      executionClass: "text.standard",
+      requestCorrelationId: "execution_shared",
+      idempotencyKey: "execution_shared",
+      allowedScopes: ["generation:execute"],
+    });
+
+    assert.equal(tenantBJob.tenant_id, "tenant_b");
+    assert.equal(repository.size(), 2);
+  });
+});

--- a/test/service-execution-make-payload.test.js
+++ b/test/service-execution-make-payload.test.js
@@ -1,0 +1,102 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+
+const { buildMakeExecutionPayload } = require("../src/service-execution/makePayload");
+
+function job(overrides = {}) {
+  return Object.freeze({
+    job_id: "job_1",
+    tenant_id: "tenant_a",
+    project_id: "project_a",
+    brand_id: "brand_a",
+    execution_class: "text.standard",
+    actor_correlation: Object.freeze({
+      kind: "customer",
+      auth_user_id: "11111111-1111-4111-8111-111111111111",
+    }),
+    request_correlation_id: "execution_001",
+    idempotency_key: "execution_001",
+    created_at: "2026-08-21T00:00:00.000Z",
+    allowed_scopes: ["generation:execute"],
+    ...overrides,
+  });
+}
+
+describe("buildMakeExecutionPayload", () => {
+  it("carries only the opaque job id, execution class, and bounded content", () => {
+    const payload = buildMakeExecutionPayload(job(), {
+      compiled_prompt: "Write a hook",
+      platform: "tiktok",
+    });
+
+    assert.deepEqual(payload, {
+      job_id: "job_1",
+      execution_class: "text.standard",
+      execution_input: {
+        compiled_prompt: "Write a hook",
+        platform: "tiktok",
+      },
+    });
+  });
+
+  it("never includes tenant, project, brand, actor, or idempotency identity", () => {
+    const payload = buildMakeExecutionPayload(job(), { topic: "hi" });
+    const serialized = JSON.stringify(payload);
+
+    for (const forbidden of [
+      "tenant_a",
+      "project_a",
+      "brand_a",
+      "11111111-1111-4111-8111-111111111111",
+      "execution_001",
+      "generation:execute",
+    ]) {
+      assert.equal(serialized.includes(forbidden), false);
+    }
+  });
+
+  it("reapplies the content allow-list at the final downstream boundary", () => {
+    const payload = buildMakeExecutionPayload(job(), {
+      compiled_prompt: "Write a hook",
+      authorization: "Bearer customer.jwt",
+      service_credential: "service-secret",
+      provider: "openai",
+      model: "gpt-x",
+      price: 999,
+      cost: 999,
+      provider_secret: "provider-secret",
+      callback_url: "https://attacker.example/callback",
+      asset_location: "gs://private-bucket/asset.png",
+      additional_context: { callback_url: "https://attacker.example/nested" },
+    });
+
+    assert.deepEqual(payload.execution_input, {
+      compiled_prompt: "Write a hook",
+    });
+    const serialized = JSON.stringify(payload);
+    for (const forbidden of [
+      "customer.jwt",
+      "service-secret",
+      "openai",
+      "gpt-x",
+      "provider-secret",
+      "attacker.example",
+      "private-bucket",
+      "price",
+      "cost",
+    ]) {
+      assert.equal(serialized.includes(forbidden), false);
+    }
+  });
+
+  it("returns a frozen payload and a frozen execution_input", () => {
+    const payload = buildMakeExecutionPayload(job(), { topic: "hi" });
+    assert.equal(Object.isFrozen(payload), true);
+    assert.equal(Object.isFrozen(payload.execution_input), true);
+  });
+
+  it("defaults to an empty execution_input when no content is stored", () => {
+    const payload = buildMakeExecutionPayload(job());
+    assert.deepEqual(payload.execution_input, {});
+  });
+});

--- a/test/service-execution.test.js
+++ b/test/service-execution.test.js
@@ -15,6 +15,7 @@ const { createServiceExecutionRouter } = require("../src/service-execution");
 
 const CREDENTIAL = "make-service-principal-credential-001";
 const AUTH_USER = "11111111-1111-4111-8111-111111111111";
+const AUTH_USER_B = "22222222-2222-4222-8222-222222222222";
 
 function authorization(overrides = {}) {
   return {
@@ -192,6 +193,83 @@ describe("service execution boundary", () => {
     const serialized = JSON.stringify(response.body);
     for (const forbidden of ["tenant_a", "project_a", "brand_a", AUTH_USER]) {
       assert.equal(serialized.includes(forbidden), false);
+    }
+  });
+
+  it("cannot reinterpret a Tenant B job using Tenant A request authority", async () => {
+    const { app, jobRepository, jobService } = appFixture();
+    const job = await jobService.authorizeAndCreateJob({
+      authorization: authorization({
+        actor: { kind: "customer", auth_user_id: AUTH_USER_B },
+        tenant_id: "tenant_b",
+        project_id: "project_b",
+        brand_id: "brand_b",
+      }),
+      executionClass: "image.normal",
+      requestCorrelationId: "execution_tenant_b_001",
+      idempotencyKey: "execution_tenant_b_001",
+      allowedScopes: ["generation:execute"],
+      executionInput: {
+        compiled_prompt: "Generate Tenant B's authorized image",
+        platform: "instagram",
+      },
+    });
+
+    const response = await request(app)
+      .get(`/_service/generation-jobs/jobs/${job.job_id}/execution-payload`)
+      .set(SERVICE_CREDENTIAL_HEADER, CREDENTIAL)
+      .set("tenant_id", "tenant_a")
+      .set("project_id", "project_a")
+      .set("brand_id", "brand_a")
+      .set("actor", AUTH_USER)
+      .set("execution_class", "video.premium")
+      .query({
+        tenant_id: "tenant_a",
+        project_id: "project_a",
+        brand_id: "brand_a",
+        actor: AUTH_USER,
+        execution_class: "video.premium",
+      })
+      .send({
+        tenant_id: "tenant_a",
+        project_id: "project_a",
+        brand_id: "brand_a",
+        actor_correlation: { kind: "customer", auth_user_id: AUTH_USER },
+        user_id: AUTH_USER,
+        execution_class: "video.premium",
+      });
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(response.body, {
+      job_id: job.job_id,
+      execution_class: "image.normal",
+      execution_input: {
+        compiled_prompt: "Generate Tenant B's authorized image",
+        platform: "instagram",
+      },
+    });
+    assert.deepEqual(Object.keys(response.body).sort(), [
+      "execution_class",
+      "execution_input",
+      "job_id",
+    ]);
+
+    const unchanged = jobRepository.getById(job.job_id);
+    assert.equal(unchanged.tenant_id, "tenant_b");
+    assert.equal(unchanged.project_id, "project_b");
+    assert.equal(unchanged.brand_id, "brand_b");
+    assert.equal(unchanged.actor_correlation.auth_user_id, AUTH_USER_B);
+    assert.equal(unchanged.execution_class, "image.normal");
+
+    const serialized = JSON.stringify(response.body);
+    for (const injected of [
+      "tenant_a",
+      "project_a",
+      "brand_a",
+      AUTH_USER,
+      "video.premium",
+    ]) {
+      assert.equal(serialized.includes(injected), false);
     }
   });
 });

--- a/test/service-execution.test.js
+++ b/test/service-execution.test.js
@@ -1,0 +1,197 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+const express = require("express");
+const request = require("supertest");
+
+const {
+  StaticServiceCredentialVerifier,
+  SERVICE_CREDENTIAL_HEADER,
+} = require("../src/service-principal");
+const {
+  GenerationJobService,
+  InMemoryGenerationJobRepository,
+} = require("../src/generation-jobs");
+const { createServiceExecutionRouter } = require("../src/service-execution");
+
+const CREDENTIAL = "make-service-principal-credential-001";
+const AUTH_USER = "11111111-1111-4111-8111-111111111111";
+
+function authorization(overrides = {}) {
+  return {
+    actor: { kind: "customer", auth_user_id: AUTH_USER },
+    tenant_id: "tenant_a",
+    project_id: "project_a",
+    brand_id: "brand_a",
+    action: "generation:create",
+    ...overrides,
+  };
+}
+
+function appFixture({ scopes = ["generation:execute"] } = {}) {
+  const jobRepository = new InMemoryGenerationJobRepository();
+  const jobService = new GenerationJobService({ repository: jobRepository });
+  const servicePrincipalVerifier = new StaticServiceCredentialVerifier({
+    serviceId: "make",
+    credential: CREDENTIAL,
+    scopes,
+  });
+  const app = express();
+  app.use(express.json());
+  app.use(
+    "/_service/generation-jobs",
+    createServiceExecutionRouter({
+      jobRepository,
+      servicePrincipalVerifier,
+      requiredScope: "generation:execute",
+    })
+  );
+  return { app, jobRepository, jobService };
+}
+
+describe("service execution boundary", () => {
+  it("returns the bounded payload for an existing job with the correct scope and credential", async () => {
+    const { app, jobService } = appFixture();
+    const job = await jobService.authorizeAndCreateJob({
+      authorization: authorization(),
+      executionClass: "text.standard",
+      requestCorrelationId: "execution_001",
+      idempotencyKey: "execution_001",
+      allowedScopes: ["generation:execute"],
+      executionInput: { compiled_prompt: "Write a hook", platform: "tiktok" },
+    });
+
+    const response = await request(app)
+      .get(`/_service/generation-jobs/jobs/${job.job_id}/execution-payload`)
+      .set(SERVICE_CREDENTIAL_HEADER, CREDENTIAL);
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(response.body, {
+      job_id: job.job_id,
+      execution_class: "text.standard",
+      execution_input: { compiled_prompt: "Write a hook", platform: "tiktok" },
+    });
+  });
+
+  it("denies a missing job id without disclosing whether it exists", async () => {
+    const { app } = appFixture();
+    const response = await request(app)
+      .get("/_service/generation-jobs/jobs/unknown-job/execution-payload")
+      .set(SERVICE_CREDENTIAL_HEADER, CREDENTIAL);
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(response.body, { error: "Forbidden" });
+  });
+
+  it("denies a verified service principal that lacks the required scope", async () => {
+    const { app, jobService } = appFixture({ scopes: ["some:other:scope"] });
+    const job = await jobService.authorizeAndCreateJob({
+      authorization: authorization(),
+      executionClass: "text.standard",
+      requestCorrelationId: "execution_001",
+      idempotencyKey: "execution_001",
+      allowedScopes: ["generation:execute"],
+    });
+
+    const response = await request(app)
+      .get(`/_service/generation-jobs/jobs/${job.job_id}/execution-payload`)
+      .set(SERVICE_CREDENTIAL_HEADER, CREDENTIAL);
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(response.body, { error: "Forbidden" });
+  });
+
+  it("does not let request headers, query, or body widen service scopes", async () => {
+    const { app, jobService } = appFixture({ scopes: ["generation:read"] });
+    const job = await jobService.authorizeAndCreateJob({
+      authorization: authorization(),
+      executionClass: "text.standard",
+      requestCorrelationId: "execution_001",
+      idempotencyKey: "execution_001",
+      allowedScopes: ["generation:execute"],
+    });
+
+    const response = await request(app)
+      .get(`/_service/generation-jobs/jobs/${job.job_id}/execution-payload`)
+      .set(SERVICE_CREDENTIAL_HEADER, CREDENTIAL)
+      .set("scope", "generation:execute")
+      .set("scopes", "generation:execute")
+      .set("allowed_scopes", "generation:execute")
+      .query({
+        scope: "generation:execute",
+        scopes: "generation:execute",
+        allowed_scopes: "generation:execute",
+      })
+      .send({
+        scope: "generation:execute",
+        scopes: ["generation:execute"],
+        allowed_scopes: ["generation:execute"],
+      });
+
+    assert.equal(response.status, 403);
+    assert.deepEqual(response.body, { error: "Forbidden" });
+  });
+
+  it("denies a job whose own allowed_scopes do not include the required scope", async () => {
+    const { app, jobService } = appFixture();
+    const job = await jobService.authorizeAndCreateJob({
+      authorization: authorization(),
+      executionClass: "text.standard",
+      requestCorrelationId: "execution_001",
+      idempotencyKey: "execution_001",
+      allowedScopes: ["some:narrower:scope"],
+    });
+
+    const response = await request(app)
+      .get(`/_service/generation-jobs/jobs/${job.job_id}/execution-payload`)
+      .set(SERVICE_CREDENTIAL_HEADER, CREDENTIAL);
+
+    assert.equal(response.status, 403);
+  });
+
+  it("never authenticates with a customer bearer token or the admin key", async () => {
+    const { app, jobService } = appFixture();
+    const job = await jobService.authorizeAndCreateJob({
+      authorization: authorization(),
+      executionClass: "text.standard",
+      requestCorrelationId: "execution_001",
+      idempotencyKey: "execution_001",
+      allowedScopes: ["generation:execute"],
+    });
+
+    const withJwt = await request(app)
+      .get(`/_service/generation-jobs/jobs/${job.job_id}/execution-payload`)
+      .set(SERVICE_CREDENTIAL_HEADER, "Bearer some.customer.jwt");
+    const withAdminKey = await request(app)
+      .get(`/_service/generation-jobs/jobs/${job.job_id}/execution-payload`)
+      .set(SERVICE_CREDENTIAL_HEADER, "admin-key-value-should-not-work");
+    const withNoHeader = await request(app).get(
+      `/_service/generation-jobs/jobs/${job.job_id}/execution-payload`
+    );
+
+    for (const response of [withJwt, withAdminKey, withNoHeader]) {
+      assert.equal(response.status, 403);
+      assert.deepEqual(response.body, { error: "Forbidden" });
+    }
+  });
+
+  it("returns a payload that never contains tenant, project, brand, or actor identity", async () => {
+    const { app, jobService } = appFixture();
+    const job = await jobService.authorizeAndCreateJob({
+      authorization: authorization(),
+      executionClass: "text.standard",
+      requestCorrelationId: "execution_001",
+      idempotencyKey: "execution_001",
+      allowedScopes: ["generation:execute"],
+      executionInput: { compiled_prompt: "Write a hook" },
+    });
+
+    const response = await request(app)
+      .get(`/_service/generation-jobs/jobs/${job.job_id}/execution-payload`)
+      .set(SERVICE_CREDENTIAL_HEADER, CREDENTIAL);
+
+    const serialized = JSON.stringify(response.body);
+    for (const forbidden of ["tenant_a", "project_a", "brand_a", AUTH_USER]) {
+      assert.equal(serialized.includes(forbidden), false);
+    }
+  });
+});

--- a/test/service-principal-middleware.test.js
+++ b/test/service-principal-middleware.test.js
@@ -1,0 +1,157 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+
+const {
+  FORBIDDEN_RESPONSE,
+  createRequireServicePrincipal,
+} = require("../src/service-principal/middleware");
+
+class FakeVerifier {
+  constructor({ credential, actor, throwOnMismatch = true } = {}) {
+    this.credential = credential;
+    this.actor = actor;
+    this.throwOnMismatch = throwOnMismatch;
+    this.calls = [];
+  }
+
+  verifyCredential(provided) {
+    this.calls.push(provided);
+    if (provided === this.credential) {
+      return this.actor;
+    }
+    if (this.throwOnMismatch) {
+      throw new Error("denied");
+    }
+    return null;
+  }
+}
+
+function fakeReqRes({ header } = {}) {
+  const jsonCalls = [];
+  const req = {
+    path: "/_service/generation-jobs/jobs/job_1/execution-payload",
+    header: () => header,
+  };
+  const res = {
+    statusCode: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      jsonCalls.push(body);
+      return this;
+    },
+  };
+  return { req, res, jsonCalls };
+}
+
+describe("requireServicePrincipal", () => {
+  it("rejects a missing credential header with the fail-closed body", () => {
+    const verifier = new FakeVerifier({
+      credential: "svc-secret",
+      actor: { kind: "service", service_id: "make", scopes: ["generation:execute"] },
+    });
+    const middleware = createRequireServicePrincipal({
+      verifier,
+      scope: "generation:execute",
+    });
+    const { req, res, jsonCalls } = fakeReqRes({ header: undefined });
+    let nextCalled = false;
+
+    middleware(req, res, () => {
+      nextCalled = true;
+    });
+
+    assert.equal(nextCalled, false);
+    assert.equal(res.statusCode, 403);
+    assert.deepEqual(jsonCalls, [FORBIDDEN_RESPONSE]);
+  });
+
+  it("rejects an unknown credential without enumerating the reason", () => {
+    const verifier = new FakeVerifier({
+      credential: "svc-secret",
+      actor: { kind: "service", service_id: "make", scopes: ["generation:execute"] },
+    });
+    const middleware = createRequireServicePrincipal({
+      verifier,
+      scope: "generation:execute",
+    });
+    const { req, res, jsonCalls } = fakeReqRes({ header: "wrong-credential" });
+
+    middleware(req, res, () => {
+      throw new Error("next must not be called");
+    });
+
+    assert.equal(res.statusCode, 403);
+    assert.deepEqual(jsonCalls, [FORBIDDEN_RESPONSE]);
+  });
+
+  it("rejects a verified service principal missing the required scope", () => {
+    const verifier = new FakeVerifier({
+      credential: "svc-secret",
+      actor: { kind: "service", service_id: "make", scopes: ["some:other:scope"] },
+      throwOnMismatch: false,
+    });
+    const middleware = createRequireServicePrincipal({
+      verifier,
+      scope: "generation:execute",
+    });
+    const { req, res, jsonCalls } = fakeReqRes({ header: "svc-secret" });
+
+    middleware(req, res, () => {
+      throw new Error("next must not be called");
+    });
+
+    assert.equal(res.statusCode, 403);
+    assert.deepEqual(jsonCalls, [FORBIDDEN_RESPONSE]);
+  });
+
+  it("admits a verified service principal with the required scope and attaches it to the request", () => {
+    const actor = Object.freeze({
+      kind: "service",
+      service_id: "make",
+      scopes: ["generation:execute"],
+    });
+    const verifier = new FakeVerifier({ credential: "svc-secret", actor });
+    const middleware = createRequireServicePrincipal({
+      verifier,
+      scope: "generation:execute",
+    });
+    const { req, res } = fakeReqRes({ header: "svc-secret" });
+    let nextCalled = false;
+
+    middleware(req, res, () => {
+      nextCalled = true;
+    });
+
+    assert.equal(nextCalled, true);
+    assert.equal(res.statusCode, null);
+    assert.deepEqual(req.serviceActor, actor);
+  });
+
+  it("never authenticates using a customer bearer token or an admin key value", () => {
+    const actor = Object.freeze({
+      kind: "service",
+      service_id: "make",
+      scopes: ["generation:execute"],
+    });
+    const verifier = new FakeVerifier({ credential: "svc-secret", actor });
+    const middleware = createRequireServicePrincipal({
+      verifier,
+      scope: "generation:execute",
+    });
+
+    for (const header of [
+      "Bearer some.customer.jwt",
+      "customer-admin-key-value",
+    ]) {
+      const { req, res, jsonCalls } = fakeReqRes({ header });
+      middleware(req, res, () => {
+        throw new Error("next must not be called");
+      });
+      assert.equal(res.statusCode, 403);
+      assert.deepEqual(jsonCalls, [FORBIDDEN_RESPONSE]);
+    }
+  });
+});

--- a/test/service-principal.test.js
+++ b/test/service-principal.test.js
@@ -1,0 +1,139 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+
+const {
+  ServicePrincipalConfigurationError,
+  ServicePrincipalDeniedError,
+  StaticServiceCredentialVerifier,
+  UnconfiguredServiceCredentialVerifier,
+  createServiceCredentialVerifierFromEnv,
+} = require("../src/service-principal");
+
+const CREDENTIAL = "service-principal-credential-value-001";
+const ADMIN_KEY = "admin-key-value-001";
+
+function verifier(overrides = {}) {
+  return new StaticServiceCredentialVerifier({
+    serviceId: "make",
+    credential: CREDENTIAL,
+    scopes: ["generation:execute"],
+    ...overrides,
+  });
+}
+
+describe("StaticServiceCredentialVerifier", () => {
+  it("verifies the exact configured credential and returns a frozen, bounded actor", () => {
+    const actor = verifier().verifyCredential(CREDENTIAL);
+    assert.deepEqual(actor, {
+      kind: "service",
+      service_id: "make",
+      scopes: ["generation:execute"],
+    });
+    assert.equal(Object.isFrozen(actor), true);
+    assert.equal(Object.isFrozen(actor.scopes), true);
+    assert.throws(() => {
+      actor.scopes.push("generation:admin");
+    }, TypeError);
+  });
+
+  it("rejects a wrong, empty, or non-string credential", () => {
+    for (const bad of ["wrong", "", undefined, null, 12345]) {
+      assert.throws(
+        () => verifier().verifyCredential(bad),
+        ServicePrincipalDeniedError
+      );
+    }
+  });
+
+  it("never accepts a customer bearer token or the ADMIN_KEY value as its own credential", () => {
+    const instance = verifier();
+    assert.throws(
+      () => instance.verifyCredential("Bearer some.customer.jwt"),
+      ServicePrincipalDeniedError
+    );
+    assert.throws(
+      () => instance.verifyCredential(ADMIN_KEY),
+      ServicePrincipalDeniedError
+    );
+  });
+
+  it("requires a service_id, a credential of reasonable length, and at least one bounded scope", () => {
+    assert.throws(
+      () => verifier({ serviceId: "" }),
+      ServicePrincipalConfigurationError
+    );
+    assert.throws(
+      () => verifier({ credential: "short" }),
+      ServicePrincipalConfigurationError
+    );
+    assert.throws(
+      () => verifier({ scopes: [] }),
+      ServicePrincipalConfigurationError
+    );
+    assert.throws(
+      () => verifier({ scopes: Array.from({ length: 21 }, (_, i) => `scope_${i}`) }),
+      ServicePrincipalConfigurationError
+    );
+  });
+});
+
+describe("UnconfiguredServiceCredentialVerifier", () => {
+  it("fails closed for every credential when unconfigured", () => {
+    const instance = new UnconfiguredServiceCredentialVerifier();
+    for (const value of [CREDENTIAL, "", undefined, "anything"]) {
+      assert.throws(
+        () => instance.verifyCredential(value),
+        ServicePrincipalDeniedError
+      );
+    }
+  });
+});
+
+describe("createServiceCredentialVerifierFromEnv", () => {
+  it("returns a fail-closed verifier when nothing is configured", () => {
+    const instance = createServiceCredentialVerifierFromEnv({ env: {} });
+    assert.ok(instance instanceof UnconfiguredServiceCredentialVerifier);
+  });
+
+  it("requires SERVICE_PRINCIPAL_ID, SERVICE_PRINCIPAL_CREDENTIAL, and SERVICE_PRINCIPAL_SCOPES together", () => {
+    for (const env of [
+      { SERVICE_PRINCIPAL_ID: "make" },
+      { SERVICE_PRINCIPAL_CREDENTIAL: CREDENTIAL },
+      { SERVICE_PRINCIPAL_SCOPES: "generation:execute" },
+      { SERVICE_PRINCIPAL_ID: "make", SERVICE_PRINCIPAL_CREDENTIAL: CREDENTIAL },
+    ]) {
+      assert.throws(
+        () => createServiceCredentialVerifierFromEnv({ env }),
+        ServicePrincipalConfigurationError
+      );
+    }
+  });
+
+  it("builds a working verifier from complete configuration", () => {
+    const instance = createServiceCredentialVerifierFromEnv({
+      env: {
+        SERVICE_PRINCIPAL_ID: "make",
+        SERVICE_PRINCIPAL_CREDENTIAL: CREDENTIAL,
+        SERVICE_PRINCIPAL_SCOPES: "generation:execute, generation:retry",
+        ADMIN_KEY,
+      },
+    });
+    const actor = instance.verifyCredential(CREDENTIAL);
+    assert.deepEqual(actor.scopes, ["generation:execute", "generation:retry"]);
+  });
+
+  it("refuses to start if SERVICE_PRINCIPAL_CREDENTIAL equals ADMIN_KEY", () => {
+    assert.throws(
+      () =>
+        createServiceCredentialVerifierFromEnv({
+          env: {
+            SERVICE_PRINCIPAL_ID: "make",
+            SERVICE_PRINCIPAL_CREDENTIAL: ADMIN_KEY,
+            SERVICE_PRINCIPAL_SCOPES: "generation:execute",
+            ADMIN_KEY,
+          },
+        }),
+      ServicePrincipalConfigurationError
+    );
+  });
+});

--- a/test/service-principal.test.js
+++ b/test/service-principal.test.js
@@ -8,6 +8,7 @@ const {
   UnconfiguredServiceCredentialVerifier,
   createServiceCredentialVerifierFromEnv,
 } = require("../src/service-principal");
+const { ServiceActorSchema } = require("../src/authorization");
 
 const CREDENTIAL = "service-principal-credential-value-001";
 const ADMIN_KEY = "admin-key-value-001";
@@ -34,6 +35,24 @@ describe("StaticServiceCredentialVerifier", () => {
     assert.throws(() => {
       actor.scopes.push("generation:admin");
     }, TypeError);
+  });
+
+  it("defines a global worker with no tenant, project, brand, or customer authority", () => {
+    const actor = verifier().verifyCredential(CREDENTIAL);
+    assert.deepEqual(Object.keys(actor).sort(), ["kind", "scopes", "service_id"]);
+
+    for (const injectedAuthority of [
+      { tenant_id: "tenant_a" },
+      { project_id: "project_a" },
+      { brand_id: "brand_a" },
+      { auth_user_id: "11111111-1111-4111-8111-111111111111" },
+      { execution_class: "text.standard" },
+    ]) {
+      assert.equal(
+        ServiceActorSchema.safeParse({ ...actor, ...injectedAuthority }).success,
+        false
+      );
+    }
   });
 
   it("rejects a wrong, empty, or non-string credential", () => {


### PR DESCRIPTION
## Summary

Remediates the independently reviewed BG-AUTH-002C implementation artifacts against canonical `main` at `9dfb618bdf06d1ac96975b193f958c5b18f9a677` (tree `dbed587daebf3ce6d9560e2878a86c1acd6894c2`).

- makes generation-job establishment a mandatory fail-closed gate before Text/Image execution
- awaits job persistence and retry-attempt persistence, propagating asynchronous failures
- reconciles concurrent idempotency races through the database unique constraint and immutable ownership comparison
- keeps service-principal scope immutable and independent of request body/header/query values
- preserves the existing in-process generation adapter; the service execution-payload route is a bounded future server-to-server seam only
- hardens the unapplied `generation_jobs` migration (ownership FKs, explicit `ON DELETE RESTRICT`, uniqueness, RLS, privilege revocation, indexes, immutability, private-schema/function controls)

## Canonical cross-tenant interpretation

Issue #32's service principal is a **global BizGenie internal execution worker**, not a tenant principal.

Repository evidence:

- the strict service actor contract contains only `kind`, immutable server-configured `service_id`, and immutable bounded `scopes`
- tenant/project/optional-brand/customer/execution-class authority is fixed in the already-authorized immutable generation job
- the internal route accepts the verified worker, its server-configured required scope, and an opaque existing `job_id`; it accepts no tenant context as authority
- Issue #32 forbids the worker from changing job authority and says not to invent a parallel tenancy model; it does not require tenant-bound service credentials

A global worker retrieving a valid Tenant B job executes Tenant B authority already fixed by that job. It is not crossing from a Tenant A service context because no tenant-bound service context exists. Cross-tenant escalation at this boundary means injecting, replacing, or reinterpreting job ownership. Deterministic tests now prove Tenant A values supplied through headers, query, and body cannot alter a Tenant B job or its payload.

See `docs/security/GENERATION_JOB_SERVICE_BOUNDARY.md`.

## Security evidence

- persistence rejection returns the existing failure contract and does not invoke the Text generator or Image provider
- asynchronous create and retry-attempt operations are deterministically proven awaited
- concurrent identical requests resolve to one logical job; immutable-authority mutations conflict
- customer JWT, `ADMIN_KEY`, and service credentials are mutually separated
- request-supplied scopes cannot widen service authority
- the service actor schema rejects tenant/project/brand/customer/execution-class authority fields
- request-side Tenant A authority cannot reinterpret an immutable Tenant B job
- tenant/project/brand/execution-class/actor/scope mutations are rejected
- the downstream payload contains only `job_id`, immutable `execution_class`, and sanitized `execution_input`
- the downstream payload allowlist excludes credentials/JWTs, identity, provider/model, price/cost, provider secrets, callbacks, and asset locations

## Verification

- Node: `v22.23.2`
- focused cross-tenant/service-boundary tests: **18/18 passed, 4 suites**
- complete AUTH-002C suite: **73/73 passed, 13 suites**
- complete repository suite: **287/287 passed, 62 suites**
- syntax checks: **119 JavaScript files passed**
- `git diff --check`: passed
- secret-pattern scan: no matches
- follow-up tree: `4d09916b0fe29dc0dab3d42e700b0234d6c386bd`

The supplied migration remains **unapplied and unchanged by the follow-up**. No deployment, production mutation, real provider call, Make activation, Stripe activation, or merge was performed.

Closes #32