### PR TITLE
BG-BILL-002C — Generation credit reservation, debit, release and refund integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,23 @@ PostgreSQL repository. The version-controlled schema and complete accounting,
 tenant-isolation, Sheets/Make projection, and follow-up contract are documented
 in `docs/billing/COMMERCIAL_CREDIT_LEDGER_FOUNDATION.md`.
 
+## Generation credit accounting
+
+BG-BILL-002C connects the active customer Text and Image paths to the existing
+immutable generation job and Billing ledger through one shared orchestrator.
+It reserves the server-owned policy cost before execution, coalesces duplicate
+job delivery, debits once on success, and releases once on failure. Video uses
+the same deterministic `video.normal` / `video.premium` contract without
+activating a customer route or provider. Automatic post-debit refunds remain
+disabled; an idempotent original-debit-bound seam is available for a future
+proven failure condition.
+
+No commercial prices are hard-coded. Production customer execution remains
+fail-closed until approved policy rows and the durable BG-BILL-002D repository
+adapter are configured. See
+`docs/billing/GENERATION_CREDIT_ACCOUNTING.md` for authority, idempotency,
+error, refund, migration, and activation boundaries.
+
 ## Customer-authenticated generation
 
 BG-AUTH-002B adds separate, fail-closed customer paths without changing the
@@ -671,8 +688,8 @@ requires:
   organization verification;
 - a durable image-generation/media repository and asset-storage adapter;
 - a rights- and tenant-aware reference asset loader;
-- an approved credit price, entitlement check, reservation, debit, or refund
-  flow; or
+- approved execution-cost policy data and the durable Billing production
+  adapter; or
 - approval, rejection, variation, or regeneration endpoints.
 
 Those dependencies require explicit storage, commercial, and production

--- a/docs/billing/COMMERCIAL_CREDIT_LEDGER_FOUNDATION.md
+++ b/docs/billing/COMMERCIAL_CREDIT_LEDGER_FOUNDATION.md
@@ -172,9 +172,10 @@ evidence, internal finance references, other tenants, or raw database errors.
 The backend ledger is the only production financial authority. Existing
 Google Sheets and Make behavior remains useful as integration semantics:
 
-- one event per logical debit or refund;
-- debit when the generation attempt starts;
-- refund a qualifying failed attempt;
+- one event per logical reservation, settlement, or refund;
+- reserve before a billable generation executes;
+- debit only after qualifying success and release on pre-debit failure;
+- refund only a separately proven qualifying post-debit failure;
 - display a derived customer balance.
 
 Sheets and Make may receive idempotent projections or events from the backend.
@@ -198,8 +199,9 @@ or generation service is wired in BG-BILL-002A.
   verification, product/price mapping, bolt-on payment evidence, cancellation,
   and grace transitions.
 - **BG-BILL-002C:** authenticated generation integration using reserve before
-  provider attempt, final debit on attempt, and one qualifying refund on
-  failure across Text, Image, and Video.
+  execution, debit on qualifying success, release on pre-debit failure, and a
+  deny-by-default post-debit refund seam across Text, Image, and Video. See
+  `GENERATION_CREDIT_ACCOUNTING.md`.
 - **BG-BILL-002D:** real PostgreSQL concurrency, RLS, idempotency, recovery,
   reconciliation, and adversarial financial acceptance.
 

--- a/docs/billing/GENERATION_CREDIT_ACCOUNTING.md
+++ b/docs/billing/GENERATION_CREDIT_ACCOUNTING.md
@@ -1,0 +1,139 @@
+# Generation credit accounting
+
+**Task:** BG-BILL-002C
+
+**Baseline:** canonical `main` at
+`9368b54122001e611c7db3af6ddca87c4c9cd6c4` (tree
+`24cc8d4d038f7208ee396ad098db84710ad634a9`)
+
+**Status:** local integration and deterministic contract only; no migration,
+database, Stripe, provider, Make, deployment, or production state was changed
+
+## Authoritative chain
+
+Customer Text and Image execution now use one shared server-side sequence:
+
+```text
+verified customer authorization
+  -> immutable generation job
+  -> tenant policy cost resolution
+  -> credit reservation
+  -> one coalesced execution
+  -> debit on success | release on failure
+```
+
+The generation job is the only execution authority. Billing receives its
+`job_id`, tenant, project, execution class, and stable request correlation.
+Operation idempotency keys are derived by the server from the job identity and
+operation name, then SHA-256 bounded. Request values cannot select the ledger
+account, amount, settlement, refund, or ledger key.
+
+## Execution-cost policy
+
+BG-BILL-002A remains the one canonical policy boundary. The active tenant
+entitlement selects an immutable commercial-policy version, whose
+`execution_costs` map resolves:
+
+- `text.standard`
+- `image.normal`
+- `image.premium`
+- `video.normal`
+- `video.premium`
+
+No launch prices are seeded in source. Tests inject visibly named fixture
+values only. If an entitlement, active policy, or execution-class price is
+missing, reservation fails before any provider operation. Production must
+remain fail-closed until approved commercial policy data is configured.
+
+## Exactly-once behavior
+
+`GenerationBillingOrchestrator` coalesces duplicate delivery by immutable
+`job_id`. Concurrent and repeated requests share one reservation, one
+execution outcome, and one settlement attempt. A transient debit failure can
+be retried without repeating the provider operation. A failed execution keeps
+the original Text/Image/Video error and releases its reservation idempotently.
+
+The BG-BILL-002A ledger remains the authoritative duplicate-effect barrier:
+one generation reservation, one mutually exclusive debit or release for that
+reservation, and one refund for the original debit. Process-local outcome
+coalescing is the deterministic adapter used by this task. Durable
+multi-instance recovery and PostgreSQL transaction acceptance remain the
+existing BG-BILL-002D gate; production startup does not substitute process
+memory for that durable authority.
+
+## Customer error contract
+
+Insufficient funds return HTTP `402` with only:
+
+```json
+{
+  "status": "failed",
+  "error": {
+    "code": "GENERATION_CREDITS_UNAVAILABLE",
+    "message": "There are not enough credits to run this generation"
+  }
+}
+```
+
+The media-specific empty field remains `script_body`, `media`, or `video`.
+Policy, entitlement, account, persistence, or settlement unavailability uses
+the sanitized HTTP `503` code `GENERATION_BILLING_UNAVAILABLE`. Neither
+contract includes a balance calculation, plan economics, provider cost,
+provider/model selection, ledger identity, or internal error detail.
+
+## Text, Image, and Video
+
+- Customer Text reserves `text.standard` before Brand Brain resolution or the
+  existing generator, then debits only after the existing complete response
+  has qualified.
+- Customer Image reserves `image.normal` before the existing image service or
+  provider. The existing response and provider-neutral adapter remain intact.
+- The shared Video router is billing-aware when invoked behind an immutable
+  generation job and requires exact `video.normal` or `video.premium`
+  agreement with the bounded quality request. Submission reserves and executes
+  once but does not debit. The separate idempotent success/failure settlement
+  methods debit only after a later completed asset qualifies, or release after
+  a terminal failure. No customer Video route, Veo configuration, asset store,
+  or real provider is activated by this task.
+- Existing `ADMIN_KEY` Text, Image, and Video routes remain operational
+  internal paths and are not reinterpreted as tenant-billable customer jobs.
+
+## Refund policy
+
+Current execution returns a successful result only after all qualifying work
+has completed and then finalizes the debit. The repository contains no proven
+post-debit delivery condition that is safe to refund automatically. The
+production refund qualification policy therefore defaults to **deny all**.
+
+The internal `refundDebit` seam accepts only the exact debit already recorded
+for the same immutable job, derives the tenant and refund key server-side, and
+is idempotent. Tests activate a clearly labelled fixture-only qualifying
+policy to prove that seam. A future reviewed task may enable one named reason
+only after durable evidence proves that delivery failed after debit without
+also delivering customer value.
+
+## Service principal, Make, and Stripe
+
+The global service principal still carries no tenant or financial authority.
+The Make payload remains limited to opaque job identity, immutable execution
+class, and allowlisted content. Billing fields, prices, account identity,
+provider selection, and secrets are dropped.
+
+Stripe continues to fund entitlements and monthly grants only. Generation
+accounting makes no Stripe call and does not create per-generation payments.
+The Stripe router and webhook lifecycle are unchanged.
+
+## Migration and production boundary
+
+No new migration is required. The existing immutable ledger already supports
+reservation, debit, release, refund, job/request correlation, tenant/project
+scope, and original reservation/debit references. Execution class is resolved
+from the immutable generation job correlated by `job_id`, so duplicating it in
+the ledger would create a second mutable audit claim.
+
+`createProductionApp` deliberately has no durable Billing repository adapter
+yet. Its customer execution paths therefore return sanitized Billing
+unavailability before provider invocation. Activation requires approved
+commercial execution-cost rows plus the existing BG-BILL-002D durable
+PostgreSQL, concurrency, recovery, and deployment review. No new environment
+variable is introduced here.

--- a/docs/billing/STRIPE_SUBSCRIPTION_LIFECYCLE.md
+++ b/docs/billing/STRIPE_SUBSCRIPTION_LIFECYCLE.md
@@ -196,10 +196,11 @@ used for local proof. Production activation requires the durable repository
 adapter and migration/recovery/concurrency acceptance covered by
 BG-BILL-002D; until then `createProductionApp` does not mount Stripe routes.
 
-## Remaining Billing programme
+## Billing programme state
 
-- **BG-BILL-002C:** integrate generation reservation, debit, release, and
-  qualifying refund across Text, Image, and Video.
+- **BG-BILL-002C:** generation reservation, debit, release, and the inactive
+  debit-bound refund seam are implemented independently of Stripe. See
+  `GENERATION_CREDIT_ACCOUNTING.md`.
 - **BG-BILL-002D:** implement and adversarially verify the real PostgreSQL
   transaction adapter, migration, RLS, recovery, reconciliation, concurrency,
   and production activation gates.

--- a/docs/video-generation.md
+++ b/docs/video-generation.md
@@ -3,8 +3,10 @@
 ## Status
 
 This is a provider-neutral, administration-only foundation. Production activation,
-credentials, deployment, customer JWT authentication, billing, and provider calls
-are intentionally absent.
+credentials, deployment, a customer JWT-authenticated Video route, durable Billing
+activation, and provider calls are intentionally absent. BG-BILL-002C supplies the
+immutable-job-driven `video.normal` / `video.premium` accounting contract without
+activating this provider path.
 
 ## Verified Google contract
 
@@ -111,8 +113,8 @@ attempted.
 
 ## Economic readiness
 
-Credit values do not exist in the provider adapter. Internal records preserve a
-client-supplied transaction correlation ID and safe provider operation/model
-evidence so later reservation, provider-cost confirmation, delivery, debit, and
-margin events can be connected without changing the provider boundary. These
-fields are deliberately omitted from public responses.
+Credit values do not exist in the provider adapter. BG-BILL-002C resolves customer
+credit cost from the immutable generation job and commercial policy before this
+adapter can run. Existing internal records preserve safe provider operation/model
+evidence, but BG-BILL-002C does not consume it or implement provider-cost or margin
+accounting. These fields are deliberately omitted from public responses.

--- a/index.js
+++ b/index.js
@@ -56,6 +56,10 @@ const {
   createGenerationJobRecorder,
 } = require("./src/generation-jobs");
 const {
+  UnconfiguredGenerationBillingOrchestrator,
+  sendGenerationBillingError,
+} = require("./src/generation-billing");
+const {
   UnconfiguredServiceCredentialVerifier,
   createServiceCredentialVerifierFromEnv,
 } = require("./src/service-principal");
@@ -83,6 +87,7 @@ function requireAdmin(req, res, next) {
 function createGenerateScriptHandler({
   brandBrainRepository,
   branding,
+  generationBillingOrchestrator,
   scriptGenerator,
   logger,
 }) {
@@ -109,30 +114,40 @@ function createGenerateScriptHandler({
         });
       }
 
-      const brandContext = await resolveBrandBrainContext({
-        repository: brandBrainRepository,
-        projectId: project_id,
-        brandId: brand_id,
-        generationContext: {
-          platform,
-          scriptType: script_type,
-          audience,
-          intent: intent_stage,
-          voice: voice_style,
-        },
-      });
+      const execute = async () => {
+        const brandContext = await resolveBrandBrainContext({
+          repository: brandBrainRepository,
+          projectId: project_id,
+          brandId: brand_id,
+          generationContext: {
+            platform,
+            scriptType: script_type,
+            audience,
+            intent: intent_stage,
+            voice: voice_style,
+          },
+        });
 
-      const generation = await scriptGenerator(compiled_prompt, {
-        branding,
-        promptOptions: {
-          platform,
-          scriptType: script_type,
-          audience,
-          intent: intent_stage,
-          voice: voice_style,
-          brandContext,
-        },
-      });
+        return scriptGenerator(compiled_prompt, {
+          branding,
+          promptOptions: {
+            platform,
+            scriptType: script_type,
+            audience,
+            intent: intent_stage,
+            voice: voice_style,
+            brandContext,
+          },
+        });
+      };
+
+      const generation = res.locals.generationJob
+        ? await generationBillingOrchestrator.execute({
+            job: res.locals.generationJob,
+            expectedExecutionClass: "text.standard",
+            operation: execute,
+          })
+        : await execute();
 
       logger.info?.("generation completed", {
         execution_id,
@@ -146,6 +161,10 @@ function createGenerateScriptHandler({
       });
 
     } catch (err) {
+      if (sendGenerationBillingError(err, res, { kind: "script" })) {
+        return;
+      }
+
       if (err instanceof BrandBrainPersistenceError) {
         logger.error?.("brand brain persistence unavailable", {
           execution_id,
@@ -212,6 +231,7 @@ function createApp({
   customerTokenVerifier = new UnconfiguredCustomerTokenVerifier(),
   generationJobRepository = new InMemoryGenerationJobRepository(),
   generationJobService,
+  generationBillingOrchestrator = new UnconfiguredGenerationBillingOrchestrator(),
   servicePrincipalVerifier = new UnconfiguredServiceCredentialVerifier(),
   stripeSubscriptionService,
   logger = console,
@@ -259,6 +279,7 @@ function createApp({
   const scriptHandler = createGenerateScriptHandler({
     brandBrainRepository,
     branding: resolvedBranding,
+    generationBillingOrchestrator,
     scriptGenerator,
     logger,
   });
@@ -312,13 +333,21 @@ function createApp({
   app.use(
     "/generate-image",
     requireAdmin,
-    createImageGenerationRouter({ service: imageGenerationService, logger })
+    createImageGenerationRouter({
+      service: imageGenerationService,
+      generationBillingOrchestrator,
+      logger,
+    })
   );
 
   app.use(
     "/generate-video",
     requireAdmin,
-    createVideoGenerationRouter({ service: videoGenerationService, logger })
+    createVideoGenerationRouter({
+      service: videoGenerationService,
+      generationBillingOrchestrator,
+      logger,
+    })
   );
 
   app.post("/generate-script", requireAdmin, scriptHandler);
@@ -334,7 +363,11 @@ function createApp({
     "/customer/generate-image",
     customerImageBoundary,
     recordImageGenerationJob,
-    createImageGenerationRouter({ service: imageGenerationService, logger })
+    createImageGenerationRouter({
+      service: imageGenerationService,
+      generationBillingOrchestrator,
+      logger,
+    })
   );
 
   // Future bounded server-to-server execution seam. Customer generation is

--- a/src/generation-billing/errors.js
+++ b/src/generation-billing/errors.js
@@ -1,0 +1,67 @@
+class GenerationBillingError extends Error {
+  constructor(status, code, message) {
+    super(message);
+    this.name = this.constructor.name;
+    this.status = status;
+    this.code = code;
+  }
+}
+
+class GenerationCreditsUnavailableError extends GenerationBillingError {
+  constructor() {
+    super(
+      402,
+      "GENERATION_CREDITS_UNAVAILABLE",
+      "There are not enough credits to run this generation"
+    );
+  }
+}
+
+class GenerationBillingUnavailableError extends GenerationBillingError {
+  constructor() {
+    super(
+      503,
+      "GENERATION_BILLING_UNAVAILABLE",
+      "Generation billing is temporarily unavailable"
+    );
+  }
+}
+
+class GenerationBillingAuthorityError extends GenerationBillingError {
+  constructor() {
+    super(
+      503,
+      "GENERATION_BILLING_UNAVAILABLE",
+      "Generation billing is temporarily unavailable"
+    );
+  }
+}
+
+function responseBody(error, kind) {
+  const body = {
+    status: "failed",
+    error: {
+      code: error.code,
+      message: error.message,
+    },
+  };
+
+  if (kind === "script") body.script_body = "";
+  if (kind === "image") body.media = null;
+  if (kind === "video") body.video = null;
+  return body;
+}
+
+function sendGenerationBillingError(error, res, { kind }) {
+  if (!(error instanceof GenerationBillingError)) return false;
+  res.status(error.status).json(responseBody(error, kind));
+  return true;
+}
+
+module.exports = {
+  GenerationBillingAuthorityError,
+  GenerationBillingError,
+  GenerationBillingUnavailableError,
+  GenerationCreditsUnavailableError,
+  sendGenerationBillingError,
+};

--- a/src/generation-billing/index.js
+++ b/src/generation-billing/index.js
@@ -1,0 +1,4 @@
+const errors = require("./errors");
+const service = require("./service");
+
+module.exports = { ...errors, ...service };

--- a/src/generation-billing/service.js
+++ b/src/generation-billing/service.js
@@ -1,0 +1,280 @@
+const { createHash } = require("node:crypto");
+const { InsufficientCreditsError } = require("../billing");
+const { freezeGenerationJob } = require("../generation-jobs");
+const {
+  GenerationBillingAuthorityError,
+  GenerationBillingUnavailableError,
+  GenerationCreditsUnavailableError,
+} = require("./errors");
+
+function financialIdempotencyKey(operation, jobId) {
+  const digest = createHash("sha256")
+    .update(`${operation}\u0000${jobId}`)
+    .digest("hex");
+  return `generation:${operation}:${digest}`;
+}
+
+function jobFingerprint(job) {
+  return JSON.stringify(job);
+}
+
+function reservationError(error) {
+  if (error instanceof InsufficientCreditsError) {
+    return new GenerationCreditsUnavailableError();
+  }
+  if (error instanceof GenerationBillingAuthorityError) return error;
+  return new GenerationBillingUnavailableError();
+}
+
+class GenerationBillingOrchestrator {
+  constructor({
+    billingService,
+    qualifiesForRefund = () => false,
+    logger = console,
+  }) {
+    if (!billingService) {
+      throw new TypeError("A billing service is required");
+    }
+    if (typeof qualifiesForRefund !== "function") {
+      throw new TypeError(
+        "A server-owned refund qualification policy is required"
+      );
+    }
+    this.billingService = billingService;
+    this.qualifiesForRefund = qualifiesForRefund;
+    this.logger = logger;
+    this.states = new Map();
+  }
+
+  stateFor(value) {
+    let job;
+    try {
+      job = freezeGenerationJob(value);
+    } catch (_error) {
+      throw new GenerationBillingAuthorityError();
+    }
+
+    const fingerprint = jobFingerprint(job);
+    const existing = this.states.get(job.job_id);
+    if (existing) {
+      if (existing.fingerprint !== fingerprint) {
+        throw new GenerationBillingAuthorityError();
+      }
+      return existing;
+    }
+
+    const state = {
+      job,
+      fingerprint,
+      reservationPromise: null,
+      executionPromise: null,
+      debitPromise: null,
+      releasePromise: null,
+      refundPromise: null,
+      debit: null,
+    };
+    this.states.set(job.job_id, state);
+    return state;
+  }
+
+  requireExecutionClass(state, expectedExecutionClass) {
+    if (
+      typeof expectedExecutionClass !== "string" ||
+      state.job.execution_class !== expectedExecutionClass
+    ) {
+      throw new GenerationBillingAuthorityError();
+    }
+  }
+
+  reserve(state) {
+    if (!state.reservationPromise) {
+      const job = state.job;
+      state.reservationPromise = this.billingService
+        .createReservation({
+          tenantId: job.tenant_id,
+          projectId: job.project_id,
+          generationId: job.job_id,
+          executionId: job.request_correlation_id,
+          transactionCorrelationId: job.request_correlation_id,
+          executionClass: job.execution_class,
+          idempotencyKey: financialIdempotencyKey("reserve", job.job_id),
+        })
+        .catch((error) => {
+          state.reservationPromise = null;
+          throw reservationError(error);
+        });
+    }
+    return state.reservationPromise;
+  }
+
+  executeOnce(state, operation) {
+    if (!state.executionPromise) {
+      state.executionPromise = Promise.resolve()
+        .then(operation)
+        .then(
+          (value) => ({ ok: true, value }),
+          (error) => ({ ok: false, error })
+        );
+    }
+    return state.executionPromise;
+  }
+
+  debitOnce(state, reservation) {
+    if (!state.debitPromise) {
+      state.debitPromise = this.billingService
+        .finalizeDebit({
+          tenantId: state.job.tenant_id,
+          reservationEntryId: reservation.ledger_entry_id,
+          idempotencyKey: financialIdempotencyKey("debit", state.job.job_id),
+        })
+        .then((debit) => {
+          state.debit = debit;
+          return debit;
+        })
+        .catch((_error) => {
+          state.debitPromise = null;
+          throw new GenerationBillingUnavailableError();
+        });
+    }
+    return state.debitPromise;
+  }
+
+  releaseOnce(state, reservation) {
+    if (!state.releasePromise) {
+      state.releasePromise = this.billingService
+        .releaseReservation({
+          tenantId: state.job.tenant_id,
+          reservationEntryId: reservation.ledger_entry_id,
+          idempotencyKey: financialIdempotencyKey("release", state.job.job_id),
+        })
+        .catch((error) => {
+          state.releasePromise = null;
+          this.logger.error?.("generation credit release failed", {
+            job_id: state.job.job_id,
+            code: error?.code || error?.name || "BILLING_RELEASE_ERROR",
+          });
+          throw new GenerationBillingUnavailableError();
+        });
+    }
+    return state.releasePromise;
+  }
+
+  async beginExecution({ job, expectedExecutionClass, operation }) {
+    if (typeof operation !== "function") {
+      throw new TypeError("A generation execution operation is required");
+    }
+    const state = this.stateFor(job);
+    this.requireExecutionClass(state, expectedExecutionClass);
+    const reservation = await this.reserve(state);
+    const outcome = await this.executeOnce(state, operation);
+
+    if (!outcome.ok) {
+      try {
+        await this.releaseOnce(state, reservation);
+      } catch (_releaseError) {
+        // The original generation error remains the public contract. A retry
+        // reuses the same failed outcome and attempts the idempotent release
+        // again without invoking the provider.
+      }
+      throw outcome.error;
+    }
+
+    return outcome.value;
+  }
+
+  async settleSuccessfulExecution({ job }) {
+    const state = this.stateFor(job);
+    if (
+      !state.reservationPromise ||
+      !state.executionPromise ||
+      state.releasePromise
+    ) {
+      throw new GenerationBillingAuthorityError();
+    }
+    const reservation = await state.reservationPromise;
+    const outcome = await state.executionPromise;
+    if (!outcome.ok) throw new GenerationBillingAuthorityError();
+
+    await this.debitOnce(state, reservation);
+    return outcome.value;
+  }
+
+  async releaseFailedExecution({ job }) {
+    const state = this.stateFor(job);
+    if (!state.reservationPromise || state.debit) {
+      throw new GenerationBillingAuthorityError();
+    }
+    const reservation = await state.reservationPromise;
+    return this.releaseOnce(state, reservation);
+  }
+
+  async execute(input) {
+    await this.beginExecution(input);
+    return this.settleSuccessfulExecution({ job: input.job });
+  }
+
+  async refundDebit({ job, debitEntryId, reason }) {
+    const state = this.stateFor(job);
+    if (
+      !state.debit ||
+      state.debit.ledger_entry_id !== debitEntryId ||
+      state.debit.generation_id !== state.job.job_id
+    ) {
+      throw new GenerationBillingAuthorityError();
+    }
+
+    let qualifying;
+    try {
+      qualifying = await this.qualifiesForRefund({
+        job: state.job,
+        debit: state.debit,
+        reason,
+      });
+    } catch (_error) {
+      throw new GenerationBillingUnavailableError();
+    }
+    if (qualifying !== true) return null;
+
+    if (!state.refundPromise) {
+      state.refundPromise = this.billingService
+        .refund({
+          tenantId: state.job.tenant_id,
+          debitEntryId: state.debit.ledger_entry_id,
+          idempotencyKey: financialIdempotencyKey("refund", state.job.job_id),
+        })
+        .catch((_error) => {
+          state.refundPromise = null;
+          throw new GenerationBillingUnavailableError();
+        });
+    }
+    return state.refundPromise;
+  }
+}
+
+class UnconfiguredGenerationBillingOrchestrator {
+  async beginExecution() {
+    throw new GenerationBillingUnavailableError();
+  }
+
+  async settleSuccessfulExecution() {
+    throw new GenerationBillingUnavailableError();
+  }
+
+  async releaseFailedExecution() {
+    throw new GenerationBillingUnavailableError();
+  }
+
+  async execute() {
+    throw new GenerationBillingUnavailableError();
+  }
+
+  async refundDebit() {
+    throw new GenerationBillingUnavailableError();
+  }
+}
+
+module.exports = {
+  GenerationBillingOrchestrator,
+  UnconfiguredGenerationBillingOrchestrator,
+  financialIdempotencyKey,
+};

--- a/src/image-generation/router.js
+++ b/src/image-generation/router.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const { sendGenerationBillingError } = require("../generation-billing");
 const {
   ImageGenerationValidationError,
   formatZodIssues,
@@ -16,7 +17,11 @@ function parseRequest(value) {
   return result.data;
 }
 
-function createImageGenerationRouter({ service, logger = console }) {
+function createImageGenerationRouter({
+  service,
+  generationBillingOrchestrator,
+  logger = console,
+}) {
   if (!service) {
     throw new Error("An image generation service is required");
   }
@@ -27,7 +32,14 @@ function createImageGenerationRouter({ service, logger = console }) {
     let input;
     try {
       input = parseRequest(req.body);
-      const record = await service.generate(input);
+      const operation = () => service.generate(input);
+      const record = res.locals.generationJob
+        ? await generationBillingOrchestrator.execute({
+            job: res.locals.generationJob,
+            expectedExecutionClass: "image.normal",
+            operation,
+          })
+        : await operation();
       logger.info?.("image generation completed", {
         execution_id: record.execution_id,
         generation_id: record.generation_id,
@@ -60,6 +72,9 @@ function createImageGenerationRouter({ service, logger = console }) {
   });
 
   router.use((error, _req, res, next) => {
+    if (sendGenerationBillingError(error, res, { kind: "image" })) {
+      return;
+    }
     if (sendImageGenerationError(error, res)) {
       return;
     }

--- a/src/video-generation/router.js
+++ b/src/video-generation/router.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const { sendGenerationBillingError } = require("../generation-billing");
 const {
   VideoGenerationValidationError,
   formatZodIssues,
@@ -35,7 +36,11 @@ function responseStatus(record) {
   return ["submitted", "processing"].includes(record.status) ? 202 : 200;
 }
 
-function createVideoGenerationRouter({ service, logger = console }) {
+function createVideoGenerationRouter({
+  service,
+  generationBillingOrchestrator,
+  logger = console,
+}) {
   if (!service) throw new Error("A video generation service is required");
   const router = express.Router();
 
@@ -43,7 +48,14 @@ function createVideoGenerationRouter({ service, logger = console }) {
     let input;
     try {
       input = parse(VideoGenerationRequestSchema, req.body);
-      const record = await service.submit(input);
+      const operation = () => service.submit(input);
+      const record = res.locals.generationJob
+        ? await generationBillingOrchestrator.beginExecution({
+            job: res.locals.generationJob,
+            expectedExecutionClass: `video.${input.quality}`,
+            operation,
+          })
+        : await operation();
       logger.info?.("video generation submitted", {
         execution_id: record.execution_id,
         generation_id: record.generation_id,
@@ -90,6 +102,7 @@ function createVideoGenerationRouter({ service, logger = console }) {
   });
 
   router.use((error, _req, res, next) => {
+    if (sendGenerationBillingError(error, res, { kind: "video" })) return;
     if (sendVideoGenerationError(error, res)) return;
     next(error);
   });

--- a/test/customer-generation-job-boundary.test.js
+++ b/test/customer-generation-job-boundary.test.js
@@ -115,6 +115,12 @@ function customer(client, token = "token-a") {
   return client.set("authorization", `Bearer ${token}`);
 }
 
+const existingBoundaryBillingFixture = Object.freeze({
+  execute({ operation }) {
+    return operation();
+  },
+});
+
 function appFixture(overrides = {}) {
   const generationJobRepository = new InMemoryGenerationJobRepository();
   const servicePrincipalVerifier = new StaticServiceCredentialVerifier({
@@ -138,6 +144,7 @@ function appFixture(overrides = {}) {
     authorizationRepository: authorizationRepository(),
     brandBrainRepository: brandBrainRepository(),
     customerTokenVerifier: new FixtureTokenVerifier(),
+    generationBillingOrchestrator: existingBoundaryBillingFixture,
     imageGenerationRepository: new InMemoryImageGenerationRepository(),
     generationJobRepository,
     servicePrincipalVerifier,

--- a/test/customer-generation.test.js
+++ b/test/customer-generation.test.js
@@ -141,6 +141,12 @@ function customer(client, token = "token-a") {
   return client.set("authorization", `Bearer ${token}`);
 }
 
+const existingBoundaryBillingFixture = Object.freeze({
+  execute({ operation }) {
+    return operation();
+  },
+});
+
 function appFixture(overrides = {}) {
   const tokenVerifier = overrides.customerTokenVerifier || new FixtureTokenVerifier();
   const imageGenerationRepository = new InMemoryImageGenerationRepository();
@@ -163,6 +169,7 @@ function appFixture(overrides = {}) {
     authorizationRepository: authorizationRepository(),
     brandBrainRepository: brandBrainRepository(),
     customerTokenVerifier: tokenVerifier,
+    generationBillingOrchestrator: existingBoundaryBillingFixture,
     imageGenerationRepository,
     imageProvider: {
       async generate(value) {

--- a/test/generation-billing.test.js
+++ b/test/generation-billing.test.js
@@ -1,0 +1,647 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+const request = require("supertest");
+
+const {
+  AuthenticationRequiredError,
+  InMemoryAuthorizationRepository,
+  createCustomerActorFromVerifiedIdentity,
+} = require("../src/authorization");
+const {
+  BillingService,
+  InMemoryBillingRepository,
+} = require("../src/billing");
+const { InMemoryBrandBrainRepository } = require("../src/brand-brain");
+const {
+  GenerationBillingAuthorityError,
+  GenerationBillingOrchestrator,
+  GenerationBillingUnavailableError,
+} = require("../src/generation-billing");
+const { freezeGenerationJob } = require("../src/generation-jobs");
+const { InMemoryImageGenerationRepository } = require("../src/image-generation");
+const { buildMakeExecutionPayload } = require("../src/service-execution");
+const { createApp } = require("../index");
+
+const NOW = "2026-08-23T08:00:00.000Z";
+const USER_A = "11111111-1111-4111-8111-111111111111";
+const TEST_EXECUTION_COSTS = Object.freeze({
+  "text.standard": 3,
+  "image.normal": 5,
+  "image.premium": 7,
+  "video.normal": 11,
+  "video.premium": 17,
+});
+const COMPLETE_OUTPUT = [
+  "Hook: Make the next step obvious.",
+  "Concept: Turn one clear plan into useful content.",
+  "Script: Choose the goal, write the message, and publish consistently.",
+  "CTA: Build your next campaign today.",
+  "Caption: Clear plans create useful work.",
+  "Hashtags: #Planning #Marketing #SmallBusiness",
+  "Filming instructions:",
+  "- Show the plan becoming a finished post.",
+].join("\n");
+
+function testJob(overrides = {}) {
+  return freezeGenerationJob({
+    job_id: "11111111-2222-4333-8444-555555555555",
+    tenant_id: "tenant_a",
+    project_id: "project_a",
+    execution_class: "text.standard",
+    actor_correlation: {
+      kind: "customer",
+      auth_user_id: USER_A,
+    },
+    request_correlation_id: "request_correlation_001",
+    idempotency_key: "customer_request_001",
+    created_at: NOW,
+    allowed_scopes: ["generation:execute"],
+    ...overrides,
+  });
+}
+
+async function billingFixture({
+  credits = 100,
+  executionCosts = TEST_EXECUTION_COSTS,
+  qualifiesForRefund,
+  logger = { error() {} },
+} = {}) {
+  const repository = new InMemoryBillingRepository({
+    policies: [
+      {
+        policy_id: "policy_launch_fixture",
+        plan_code: "test_plan",
+        policy_version: 1,
+        status: "active",
+        included_monthly_credits: 100,
+        bolt_on_eligible: true,
+        effective_from: "2026-01-01T00:00:00.000Z",
+        execution_costs: executionCosts,
+      },
+    ],
+    entitlements: [
+      {
+        entitlement_id: "entitlement_a",
+        tenant_id: "tenant_a",
+        policy_id: "policy_launch_fixture",
+        plan_code: "test_plan",
+        status: "active",
+        starts_at: "2026-01-01T00:00:00.000Z",
+        reference_period_start: "2026-08-01T00:00:00.000Z",
+        reference_period_end: "2026-09-01T00:00:00.000Z",
+        included_monthly_credit_grant: 100,
+      },
+    ],
+    accounts: [
+      {
+        account_id: "account_a",
+        tenant_id: "tenant_a",
+        status: "active",
+        created_at: "2026-01-01T00:00:00.000Z",
+      },
+    ],
+    projects: [{ project_id: "project_a", tenant_id: "tenant_a" }],
+    now: () => new Date(NOW),
+  });
+  const billingService = new BillingService({
+    repository,
+    now: () => new Date(NOW),
+  });
+  if (credits > 0) {
+    await billingService.adjustCredits({
+      tenantId: "tenant_a",
+      amount: credits,
+      direction: "credit",
+      transactionCorrelationId: "fixture_credit_funding",
+      idempotencyKey: "fixture_credit_funding",
+    });
+  }
+  const orchestrator = new GenerationBillingOrchestrator({
+    billingService,
+    qualifiesForRefund,
+    logger,
+  });
+  return { billingService, orchestrator, repository };
+}
+
+function ledgerTypes(repository) {
+  return repository.listLedger("tenant_a").map((entry) => entry.entry_type);
+}
+
+function authorizationRepository() {
+  return new InMemoryAuthorizationRepository({
+    customerProfiles: [{ auth_user_id: USER_A, display_name: "Customer A" }],
+    tenants: [{ tenant_id: "tenant_a", name: "Tenant A", created_by: USER_A }],
+    memberships: [
+      { tenant_id: "tenant_a", auth_user_id: USER_A, role: "owner" },
+    ],
+    projects: [
+      { project_id: "project_a", tenant_id: "tenant_a", name: "Project A" },
+    ],
+  });
+}
+
+class FixtureTokenVerifier {
+  async verifyAccessToken(token) {
+    if (token !== "token-a") throw new AuthenticationRequiredError();
+    return createCustomerActorFromVerifiedIdentity({
+      verifiedAuthUserId: USER_A,
+    });
+  }
+}
+
+async function customerAppFixture({
+  credits = 100,
+  orchestrator,
+  scriptGenerator,
+  imageProvider,
+} = {}) {
+  const billing = orchestrator ? null : await billingFixture({ credits });
+  const providerCalls = { text: 0, image: 0 };
+  const app = createApp({
+    authorizationRepository: authorizationRepository(),
+    brandBrainRepository: new InMemoryBrandBrainRepository(),
+    customerTokenVerifier: new FixtureTokenVerifier(),
+    generationBillingOrchestrator: orchestrator || billing.orchestrator,
+    imageGenerationRepository: new InMemoryImageGenerationRepository(),
+    imageProvider: imageProvider || {
+      async generate() {
+        providerCalls.image += 1;
+        return {
+          provider: "fixture-image-provider",
+          provider_job_id: "fixture-image-job",
+          asset: {
+            location: "gs://fixture-assets/image.png",
+            mime_type: "image/png",
+            width: 1024,
+            height: 1024,
+          },
+        };
+      },
+    },
+    scriptGenerator: scriptGenerator || (async () => {
+      providerCalls.text += 1;
+      return { text: COMPLETE_OUTPUT, metadata: { provider: "fixture" } };
+    }),
+    logger: { info() {}, warn() {}, error() {} },
+  });
+  return {
+    app,
+    billing,
+    providerCalls,
+  };
+}
+
+function customer(client) {
+  return client.set("authorization", "Bearer token-a");
+}
+
+function scriptRequest(overrides = {}) {
+  return {
+    execution_id: "customer_text_execution_001",
+    tenant_id: "tenant_a",
+    project_id: "project_a",
+    compiled_prompt: "Create a useful campaign script",
+    ...overrides,
+  };
+}
+
+function imageRequest(overrides = {}) {
+  return {
+    execution_id: "customer_image_execution_001",
+    generation_id: "customer_image_generation_001",
+    tenant_id: "tenant_a",
+    project_id: "project_a",
+    topic: "A useful campaign image",
+    image_purpose: "Campaign launch",
+    aspect_ratio: "1:1",
+    ...overrides,
+  };
+}
+
+describe("generation credit orchestration", () => {
+  it("reserves from the immutable job before execution and debits exactly once", async () => {
+    const fixture = await billingFixture();
+    let observedTypes;
+    const result = await fixture.orchestrator.execute({
+      job: testJob(),
+      expectedExecutionClass: "text.standard",
+      operation: async () => {
+        observedTypes = ledgerTypes(fixture.repository);
+        return { output: "completed" };
+      },
+    });
+
+    assert.deepEqual(result, { output: "completed" });
+    assert.deepEqual(observedTypes, ["admin_adjustment", "reservation"]);
+    assert.deepEqual(ledgerTypes(fixture.repository), [
+      "admin_adjustment",
+      "reservation",
+      "debit",
+    ]);
+    const entries = fixture.repository.listLedger("tenant_a");
+    assert.equal(entries[1].generation_id, testJob().job_id);
+    assert.equal(entries[1].execution_id, testJob().request_correlation_id);
+    assert.equal(entries[1].amount, TEST_EXECUTION_COSTS["text.standard"]);
+    assert.equal(entries[2].reservation_entry_id, entries[1].ledger_entry_id);
+  });
+
+  it("fails closed before execution for insufficient credits or unavailable Billing", async () => {
+    const insufficient = await billingFixture({ credits: 0 });
+    let calls = 0;
+    await assert.rejects(
+      insufficient.orchestrator.execute({
+        job: testJob(),
+        expectedExecutionClass: "text.standard",
+        operation: async () => { calls += 1; },
+      }),
+      (error) => error.code === "GENERATION_CREDITS_UNAVAILABLE" && error.status === 402
+    );
+    assert.equal(calls, 0);
+
+    const unavailable = new GenerationBillingOrchestrator({
+      billingService: {
+        async createReservation() {
+          throw new Error("database connection detail that must stay private");
+        },
+      },
+    });
+    await assert.rejects(
+      unavailable.execute({
+        job: testJob(),
+        expectedExecutionClass: "text.standard",
+        operation: async () => { calls += 1; },
+      }),
+      (error) =>
+        error instanceof GenerationBillingUnavailableError &&
+        !error.message.includes("database")
+    );
+    assert.equal(calls, 0);
+  });
+
+  it("coalesces concurrent and repeated delivery into one execution and one financial effect", async () => {
+    const fixture = await billingFixture();
+    let calls = 0;
+    let releaseExecution;
+    const gate = new Promise((resolve) => { releaseExecution = resolve; });
+    const operation = async () => {
+      calls += 1;
+      await gate;
+      return { output: "same-result" };
+    };
+    const input = {
+      job: testJob(),
+      expectedExecutionClass: "text.standard",
+      operation,
+    };
+
+    const first = fixture.orchestrator.execute(input);
+    const duplicate = fixture.orchestrator.execute(input);
+    releaseExecution();
+    const [left, right] = await Promise.all([first, duplicate]);
+    const replay = await fixture.orchestrator.execute(input);
+
+    assert.equal(calls, 1);
+    assert.deepEqual(left, right);
+    assert.deepEqual(replay, left);
+    assert.equal(
+      fixture.repository.listLedger("tenant_a")
+        .filter((entry) => entry.entry_type === "reservation").length,
+      1
+    );
+    assert.equal(
+      fixture.repository.listLedger("tenant_a")
+        .filter((entry) => entry.entry_type === "debit").length,
+      1
+    );
+  });
+
+  it("releases once on execution failure and preserves the original error", async () => {
+    const fixture = await billingFixture();
+    const providerError = new Error("fixture provider failure");
+    providerError.code = "FIXTURE_PROVIDER_FAILURE";
+    let calls = 0;
+    const input = {
+      job: testJob(),
+      expectedExecutionClass: "text.standard",
+      operation: async () => {
+        calls += 1;
+        throw providerError;
+      },
+    };
+
+    await assert.rejects(fixture.orchestrator.execute(input), (error) => error === providerError);
+    await assert.rejects(fixture.orchestrator.execute(input), (error) => error === providerError);
+    assert.equal(calls, 1);
+    assert.equal(
+      fixture.repository.listLedger("tenant_a")
+        .filter((entry) => entry.entry_type === "reservation_release").length,
+      1
+    );
+    const balance = await fixture.billingService.readBalance({ tenantId: "tenant_a" });
+    assert.equal(balance.available_balance, 100);
+    assert.equal(balance.reserved_balance, 0);
+  });
+
+  it("does not repeat provider execution when debit settlement is retried", async () => {
+    const fixture = await billingFixture();
+    let debitAttempts = 0;
+    let calls = 0;
+    const recoveringBillingService = {
+      createReservation: (input) => fixture.billingService.createReservation(input),
+      releaseReservation: (input) => fixture.billingService.releaseReservation(input),
+      refund: (input) => fixture.billingService.refund(input),
+      async finalizeDebit(input) {
+        debitAttempts += 1;
+        if (debitAttempts === 1) throw new Error("temporary settlement outage");
+        return fixture.billingService.finalizeDebit(input);
+      },
+    };
+    const orchestrator = new GenerationBillingOrchestrator({
+      billingService: recoveringBillingService,
+    });
+    const input = {
+      job: testJob(),
+      expectedExecutionClass: "text.standard",
+      operation: async () => {
+        calls += 1;
+        return "completed";
+      },
+    };
+
+    await assert.rejects(
+      orchestrator.execute(input),
+      (error) => error.code === "GENERATION_BILLING_UNAVAILABLE"
+    );
+    assert.equal(await orchestrator.execute(input), "completed");
+    assert.equal(calls, 1);
+    assert.equal(debitAttempts, 2);
+    assert.deepEqual(ledgerTypes(fixture.repository), [
+      "admin_adjustment",
+      "reservation",
+      "debit",
+    ]);
+  });
+
+  it("rejects execution-class and immutable-job authority changes", async () => {
+    const fixture = await billingFixture();
+    let calls = 0;
+    await assert.rejects(
+      fixture.orchestrator.execute({
+        job: testJob(),
+        expectedExecutionClass: "image.normal",
+        operation: async () => { calls += 1; },
+      }),
+      GenerationBillingAuthorityError
+    );
+    assert.equal(calls, 0);
+
+    await fixture.orchestrator.execute({
+      job: testJob(),
+      expectedExecutionClass: "text.standard",
+      operation: async () => "ok",
+    });
+    const forged = testJob({ project_id: "project_forged" });
+    await assert.rejects(
+      fixture.orchestrator.execute({
+        job: forged,
+        expectedExecutionClass: "text.standard",
+        operation: async () => { calls += 1; },
+      }),
+      GenerationBillingAuthorityError
+    );
+    assert.equal(calls, 0);
+  });
+
+  it("keeps automatic refund inactive and exposes an idempotent debit-bound seam", async () => {
+    const inactive = await billingFixture();
+    const job = testJob();
+    await inactive.orchestrator.execute({
+      job,
+      expectedExecutionClass: "text.standard",
+      operation: async () => "completed",
+    });
+    const debit = inactive.repository.listLedger("tenant_a")
+      .find((entry) => entry.entry_type === "debit");
+    assert.equal(
+      await inactive.orchestrator.refundDebit({
+        job,
+        debitEntryId: debit.ledger_entry_id,
+        reason: "non_qualifying_failure",
+      }),
+      null
+    );
+    assert.equal(
+      inactive.repository.listLedger("tenant_a")
+        .filter((entry) => entry.entry_type === "refund").length,
+      0
+    );
+
+    const qualified = await billingFixture({
+      qualifiesForRefund: ({ reason }) => reason === "fixture.proven_post_debit_failure",
+    });
+    const qualifiedJob = testJob({ job_id: "22222222-3333-4444-8555-666666666666" });
+    await qualified.orchestrator.execute({
+      job: qualifiedJob,
+      expectedExecutionClass: "text.standard",
+      operation: async () => "completed",
+    });
+    const qualifiedDebit = qualified.repository.listLedger("tenant_a")
+      .find((entry) => entry.entry_type === "debit");
+    const refundInput = {
+      job: qualifiedJob,
+      debitEntryId: qualifiedDebit.ledger_entry_id,
+      reason: "fixture.proven_post_debit_failure",
+    };
+    const refund = await qualified.orchestrator.refundDebit(refundInput);
+    const replay = await qualified.orchestrator.refundDebit(refundInput);
+    assert.equal(replay.ledger_entry_id, refund.ledger_entry_id);
+    assert.equal(refund.debit_entry_id, qualifiedDebit.ledger_entry_id);
+    assert.equal(refund.generation_id, qualifiedJob.job_id);
+    assert.equal(
+      qualified.repository.listLedger("tenant_a")
+        .filter((entry) => entry.entry_type === "refund").length,
+      1
+    );
+    await assert.rejects(
+      qualified.orchestrator.refundDebit({
+        job: qualifiedJob,
+        debitEntryId: "ledger_not_the_original_debit",
+        reason: "fixture.proven_post_debit_failure",
+      }),
+      GenerationBillingAuthorityError
+    );
+  });
+
+  it("keeps Video reserved at submission and settles only a later qualifying outcome", async () => {
+    const fixture = await billingFixture();
+    for (const [quality, cost] of [["normal", 11], ["premium", 17]]) {
+      const job = testJob({
+        job_id: quality === "normal"
+          ? "33333333-4444-4555-8666-777777777777"
+          : "44444444-5555-4666-8777-888888888888",
+        execution_class: `video.${quality}`,
+        request_correlation_id: `video_${quality}_request`,
+        idempotency_key: `video_${quality}_request`,
+      });
+      const value = await fixture.orchestrator.beginExecution({
+        job,
+        expectedExecutionClass: `video.${quality}`,
+        operation: async () => ({ status: "provider-dormant" }),
+      });
+      assert.deepEqual(value, { status: "provider-dormant" });
+      const reservation = fixture.repository.listLedger("tenant_a")
+        .find((entry) =>
+          entry.entry_type === "reservation" && entry.generation_id === job.job_id
+        );
+      assert.equal(reservation.amount, cost);
+      assert.equal(
+        fixture.repository.listLedger("tenant_a").some((entry) =>
+          entry.entry_type === "debit" && entry.generation_id === job.job_id
+        ),
+        false
+      );
+
+      if (quality === "normal") {
+        await fixture.orchestrator.settleSuccessfulExecution({ job });
+        const debit = fixture.repository.listLedger("tenant_a").find((entry) =>
+          entry.entry_type === "debit" && entry.generation_id === job.job_id
+        );
+        assert.equal(debit.reservation_entry_id, reservation.ledger_entry_id);
+      } else {
+        await fixture.orchestrator.releaseFailedExecution({ job });
+        const release = fixture.repository.listLedger("tenant_a").find((entry) =>
+          entry.entry_type === "reservation_release" &&
+          entry.generation_id === job.job_id
+        );
+        assert.equal(release.reservation_entry_id, reservation.ledger_entry_id);
+      }
+    }
+  });
+});
+
+describe("customer Text and Image billing boundary", () => {
+  it("settles one debit for successful Text and Image while preserving responses", async () => {
+    const fixture = await customerAppFixture();
+    const text = await customer(
+      request(fixture.app).post("/customer/generate-script")
+    ).send(scriptRequest());
+    const image = await customer(
+      request(fixture.app).post("/customer/generate-image")
+    ).send(imageRequest());
+
+    assert.equal(text.status, 200);
+    assert.equal(text.body.status, "completed");
+    assert.equal(text.body.script_body, COMPLETE_OUTPUT);
+    assert.equal(image.status, 200);
+    assert.equal(image.body.status, "completed");
+    assert.equal(image.body.media.provider, "fixture-image-provider");
+    assert.deepEqual(fixture.providerCalls, { text: 1, image: 1 });
+    const ledger = fixture.billing.repository.listLedger("tenant_a");
+    assert.equal(ledger.filter((entry) => entry.entry_type === "reservation").length, 2);
+    assert.equal(ledger.filter((entry) => entry.entry_type === "debit").length, 2);
+    assert.deepEqual(
+      ledger.filter((entry) => entry.entry_type === "reservation")
+        .map((entry) => entry.amount).sort((a, b) => a - b),
+      [3, 5]
+    );
+  });
+
+  it("rejects insufficient credits before Text provider execution with a sanitized contract", async () => {
+    const fixture = await customerAppFixture({ credits: 0 });
+    const response = await customer(
+      request(fixture.app).post("/customer/generate-script")
+    ).send(scriptRequest());
+
+    assert.equal(response.status, 402);
+    assert.deepEqual(response.body, {
+      status: "failed",
+      error: {
+        code: "GENERATION_CREDITS_UNAVAILABLE",
+        message: "There are not enough credits to run this generation",
+      },
+      script_body: "",
+    });
+    assert.equal(fixture.providerCalls.text, 0);
+    assert.doesNotMatch(JSON.stringify(response.body), /balance|provider|ledger|policy/i);
+  });
+
+  it("ignores customer cost, ledger, and alternate billing-tenant fields", async () => {
+    const fixture = await customerAppFixture();
+    const response = await customer(
+      request(fixture.app).post("/customer/generate-script")
+    ).send(scriptRequest({
+      credit_cost: 0,
+      reservation_amount: 0,
+      debit_amount: 0,
+      refund_amount: 999999,
+      provider_cost: 1,
+      billing_tenant_id: "tenant_b",
+      billing_idempotency_key: "caller_controlled",
+    }));
+
+    assert.equal(response.status, 200);
+    const reservation = fixture.billing.repository.listLedger("tenant_a")
+      .find((entry) => entry.entry_type === "reservation");
+    assert.equal(reservation.tenant_id, "tenant_a");
+    assert.equal(reservation.amount, TEST_EXECUTION_COSTS["text.standard"]);
+    assert.notEqual(reservation.idempotency_key, "caller_controlled");
+  });
+
+  it("coalesces concurrent duplicate customer requests before provider execution", async () => {
+    const fixture = await customerAppFixture();
+    const payload = scriptRequest({ execution_id: "concurrent_customer_request" });
+    const [first, duplicate] = await Promise.all([
+      customer(request(fixture.app).post("/customer/generate-script")).send(payload),
+      customer(request(fixture.app).post("/customer/generate-script")).send(payload),
+    ]);
+
+    assert.equal(first.status, 200);
+    assert.equal(duplicate.status, 200);
+    assert.deepEqual(duplicate.body, first.body);
+    assert.equal(fixture.providerCalls.text, 1);
+    const ledger = fixture.billing.repository.listLedger("tenant_a");
+    assert.equal(ledger.filter((entry) => entry.entry_type === "reservation").length, 1);
+    assert.equal(ledger.filter((entry) => entry.entry_type === "debit").length, 1);
+  });
+
+  it("fails closed when no production Billing authority is configured", async () => {
+    let calls = 0;
+    const app = createApp({
+      authorizationRepository: authorizationRepository(),
+      brandBrainRepository: new InMemoryBrandBrainRepository(),
+      customerTokenVerifier: new FixtureTokenVerifier(),
+      scriptGenerator: async () => {
+        calls += 1;
+        return { text: COMPLETE_OUTPUT, metadata: { provider: "fixture" } };
+      },
+      logger: { info() {}, warn() {}, error() {} },
+    });
+    const response = await customer(
+      request(app).post("/customer/generate-script")
+    ).send(scriptRequest());
+
+    assert.equal(response.status, 503);
+    assert.equal(response.body.error.code, "GENERATION_BILLING_UNAVAILABLE");
+    assert.equal(calls, 0);
+  });
+
+  it("keeps service/Make payloads outside financial authority", () => {
+    const payload = buildMakeExecutionPayload(testJob(), {
+      compiled_prompt: "Safe bounded content",
+      tenant_id: "tenant_b",
+      credit_cost: 0,
+      reservation_amount: 0,
+      debit_amount: 0,
+      refund_amount: 100,
+      billing_idempotency_key: "caller_controlled",
+      provider: "caller-provider",
+      model: "caller-model",
+    });
+    assert.deepEqual(payload, {
+      job_id: testJob().job_id,
+      execution_class: "text.standard",
+      execution_input: { compiled_prompt: "Safe bounded content" },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements Issue #35 (BG-BILL-002C) on the canonical Billing/Auth/generation architecture.

- derives tenant, project, execution class, job correlation, and financial idempotency only from the immutable authorized generation job
- reuses the BG-BILL-002A commercial policy and append-only reservation/debit/release/refund ledger
- reserves before customer Text/Image execution and fails closed before provider access
- coalesces concurrent/repeated job delivery into one execution outcome and one net financial effect
- debits synchronous Text/Image only after qualifying success and releases on pre-debit failure
- keeps Video provider-dormant: submission reserves without debit; explicit later success/failure settlement debits or releases
- keeps automatic refund qualification deny-by-default while proving an idempotent seam tied to the original job/debit
- preserves BG-AUTH-002C service-principal/Make boundaries and BG-BILL-002B Stripe monthly grants

## Baseline and head

- baseline commit: `9368b54122001e611c7db3af6ddca87c4c9cd6c4`
- baseline tree: `24cc8d4d038f7208ee396ad098db84710ad634a9`
- PR head commit: `c2767458df79e54e318cecb53c49e7f4d6e2699c`
- PR head tree: `c127196016bba3d5d1911b29df0617787bd1e349`
- remote compare: one commit ahead, zero behind, 14 task files

## Validation (Node 22.23.2)

Untouched baseline:
- `npm ci`: passed with a workspace-local npm cache after the Windows global cache rejected access
- `npm test`: 322 passed, 0 failed

Head:
- `npm ci`: passed
- focused BG-BILL-002C: 14 passed, 0 failed
- focused Billing/Video combined: 31 passed, 0 failed
- complete `npm test`: 336 passed, 0 failed
- JavaScript syntax: 131 files checked, 0 failures
- `git diff --check` / staged diff check: passed
- changed-file secret signature scan: 0 matches
- package/runtime/production-config diff: none

## Migration and production state

- no migration added
- no migration applied
- no database, Stripe, provider, Make, Cloud Run, deployment, secret, payment, or production call/mutation
- no Stripe per-generation charge path
- production customer generation remains fail-closed until a durable Billing adapter and approved execution-cost policy data are configured
- launch credit values are not invented; tests use explicit fixture-only costs

## Remaining gate

Commercial approval/configuration of launch execution-cost values and the existing BG-BILL-002D durable PostgreSQL concurrency/recovery/activation work remain required before production activation.

Refs #35
