### PR TITLE
BG-BILL-002D: durable PostgreSQL billing authority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,23 @@ jobs:
     name: Node 22 tests and syntax
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      TEST_DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
 
     steps:
       - name: Check out repository
@@ -49,6 +66,9 @@ jobs:
 
       - name: Run automated tests
         run: npm test
+
+      - name: Run real PostgreSQL billing adversarial tests
+        run: npm run test:billing:postgres
 
       - name: Check JavaScript syntax
         shell: bash

--- a/docs/billing/DURABLE_POSTGRES_BILLING.md
+++ b/docs/billing/DURABLE_POSTGRES_BILLING.md
@@ -1,0 +1,87 @@
+# Durable PostgreSQL billing authority
+
+BG-BILL-002D keeps the existing commercial policy, entitlement, credit account,
+immutable `credit_ledger`, Stripe evidence, and generation-job tables as the
+only financial model. `PostgresBillingRepository` implements the established
+Billing repository contract over the application's existing PostgreSQL pool.
+
+## Transaction and balance model
+
+Each financial mutation uses an explicit, short transaction. The repository
+locks only the tenant's `credit_accounts` row with `SELECT ... FOR UPDATE`, then
+derives posted and reserved balances by summing the immutable ledger. Requests
+for different accounts therefore proceed independently; requests for the same
+account serialize before checking available credit and appending an effect.
+There is no mutable balance projection to reconcile.
+
+Global idempotency-key uniqueness prevents the same durable identity from being
+reused across accounts or tenants. On retry, the repository compares the full
+immutable intent hash and authority before returning the committed row. Logical
+effect indexes independently enforce one reservation per generation, one
+settlement per reservation, one refund per debit, one monthly grant per
+entitlement period, and one bolt-on grant per verified payment. A settlement
+transaction locks the original reservation and derives its amount, tenant,
+project, generation, execution, and correlation values from that row. A refund
+does the same from the original debit.
+
+Because the effect row and all dependent checks commit in one database
+transaction, a failure before commit leaves no effect. If the commit succeeds
+but acknowledgement is lost, the same idempotent request discovers and returns
+the committed effect. Generation orchestration checks durable settlement state
+before provider execution, so a recovered debit does not rerun the provider.
+
+## Database enforcement and access
+
+Migration `20260823001722_durable_billing_authority.sql` is additive. It adds
+global idempotency uniqueness, a tenant/project-bound generation-job reference,
+validated lifecycle checks, and a private insert trigger that verifies
+reservation pricing and generation authority, exact settlement lineage,
+refund lineage, monthly entitlement references, and bolt-on payment evidence.
+The immutable ledger remains the balance source of truth.
+
+Financial tables retain RLS, direct authority remains revoked from `anon`,
+`authenticated`, and `service_role`, private functions use an empty
+`search_path`, and deletion remains prohibited. The application connection is
+the trusted financial writer; customers cannot supply arbitrary database
+mutation authority.
+
+## Reconciliation
+
+`repository.reconcile({ olderThan, limit })` opens a read-only,
+repeatable-read transaction and returns a bounded report of:
+
+- old reservations without debit or release;
+- reservations with invalid or duplicate settlement state;
+- refunds without their original debit;
+- duplicate logical effects;
+- monthly grants whose entitlement/period/amount no longer agrees with
+  canonical data, plus active entitlements missing the current-period grant.
+
+The seam reports evidence only. It performs no automatic repair.
+
+## Production activation gate
+
+Production composition defaults to the unconfigured, fail-closed generation
+billing orchestrator. Activation requires all of the following:
+
+- `BILLING_DURABLE_ENABLED=true`;
+- `BILLING_APPROVED_POLICY_IDS` containing the explicitly approved policy IDs;
+- `BILLING_APPROVED_EXECUTION_CLASSES` containing every approved execution
+  class;
+- the additive migration applied through a separately authorized process;
+- all required relations and validated constraints present;
+- each approved policy active and each approved execution class carrying a
+  positive database-configured credit price.
+
+Initialization fails closed if any requirement is absent. This change neither
+applies the migration nor sets these variables, calls Stripe/providers, or
+activates production billing.
+
+## Verification
+
+CI supplies PostgreSQL 17 and runs the real-database suite explicitly. That
+suite applies the version-controlled migrations to a disposable database and
+proves concurrent reservation, settlement, refund and monthly-grant behavior;
+authority mismatch rejection; rollback and lost-ack recovery; reconstruction;
+tenant isolation; customer-role denial; Stripe evidence isolation;
+reconciliation; and Text/Image/Video accounting.

--- a/index.js
+++ b/index.js
@@ -71,7 +71,10 @@ const {
 // per-execution-class scopes; for now every generation job authorizes
 // exactly this one bounded downstream capability.
 const GENERATION_EXECUTE_SCOPE = "generation:execute";
-const { createStripeBillingRouter } = require("./src/billing");
+const {
+  createPostgresBillingProductionComposition,
+  createStripeBillingRouter,
+} = require("./src/billing");
 
 function requireAdmin(req, res, next) {
   const adminKey = process.env.ADMIN_KEY;
@@ -476,6 +479,11 @@ async function createProductionApp({ env = process.env, logger = console } = {})
   const generationJobRepository = new PostgresGenerationJobRepository({
     pool: brandBrainRepository.pool,
   });
+  const billing = await createPostgresBillingProductionComposition({
+    pool: brandBrainRepository.pool,
+    env,
+    logger,
+  });
   const servicePrincipalVerifier = createServiceCredentialVerifierFromEnv({
     env,
   });
@@ -485,6 +493,7 @@ async function createProductionApp({ env = process.env, logger = console } = {})
       brandBrainRepository,
       customerTokenVerifier,
       generationJobRepository,
+      generationBillingOrchestrator: billing.generationBillingOrchestrator,
       servicePrincipalVerifier,
       logger,
     }),
@@ -492,6 +501,9 @@ async function createProductionApp({ env = process.env, logger = console } = {})
     brandBrainRepository,
     customerTokenVerifier,
     generationJobRepository,
+    billingRepository: billing.billingRepository,
+    billingService: billing.billingService,
+    generationBillingOrchestrator: billing.generationBillingOrchestrator,
     servicePrincipalVerifier,
   };
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "node index.js",
     "test": "node --test",
+    "test:billing:postgres": "node --test test/postgres-billing.integration.test.js",
     "test:brand-brain:integration": "node --test scripts/brand-brain-postgres-integration.js"
   },
   "dependencies": {

--- a/src/billing/errors.js
+++ b/src/billing/errors.js
@@ -6,6 +6,21 @@ class BillingError extends Error {
   }
 }
 
+class BillingConfigurationError extends BillingError {
+  constructor(message = "Durable billing is not configured") {
+    super("BILLING_NOT_CONFIGURED", message);
+  }
+}
+
+class BillingPersistenceError extends BillingError {
+  constructor() {
+    super(
+      "BILLING_PERSISTENCE_UNAVAILABLE",
+      "Durable billing persistence is unavailable"
+    );
+  }
+}
+
 class CommercialPolicyUnavailableError extends BillingError {
   constructor() {
     super(
@@ -82,7 +97,9 @@ class InvalidFinancialOperationError extends BillingError {
 }
 
 module.exports = {
+  BillingConfigurationError,
   BillingError,
+  BillingPersistenceError,
   CommercialPolicyUnavailableError,
   CreditAccountUnavailableError,
   DuplicateFinancialEffectError,

--- a/src/billing/index.js
+++ b/src/billing/index.js
@@ -7,11 +7,15 @@ const {
 const schema = require("./schema");
 const stripe = require("./stripe");
 const { BillingService } = require("./service");
+const postgres = require("./postgresRepository");
+const composition = require("./productionComposition");
 
 module.exports = {
   ...errors,
   ...schema,
   ...stripe,
+  ...postgres,
+  ...composition,
   BillingRepository,
   BillingService,
   InMemoryBillingRepository,

--- a/src/billing/postgresRepository.js
+++ b/src/billing/postgresRepository.js
@@ -1,0 +1,1370 @@
+const { randomUUID } = require("node:crypto");
+const {
+  BillingConfigurationError,
+  BillingError,
+  BillingPersistenceError,
+  CreditAccountUnavailableError,
+  DuplicateFinancialEffectError,
+  FinancialResourceUnavailableError,
+  IdempotencyConflictError,
+  InsufficientCreditsError,
+  InvalidFinancialOperationError,
+} = require("./errors");
+const { BillingRepository, ENTITLED_STATUSES, hashIntent } = require("./repository");
+const {
+  CommercialPolicySchema,
+  CreditAccountSchema,
+  CreditLedgerEntrySchema,
+  TenantEntitlementSchema,
+  identifier,
+} = require("./schema");
+const {
+  StripeBillingConflictError,
+  StripeBillingError,
+  StripeBillingResourceUnavailableError,
+  StripeEventConflictError,
+  StripeEventInProgressError,
+} = require("./stripe/errors");
+
+const GENERIC_ENTRY_TYPES = new Set([
+  "monthly_grant",
+  "bolt_on_grant",
+  "admin_adjustment",
+  "expiry_reset",
+]);
+const SETTLEMENT_TYPES = new Set(["reservation_release", "debit"]);
+const REQUIRED_RELATIONS = Object.freeze([
+  "public.commercial_policies",
+  "public.commercial_execution_prices",
+  "public.tenant_entitlements",
+  "public.credit_accounts",
+  "public.credit_ledger",
+  "public.generation_jobs",
+  "public.stripe_customer_mappings",
+  "public.stripe_subscription_mappings",
+  "public.stripe_webhook_events",
+  "public.stripe_bolt_on_payment_evidence",
+  "public.credit_account_balances_internal",
+]);
+
+const LEDGER_COLUMNS = Object.freeze([
+  "ledger_entry_id",
+  "account_id",
+  "tenant_id",
+  "entry_type",
+  "amount",
+  "balance_delta",
+  "reserved_delta",
+  "idempotency_key",
+  "intent_hash",
+  "project_id",
+  "generation_id",
+  "execution_id",
+  "transaction_correlation_id",
+  "entitlement_id",
+  "reference_period_start",
+  "reference_period_end",
+  "stripe_event_ref",
+  "payment_ref",
+  "provider_cost_evidence_ref",
+  "reservation_entry_id",
+  "debit_entry_id",
+  "occurred_at",
+  "created_at",
+]);
+
+function toIso(value) {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function toSafeInteger(value) {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isSafeInteger(parsed)) throw new BillingPersistenceError();
+  return parsed;
+}
+
+function omitNullish(value) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, field]) => field !== null && field !== undefined)
+  );
+}
+
+function mapEntitlement(row) {
+  if (!row) return null;
+  return TenantEntitlementSchema.parse({
+    entitlement_id: row.entitlement_id,
+    tenant_id: row.tenant_id,
+    policy_id: row.policy_id,
+    plan_code: row.plan_code,
+    status: row.status,
+    starts_at: toIso(row.starts_at),
+    ends_at: row.ends_at ? toIso(row.ends_at) : null,
+    reference_period_start: toIso(row.reference_period_start),
+    reference_period_end: toIso(row.reference_period_end),
+    included_monthly_credit_grant: toSafeInteger(
+      row.included_monthly_credit_grant
+    ),
+    stripe_subscription_ref: row.stripe_subscription_ref || null,
+    cancellation_effective_at: row.cancellation_effective_at
+      ? toIso(row.cancellation_effective_at)
+      : null,
+    grace_ends_at: row.grace_ends_at ? toIso(row.grace_ends_at) : null,
+  });
+}
+
+function mapPolicy(row) {
+  if (!row) return null;
+  const costs = Object.fromEntries(
+    Object.entries(row.execution_costs || {}).map(([key, value]) => [
+      key,
+      toSafeInteger(value),
+    ])
+  );
+  return CommercialPolicySchema.parse({
+    policy_id: row.policy_id,
+    plan_code: row.plan_code,
+    policy_version: toSafeInteger(row.policy_version),
+    status: row.status,
+    included_monthly_credits: toSafeInteger(row.included_monthly_credits),
+    bolt_on_eligible: row.bolt_on_eligible,
+    effective_from: toIso(row.effective_from),
+    effective_to: row.effective_to ? toIso(row.effective_to) : null,
+    execution_costs: costs,
+  });
+}
+
+function mapAccount(row) {
+  if (!row) return null;
+  return CreditAccountSchema.parse({
+    account_id: row.account_id,
+    tenant_id: row.tenant_id,
+    status: row.status,
+    created_at: toIso(row.created_at),
+  });
+}
+
+function mapLedger(row) {
+  if (!row) return null;
+  return CreditLedgerEntrySchema.parse(
+    omitNullish({
+      ...Object.fromEntries(LEDGER_COLUMNS.map((column) => [column, row[column]])),
+      amount: toSafeInteger(row.amount),
+      balance_delta: toSafeInteger(row.balance_delta),
+      reserved_delta: toSafeInteger(row.reserved_delta),
+      reference_period_start: row.reference_period_start
+        ? toIso(row.reference_period_start)
+        : undefined,
+      reference_period_end: row.reference_period_end
+        ? toIso(row.reference_period_end)
+        : undefined,
+      occurred_at: toIso(row.occurred_at),
+      created_at: toIso(row.created_at),
+    })
+  );
+}
+
+function mapStripeSubscription(row) {
+  if (!row) return null;
+  return {
+    stripe_subscription_id: row.stripe_subscription_id,
+    tenant_id: row.tenant_id,
+    stripe_customer_id: row.stripe_customer_id,
+    entitlement_id: row.entitlement_id,
+    policy_id: row.policy_id,
+    plan_code: row.plan_code,
+    stripe_price_id: row.stripe_price_id,
+    stripe_status: row.stripe_status,
+    entitlement_status: row.entitlement_status,
+    livemode: row.livemode,
+    last_event_created: toIso(row.last_event_created),
+    last_event_id: row.last_event_id,
+    updated_at: toIso(row.updated_at),
+  };
+}
+
+function knownError(error) {
+  return error instanceof BillingError || error instanceof StripeBillingError;
+}
+
+function databaseError(error) {
+  if (knownError(error)) return error;
+  if (
+    error?.code === "23505" &&
+    [
+      "credit_ledger_idempotency_global_unique",
+      "credit_ledger_account_idempotency_unique",
+    ].includes(error.constraint)
+  ) {
+    return new IdempotencyConflictError();
+  }
+  if (
+    error?.code === "23505" &&
+    [
+      "credit_ledger_monthly_grant_unique",
+      "credit_ledger_bolt_on_payment_unique",
+      "credit_ledger_generation_reservation_unique",
+      "credit_ledger_reservation_settlement_unique",
+      "credit_ledger_debit_refund_unique",
+    ].includes(error.constraint)
+  ) {
+    return new DuplicateFinancialEffectError();
+  }
+  return new BillingPersistenceError();
+}
+
+function logicalEffectQuery(input) {
+  switch (input.entry_type) {
+    case "monthly_grant":
+      return {
+        sql: "entry_type = 'monthly_grant' AND entitlement_id = $2 AND reference_period_start = $3",
+        values: [input.entitlement_id, input.reference_period_start],
+      };
+    case "bolt_on_grant":
+      return {
+        sql: "entry_type = 'bolt_on_grant' AND payment_ref = $2",
+        values: [input.payment_ref],
+      };
+    case "reservation":
+      return {
+        sql: "entry_type = 'reservation' AND generation_id = $2",
+        values: [input.generation_id],
+      };
+    case "reservation_release":
+    case "debit":
+      return {
+        sql: "entry_type IN ('reservation_release', 'debit') AND reservation_entry_id = $2",
+        values: [input.reservation_entry_id],
+      };
+    case "refund":
+      return {
+        sql: "entry_type = 'refund' AND debit_entry_id = $2",
+        values: [input.debit_entry_id],
+      };
+    default:
+      return null;
+  }
+}
+
+class PostgresBillingRepository extends BillingRepository {
+  constructor({
+    pool,
+    now = () => new Date(),
+    idFactory = () => `ledger_${randomUUID()}`,
+    entitlementIdFactory = () => `entitlement_${randomUUID()}`,
+  }) {
+    super();
+    if (
+      !pool ||
+      typeof pool.query !== "function" ||
+      typeof pool.connect !== "function"
+    ) {
+      throw new BillingConfigurationError(
+        "A transactional PostgreSQL connection pool is required"
+      );
+    }
+    this.pool = pool;
+    this.now = now;
+    this.idFactory = idFactory;
+    this.entitlementIdFactory = entitlementIdFactory;
+  }
+
+  timestamp() {
+    return this.now().toISOString();
+  }
+
+  // Overridable only for deterministic transaction-boundary tests.
+  async beforeCommit() {}
+
+  // Overridable only for deterministic lost-ack tests. This runs after COMMIT.
+  async afterCommit() {}
+
+  async withTransaction(operation, { readOnly = false, observe = true } = {}) {
+    let client;
+    let transactionOpen = false;
+    try {
+      client = await this.pool.connect();
+      await client.query(
+        readOnly
+          ? "BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY"
+          : "BEGIN"
+      );
+      transactionOpen = true;
+      const result = await operation(client);
+      if (observe) await this.beforeCommit();
+      await client.query("COMMIT");
+      transactionOpen = false;
+      if (observe) await this.afterCommit();
+      return result;
+    } catch (error) {
+      if (client && transactionOpen) {
+        await client.query("ROLLBACK").catch(() => {});
+      }
+      throw databaseError(error);
+    } finally {
+      client?.release();
+    }
+  }
+
+  async read(operation) {
+    try {
+      return await operation();
+    } catch (error) {
+      throw databaseError(error);
+    }
+  }
+
+  async initialize({ approvedPolicyIds = [], requiredExecutionClasses = [] } = {}) {
+    if (approvedPolicyIds.length === 0 || requiredExecutionClasses.length === 0) {
+      throw new BillingConfigurationError(
+        "Approved policy IDs and execution classes are required"
+      );
+    }
+    return this.read(async () => {
+      const relations = await this.pool.query(
+        `SELECT name, to_regclass(name) AS relation
+           FROM unnest($1::text[]) AS required(name)`,
+        [REQUIRED_RELATIONS]
+      );
+      if (relations.rows.some((row) => !row.relation)) {
+        throw new BillingConfigurationError(
+          "Durable billing database migrations are incomplete"
+        );
+      }
+
+      const guards = await this.pool.query(
+        `SELECT conname
+           FROM pg_constraint
+          WHERE conname IN (
+            'generation_jobs_job_tenant_project_unique',
+            'credit_ledger_generation_job_fkey',
+            'credit_ledger_generation_authority_shape'
+          )
+            AND convalidated`
+      );
+      const guardNames = new Set(guards.rows.map((row) => row.conname));
+      if (guardNames.size !== 3) {
+        throw new BillingConfigurationError(
+          "Durable billing authority constraints are incomplete"
+        );
+      }
+
+      const infrastructure = await this.pool.query(
+        `SELECT
+           to_regclass('public.credit_ledger_idempotency_global_unique')
+             AS idempotency_index,
+           EXISTS (
+             SELECT 1
+               FROM pg_trigger
+              WHERE tgrelid = 'public.credit_ledger'::regclass
+                AND tgname = 'validate_credit_ledger_authority'
+                AND tgenabled <> 'D'
+           ) AS authority_trigger`
+      );
+      if (
+        !infrastructure.rows[0]?.idempotency_index ||
+        !infrastructure.rows[0]?.authority_trigger
+      ) {
+        throw new BillingConfigurationError(
+          "Durable billing indexes or authority triggers are incomplete"
+        );
+      }
+
+      const unsafePrivileges = await this.pool.query(
+        `WITH financial_tables(relation) AS (
+           VALUES
+             ('public.commercial_policies'),
+             ('public.commercial_execution_prices'),
+             ('public.tenant_entitlements'),
+             ('public.credit_accounts'),
+             ('public.credit_ledger'),
+             ('public.stripe_customer_mappings'),
+             ('public.stripe_subscription_mappings'),
+             ('public.stripe_webhook_events'),
+             ('public.stripe_bolt_on_payment_evidence')
+         ), customer_roles(role_name) AS (
+           VALUES ('anon'), ('authenticated'), ('service_role')
+         )
+         SELECT role_name, relation
+           FROM financial_tables CROSS JOIN customer_roles
+          WHERE EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name)
+            AND has_table_privilege(
+              role_name,
+              relation,
+              'INSERT,UPDATE,DELETE'
+            )`
+      );
+      if (unsafePrivileges.rowCount !== 0) {
+        throw new BillingConfigurationError(
+          "Customer-facing roles retain authoritative billing mutation privileges"
+        );
+      }
+
+      const policies = await this.pool.query(
+        `SELECT policy.policy_id, price.execution_class, price.credit_cost
+           FROM public.commercial_policies AS policy
+           JOIN public.commercial_execution_prices AS price
+             ON price.policy_id = policy.policy_id
+          WHERE policy.policy_id = ANY($1::text[])
+            AND policy.status = 'active'
+            AND policy.effective_from <= $2::timestamptz
+            AND (policy.effective_to IS NULL OR $2::timestamptz < policy.effective_to)
+            AND price.execution_class = ANY($3::text[])
+            AND price.credit_cost > 0`,
+        [approvedPolicyIds, this.timestamp(), requiredExecutionClasses]
+      );
+      const configured = new Set(
+        policies.rows.map((row) => `${row.policy_id}\u0000${row.execution_class}`)
+      );
+      for (const policyId of approvedPolicyIds) {
+        for (const executionClass of requiredExecutionClasses) {
+          if (!configured.has(`${policyId}\u0000${executionClass}`)) {
+            throw new BillingConfigurationError(
+              "Approved execution-credit policy data is incomplete"
+            );
+          }
+        }
+      }
+      return true;
+    });
+  }
+
+  async getActiveEntitlement(tenantId, at) {
+    const tenant_id = identifier.parse(tenantId);
+    return this.read(async () => {
+      const result = await this.pool.query(
+        `SELECT entitlement_id, tenant_id, policy_id, plan_code, status,
+                starts_at, ends_at, reference_period_start,
+                reference_period_end, included_monthly_credit_grant,
+                stripe_subscription_ref, cancellation_effective_at,
+                grace_ends_at
+           FROM public.tenant_entitlements
+          WHERE tenant_id = $1
+            AND status = ANY($2::text[])
+            AND starts_at <= $3::timestamptz
+            AND (ends_at IS NULL OR $3::timestamptz < ends_at)
+          ORDER BY starts_at DESC
+          LIMIT 2`,
+        [tenant_id, [...ENTITLED_STATUSES], at]
+      );
+      if (result.rows.length > 1) {
+        throw new InvalidFinancialOperationError(
+          "Multiple serving entitlements were found for one tenant"
+        );
+      }
+      return mapEntitlement(result.rows[0]);
+    });
+  }
+
+  async getCommercialPolicy(policyId, at) {
+    const policy_id = identifier.parse(policyId);
+    return this.read(async () => {
+      const result = await this.pool.query(
+        `SELECT policy.policy_id, policy.plan_code, policy.policy_version,
+                policy.status, policy.included_monthly_credits,
+                policy.bolt_on_eligible, policy.effective_from,
+                policy.effective_to,
+                jsonb_object_agg(price.execution_class, price.credit_cost)
+                  AS execution_costs
+           FROM public.commercial_policies AS policy
+           JOIN public.commercial_execution_prices AS price
+             ON price.policy_id = policy.policy_id
+          WHERE policy.policy_id = $1
+            AND policy.status = 'active'
+            AND policy.effective_from <= $2::timestamptz
+            AND (policy.effective_to IS NULL OR $2::timestamptz < policy.effective_to)
+          GROUP BY policy.policy_id`,
+        [policy_id, at]
+      );
+      return mapPolicy(result.rows[0]);
+    });
+  }
+
+  async getCreditAccountByTenant(tenantId) {
+    const tenant_id = identifier.parse(tenantId);
+    return this.read(async () => {
+      const result = await this.pool.query(
+        `SELECT account_id, tenant_id, status, created_at
+           FROM public.credit_accounts
+          WHERE tenant_id = $1`,
+        [tenant_id]
+      );
+      return mapAccount(result.rows[0]);
+    });
+  }
+
+  async readBalance(tenantId) {
+    const tenant_id = identifier.parse(tenantId);
+    return this.read(async () => {
+      const result = await this.pool.query(
+        `SELECT account_id, tenant_id, ledger_balance, reserved_balance,
+                available_balance, debited_credits, refunded_credits,
+                net_spent_credits
+           FROM public.credit_account_balances_internal
+          WHERE tenant_id = $1`,
+        [tenant_id]
+      );
+      const row = result.rows[0];
+      if (!row) throw new CreditAccountUnavailableError();
+      return Object.freeze({
+        tenant_id: row.tenant_id,
+        account_id: row.account_id,
+        available_balance: toSafeInteger(row.available_balance),
+        reserved_balance: toSafeInteger(row.reserved_balance),
+        ledger_balance: toSafeInteger(row.ledger_balance),
+        debited_credits: toSafeInteger(row.debited_credits),
+        refunded_credits: toSafeInteger(row.refunded_credits),
+        net_spent_credits: toSafeInteger(row.net_spent_credits),
+      });
+    });
+  }
+
+  async listLedger(tenantId) {
+    const tenant_id = identifier.parse(tenantId);
+    return this.read(async () => {
+      const result = await this.pool.query(
+        `SELECT ${LEDGER_COLUMNS.join(", ")}
+           FROM public.credit_ledger
+          WHERE tenant_id = $1
+          ORDER BY created_at, ledger_entry_id`,
+        [tenant_id]
+      );
+      return result.rows.map(mapLedger);
+    });
+  }
+
+  async requireLockedAccount(client, tenantId) {
+    const result = await client.query(
+      `SELECT account_id, tenant_id, status, created_at
+         FROM public.credit_accounts
+        WHERE tenant_id = $1
+        FOR UPDATE`,
+      [tenantId]
+    );
+    const account = mapAccount(result.rows[0]);
+    if (!account || account.status !== "active") {
+      throw new CreditAccountUnavailableError();
+    }
+    return account;
+  }
+
+  async findReplay(client, account, idempotencyKey, intentHash) {
+    const result = await client.query(
+      `SELECT ${LEDGER_COLUMNS.join(", ")}
+         FROM public.credit_ledger
+        WHERE idempotency_key = $1`,
+      [idempotencyKey]
+    );
+    if (!result.rows[0]) return null;
+    const entry = mapLedger(result.rows[0]);
+    if (
+      entry.account_id !== account.account_id ||
+      entry.tenant_id !== account.tenant_id ||
+      entry.intent_hash !== intentHash
+    ) {
+      throw new IdempotencyConflictError();
+    }
+    return entry;
+  }
+
+  async rejectDuplicateEffect(client, accountId, input) {
+    const logical = logicalEffectQuery(input);
+    if (!logical) return;
+    const result = await client.query(
+      `SELECT ledger_entry_id
+         FROM public.credit_ledger
+        WHERE account_id = $1 AND ${logical.sql}
+        LIMIT 1`,
+      [accountId, ...logical.values]
+    );
+    if (result.rows[0]) throw new DuplicateFinancialEffectError();
+  }
+
+  async verifyAppendAuthority(client, account, input) {
+    if (input.entry_type === "reservation") {
+      const job = await client.query(
+        `SELECT job.execution_class, price.credit_cost
+           FROM public.generation_jobs AS job
+           JOIN public.tenant_entitlements AS entitlement
+             ON entitlement.tenant_id = job.tenant_id
+            AND entitlement.status = ANY($6::text[])
+            AND entitlement.starts_at <= $7::timestamptz
+            AND (entitlement.ends_at IS NULL OR $7::timestamptz < entitlement.ends_at)
+           JOIN public.commercial_policies AS policy
+             ON policy.policy_id = entitlement.policy_id
+            AND policy.plan_code = entitlement.plan_code
+            AND policy.status = 'active'
+            AND policy.effective_from <= $7::timestamptz
+            AND (policy.effective_to IS NULL OR $7::timestamptz < policy.effective_to)
+           JOIN public.commercial_execution_prices AS price
+             ON price.policy_id = policy.policy_id
+            AND price.execution_class = job.execution_class
+          WHERE job.job_id = $1
+            AND job.tenant_id = $2
+            AND job.project_id = $3
+            AND job.request_correlation_id = $4
+            AND job.request_correlation_id = $5`,
+        [
+          input.generation_id,
+          account.tenant_id,
+          input.project_id,
+          input.execution_id,
+          input.transaction_correlation_id,
+          [...ENTITLED_STATUSES],
+          input.occurred_at || this.timestamp(),
+        ]
+      );
+      if (
+        job.rows.length !== 1 ||
+        toSafeInteger(job.rows[0].credit_cost) !== input.amount
+      ) {
+        throw new FinancialResourceUnavailableError();
+      }
+      return;
+    }
+
+    if (input.entry_type === "monthly_grant") {
+      const entitlement = await client.query(
+        `SELECT 1
+           FROM public.tenant_entitlements
+          WHERE entitlement_id = $1
+            AND tenant_id = $2
+            AND included_monthly_credit_grant = $3
+            AND reference_period_start = $4::timestamptz
+            AND reference_period_end = $5::timestamptz`,
+        [
+          input.entitlement_id,
+          account.tenant_id,
+          input.amount,
+          input.reference_period_start,
+          input.reference_period_end,
+        ]
+      );
+      if (entitlement.rowCount !== 1) {
+        throw new FinancialResourceUnavailableError();
+      }
+      return;
+    }
+
+    if (input.entry_type === "bolt_on_grant") {
+      const evidence = await client.query(
+        `SELECT 1
+           FROM public.stripe_bolt_on_payment_evidence
+          WHERE payment_reference = $1
+            AND tenant_id = $2
+            AND credits = $3
+            AND status = 'verified'
+            AND ($4::text IS NULL OR stripe_event_id = $4)`,
+        [
+          input.payment_ref,
+          account.tenant_id,
+          input.amount,
+          input.stripe_event_ref || null,
+        ]
+      );
+      if (evidence.rowCount !== 1) {
+        throw new FinancialResourceUnavailableError();
+      }
+    }
+  }
+
+  async appendLocked(client, account, input) {
+    const intentHash = hashIntent({
+      ...input,
+      account_id: account.account_id,
+      tenant_id: account.tenant_id,
+    });
+    const replay = await this.findReplay(
+      client,
+      account,
+      input.idempotency_key,
+      intentHash
+    );
+    if (replay) return replay;
+
+    await this.rejectDuplicateEffect(client, account.account_id, input);
+    await this.verifyAppendAuthority(client, account, input);
+
+    const occurredAt = input.occurred_at || this.timestamp();
+    const candidate = CreditLedgerEntrySchema.parse({
+      ...input,
+      ledger_entry_id: this.idFactory(),
+      account_id: account.account_id,
+      tenant_id: account.tenant_id,
+      intent_hash: intentHash,
+      occurred_at: occurredAt,
+      created_at: this.timestamp(),
+    });
+    const balance = await client.query(
+      `SELECT COALESCE(SUM(balance_delta), 0)::bigint AS ledger_balance,
+              COALESCE(SUM(reserved_delta), 0)::bigint AS reserved_balance
+         FROM public.credit_ledger
+        WHERE account_id = $1`,
+      [account.account_id]
+    );
+    const projectedLedger =
+      toSafeInteger(balance.rows[0].ledger_balance) + candidate.balance_delta;
+    const projectedReserved =
+      toSafeInteger(balance.rows[0].reserved_balance) + candidate.reserved_delta;
+    if (projectedReserved < 0 || projectedLedger - projectedReserved < 0) {
+      throw new InsufficientCreditsError();
+    }
+
+    const values = LEDGER_COLUMNS.map((column) => candidate[column] ?? null);
+    const placeholders = LEDGER_COLUMNS.map((_, index) => `$${index + 1}`);
+    const result = await client.query(
+      `INSERT INTO public.credit_ledger (${LEDGER_COLUMNS.join(", ")})
+       VALUES (${placeholders.join(", ")})
+       RETURNING ${LEDGER_COLUMNS.join(", ")}`,
+      values
+    );
+    return mapLedger(result.rows[0]);
+  }
+
+  async appendFinancialTransaction(input) {
+    if (!GENERIC_ENTRY_TYPES.has(input.entry_type)) {
+      throw new InvalidFinancialOperationError(
+        "Reservation, debit, release, and refund require dedicated operations"
+      );
+    }
+    return this.withTransaction(async (client) => {
+      const account = await this.requireLockedAccount(client, input.tenant_id);
+      return this.appendLocked(client, account, input);
+    });
+  }
+
+  async createReservation(input) {
+    return this.withTransaction(async (client) => {
+      const account = await this.requireLockedAccount(client, input.tenant_id);
+      return this.appendLocked(client, account, {
+        ...input,
+        entry_type: "reservation",
+        balance_delta: 0,
+        reserved_delta: input.amount,
+      });
+    });
+  }
+
+  async requireRelatedEntry(client, account, entryId, expectedType) {
+    const result = await client.query(
+      `SELECT ${LEDGER_COLUMNS.join(", ")}
+         FROM public.credit_ledger
+        WHERE ledger_entry_id = $1
+          AND account_id = $2
+          AND tenant_id = $3
+          AND entry_type = $4`,
+      [entryId, account.account_id, account.tenant_id, expectedType]
+    );
+    const entry = mapLedger(result.rows[0]);
+    if (!entry) throw new FinancialResourceUnavailableError();
+    return entry;
+  }
+
+  async settleReservation(input, entryType) {
+    return this.withTransaction(async (client) => {
+      const account = await this.requireLockedAccount(client, input.tenant_id);
+      const reservation = await this.requireRelatedEntry(
+        client,
+        account,
+        input.reservation_entry_id,
+        "reservation"
+      );
+      return this.appendLocked(client, account, {
+        ...input,
+        amount: reservation.amount,
+        project_id: reservation.project_id,
+        generation_id: reservation.generation_id,
+        execution_id: reservation.execution_id,
+        transaction_correlation_id: reservation.transaction_correlation_id,
+        entry_type: entryType,
+        balance_delta: entryType === "debit" ? -reservation.amount : 0,
+        reserved_delta: -reservation.amount,
+      });
+    });
+  }
+
+  async releaseReservation(input) {
+    return this.settleReservation(input, "reservation_release");
+  }
+
+  async finalizeDebit(input) {
+    return this.settleReservation(input, "debit");
+  }
+
+  async refund(input) {
+    return this.withTransaction(async (client) => {
+      const account = await this.requireLockedAccount(client, input.tenant_id);
+      const debit = await this.requireRelatedEntry(
+        client,
+        account,
+        input.debit_entry_id,
+        "debit"
+      );
+      return this.appendLocked(client, account, {
+        ...input,
+        amount: debit.amount,
+        project_id: debit.project_id,
+        generation_id: debit.generation_id,
+        execution_id: debit.execution_id,
+        transaction_correlation_id: debit.transaction_correlation_id,
+        reservation_entry_id: undefined,
+        entry_type: "refund",
+        balance_delta: debit.amount,
+        reserved_delta: 0,
+      });
+    });
+  }
+
+  async getStripeCustomerByTenant(tenantId) {
+    const tenant_id = identifier.parse(tenantId);
+    return this.read(async () => {
+      const result = await this.pool.query(
+        `SELECT tenant_id, stripe_customer_id, livemode, created_at
+           FROM public.stripe_customer_mappings
+          WHERE tenant_id = $1`,
+        [tenant_id]
+      );
+      const row = result.rows[0];
+      return row ? { ...row, created_at: toIso(row.created_at) } : null;
+    });
+  }
+
+  async getStripeCustomerById(stripeCustomerId) {
+    const customerId = identifier.parse(stripeCustomerId);
+    return this.read(async () => {
+      const result = await this.pool.query(
+        `SELECT tenant_id, stripe_customer_id, livemode, created_at
+           FROM public.stripe_customer_mappings
+          WHERE stripe_customer_id = $1`,
+        [customerId]
+      );
+      const row = result.rows[0];
+      return row ? { ...row, created_at: toIso(row.created_at) } : null;
+    });
+  }
+
+  async createStripeCustomerMapping(input) {
+    const candidate = {
+      tenant_id: identifier.parse(input.tenant_id),
+      stripe_customer_id: identifier.parse(input.stripe_customer_id),
+      livemode: Boolean(input.livemode),
+      created_at: input.created_at || this.timestamp(),
+    };
+    return this.withTransaction(async (client) => {
+      const inserted = await client.query(
+        `INSERT INTO public.stripe_customer_mappings
+           (tenant_id, stripe_customer_id, livemode, created_at)
+         VALUES ($1, $2, $3, $4)
+         ON CONFLICT DO NOTHING
+         RETURNING tenant_id, stripe_customer_id, livemode, created_at`,
+        Object.values(candidate)
+      );
+      const row = inserted.rows[0] || (
+        await client.query(
+          `SELECT tenant_id, stripe_customer_id, livemode, created_at
+             FROM public.stripe_customer_mappings
+            WHERE tenant_id = $1 OR stripe_customer_id = $2
+            FOR UPDATE`,
+          [candidate.tenant_id, candidate.stripe_customer_id]
+        )
+      ).rows[0];
+      if (
+        !row ||
+        row.tenant_id !== candidate.tenant_id ||
+        row.stripe_customer_id !== candidate.stripe_customer_id ||
+        row.livemode !== candidate.livemode
+      ) {
+        throw new StripeBillingConflictError();
+      }
+      return { ...row, created_at: toIso(row.created_at) };
+    });
+  }
+
+  async getStripeSubscription(stripeSubscriptionId) {
+    const subscriptionId = identifier.parse(stripeSubscriptionId);
+    return this.read(async () => {
+      const result = await this.pool.query(
+        `SELECT * FROM public.stripe_subscription_mappings
+          WHERE stripe_subscription_id = $1`,
+        [subscriptionId]
+      );
+      return mapStripeSubscription(result.rows[0]);
+    });
+  }
+
+  async applyStripeSubscriptionState(input) {
+    const tenantId = identifier.parse(input.tenant_id);
+    const subscriptionId = identifier.parse(input.stripe_subscription_id);
+    const customerId = identifier.parse(input.stripe_customer_id);
+    const eventId = identifier.parse(input.event_id);
+    return this.withTransaction(async (client) => {
+      const customer = await client.query(
+        `SELECT tenant_id, stripe_customer_id, livemode
+           FROM public.stripe_customer_mappings
+          WHERE tenant_id = $1 AND stripe_customer_id = $2
+          FOR KEY SHARE`,
+        [tenantId, customerId]
+      );
+      if (
+        customer.rowCount !== 1 ||
+        customer.rows[0].livemode !== Boolean(input.livemode)
+      ) {
+        throw new StripeBillingResourceUnavailableError();
+      }
+
+      const mappingResult = await client.query(
+        `SELECT * FROM public.stripe_subscription_mappings
+          WHERE stripe_subscription_id = $1
+          FOR UPDATE`,
+        [subscriptionId]
+      );
+      const existingMapping = mapStripeSubscription(mappingResult.rows[0]);
+      let existingEntitlement = null;
+      if (existingMapping) {
+        const entitlementResult = await client.query(
+          `SELECT * FROM public.tenant_entitlements
+            WHERE entitlement_id = $1 AND tenant_id = $2
+            FOR UPDATE`,
+          [existingMapping.entitlement_id, tenantId]
+        );
+        existingEntitlement = mapEntitlement(entitlementResult.rows[0]);
+        for (const [field, value] of [
+          ["tenant_id", tenantId],
+          ["stripe_customer_id", customerId],
+          ["policy_id", input.policy_id],
+          ["plan_code", input.plan_code],
+          ["stripe_price_id", input.stripe_price_id],
+          ["livemode", Boolean(input.livemode)],
+        ]) {
+          if (existingMapping[field] !== value) {
+            throw new StripeBillingConflictError();
+          }
+        }
+        const stale = (reason) => Object.freeze({
+          stale: true,
+          stale_reason: reason,
+          mapping: existingMapping,
+          entitlement: existingEntitlement,
+        });
+        if (eventId === existingMapping.last_event_id) return stale("same_event");
+        const incomingTime = Date.parse(input.event_created);
+        const existingTime = Date.parse(existingMapping.last_event_created);
+        if (incomingTime < existingTime) return stale("older_event");
+        const existingTerminal =
+          existingMapping.stripe_status === "canceled" ||
+          existingEntitlement?.status === "cancelled";
+        const incomingTerminal = input.entitlement_status === "cancelled";
+        if (incomingTime === existingTime) {
+          if (existingTerminal) return stale("terminal_state");
+          if (!incomingTerminal) return stale("same_second_ambiguous");
+        } else if (existingTerminal && !incomingTerminal) {
+          return stale("terminal_state");
+        }
+      }
+
+      let entitlement = existingEntitlement;
+      if (!entitlement) {
+        const candidates = await client.query(
+          `SELECT * FROM public.tenant_entitlements
+            WHERE tenant_id = $1
+              AND policy_id = $2
+              AND (stripe_subscription_ref = $3 OR stripe_subscription_ref IS NULL)
+            ORDER BY (stripe_subscription_ref = $3) DESC
+            FOR UPDATE`,
+          [tenantId, input.policy_id, subscriptionId]
+        );
+        const exact = candidates.rows.filter(
+          (row) => row.stripe_subscription_ref === subscriptionId
+        );
+        const unbound = candidates.rows.filter((row) => !row.stripe_subscription_ref);
+        if (exact.length > 1 || (exact.length === 0 && unbound.length > 1)) {
+          throw new StripeBillingConflictError();
+        }
+        entitlement = mapEntitlement(exact[0] || unbound[0]);
+      }
+      if (entitlement && entitlement.tenant_id !== tenantId) {
+        throw new StripeBillingConflictError();
+      }
+      if (
+        entitlement &&
+        (entitlement.policy_id !== input.policy_id ||
+          entitlement.plan_code !== input.plan_code)
+      ) {
+        throw new StripeBillingConflictError(
+          "A Stripe event cannot change a historical commercial policy version"
+        );
+      }
+
+      if (ENTITLED_STATUSES.has(input.entitlement_status)) {
+        const other = await client.query(
+          `SELECT 1 FROM public.tenant_entitlements
+            WHERE tenant_id = $1
+              AND entitlement_id <> $2
+              AND status = ANY($3::text[])
+            LIMIT 1`,
+          [tenantId, entitlement?.entitlement_id || "", [...ENTITLED_STATUSES]]
+        );
+        if (other.rowCount) throw new StripeBillingConflictError();
+      }
+
+      const next = TenantEntitlementSchema.parse({
+        entitlement_id: entitlement?.entitlement_id || this.entitlementIdFactory(),
+        tenant_id: tenantId,
+        policy_id: entitlement?.policy_id || input.policy_id,
+        plan_code: entitlement?.plan_code || input.plan_code,
+        status: input.entitlement_status,
+        starts_at: entitlement?.starts_at || input.starts_at,
+        ends_at: input.ends_at,
+        reference_period_start: input.reference_period_start,
+        reference_period_end: input.reference_period_end,
+        included_monthly_credit_grant:
+          entitlement?.included_monthly_credit_grant ??
+          input.included_monthly_credit_grant,
+        stripe_subscription_ref: subscriptionId,
+        cancellation_effective_at: input.cancellation_effective_at,
+        grace_ends_at: input.grace_ends_at,
+      });
+      if (entitlement) {
+        await client.query(
+          `UPDATE public.tenant_entitlements
+              SET status = $2, ends_at = $3, reference_period_start = $4,
+                  reference_period_end = $5, stripe_subscription_ref = $6,
+                  cancellation_effective_at = $7, grace_ends_at = $8,
+                  updated_at = $9
+            WHERE entitlement_id = $1`,
+          [
+            next.entitlement_id,
+            next.status,
+            next.ends_at || null,
+            next.reference_period_start,
+            next.reference_period_end,
+            subscriptionId,
+            next.cancellation_effective_at || null,
+            next.grace_ends_at || null,
+            this.timestamp(),
+          ]
+        );
+      } else {
+        await client.query(
+          `INSERT INTO public.tenant_entitlements
+             (entitlement_id, tenant_id, policy_id, plan_code, status,
+              starts_at, ends_at, reference_period_start, reference_period_end,
+              included_monthly_credit_grant, stripe_subscription_ref,
+              cancellation_effective_at, grace_ends_at)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`,
+          [
+            next.entitlement_id,
+            next.tenant_id,
+            next.policy_id,
+            next.plan_code,
+            next.status,
+            next.starts_at,
+            next.ends_at || null,
+            next.reference_period_start,
+            next.reference_period_end,
+            next.included_monthly_credit_grant,
+            subscriptionId,
+            next.cancellation_effective_at || null,
+            next.grace_ends_at || null,
+          ]
+        );
+      }
+
+      const mappingValues = [
+        subscriptionId,
+        tenantId,
+        customerId,
+        next.entitlement_id,
+        next.policy_id,
+        next.plan_code,
+        identifier.parse(input.stripe_price_id),
+        input.stripe_status,
+        next.status,
+        Boolean(input.livemode),
+        input.event_created,
+        eventId,
+        this.timestamp(),
+      ];
+      const storedMapping = await client.query(
+        `INSERT INTO public.stripe_subscription_mappings
+           (stripe_subscription_id, tenant_id, stripe_customer_id,
+            entitlement_id, policy_id, plan_code, stripe_price_id,
+            stripe_status, entitlement_status, livemode, last_event_created,
+            last_event_id, updated_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+         ON CONFLICT (stripe_subscription_id) DO UPDATE SET
+           stripe_status = EXCLUDED.stripe_status,
+           entitlement_status = EXCLUDED.entitlement_status,
+           last_event_created = EXCLUDED.last_event_created,
+           last_event_id = EXCLUDED.last_event_id,
+           updated_at = EXCLUDED.updated_at
+         RETURNING *`,
+        mappingValues
+      );
+      return Object.freeze({
+        stale: false,
+        mapping: mapStripeSubscription(storedMapping.rows[0]),
+        entitlement: next,
+      });
+    });
+  }
+
+  async beginStripeEvent(input) {
+    const eventId = identifier.parse(input.event_id);
+    return this.withTransaction(async (client) => {
+      const inserted = await client.query(
+        `INSERT INTO public.stripe_webhook_events
+           (stripe_event_id, event_type, livemode, intent_hash, status, received_at)
+         VALUES ($1, $2, $3, $4, 'processing', $5)
+         ON CONFLICT DO NOTHING
+         RETURNING stripe_event_id`,
+        [
+          eventId,
+          input.event_type,
+          Boolean(input.livemode),
+          input.intent_hash,
+          input.received_at || this.timestamp(),
+        ]
+      );
+      if (inserted.rowCount === 1) return Object.freeze({ replay: false });
+      const existingResult = await client.query(
+        `SELECT * FROM public.stripe_webhook_events
+          WHERE stripe_event_id = $1
+          FOR UPDATE`,
+        [eventId]
+      );
+      const existing = existingResult.rows[0];
+      if (
+        !existing ||
+        existing.event_type !== input.event_type ||
+        existing.livemode !== Boolean(input.livemode) ||
+        existing.intent_hash !== input.intent_hash
+      ) {
+        throw new StripeEventConflictError();
+      }
+      if (existing.status === "processed") {
+        return Object.freeze({ replay: true, result: existing.result });
+      }
+      if (existing.status === "failed") {
+        await client.query(
+          `UPDATE public.stripe_webhook_events
+              SET status = 'processing'
+            WHERE stripe_event_id = $1`,
+          [eventId]
+        );
+        return Object.freeze({ replay: false });
+      }
+      throw new StripeEventInProgressError();
+    });
+  }
+
+  async completeStripeEvent({ event_id, result }) {
+    const eventId = identifier.parse(event_id);
+    return this.withTransaction(async (client) => {
+      const updated = await client.query(
+        `UPDATE public.stripe_webhook_events
+            SET status = 'processed', result = $2::jsonb,
+                processed_at = $3
+          WHERE stripe_event_id = $1 AND status = 'processing'
+          RETURNING *`,
+        [eventId, JSON.stringify(result), this.timestamp()]
+      );
+      if (updated.rowCount !== 1) throw new StripeEventConflictError();
+      return updated.rows[0];
+    });
+  }
+
+  async abandonStripeEvent(eventId) {
+    const parsed = identifier.parse(eventId);
+    return this.withTransaction(async (client) => {
+      await client.query(
+        `UPDATE public.stripe_webhook_events
+            SET status = 'failed'
+          WHERE stripe_event_id = $1 AND status = 'processing'`,
+        [parsed]
+      );
+    });
+  }
+
+  async recordBoltOnPaymentEvidence(input) {
+    const candidate = {
+      payment_reference: identifier.parse(input.payment_reference),
+      stripe_event_id: identifier.parse(input.stripe_event_id),
+      tenant_id: identifier.parse(input.tenant_id),
+      stripe_customer_id: identifier.parse(input.stripe_customer_id),
+      stripe_price_id: identifier.parse(input.stripe_price_id),
+      credits: toSafeInteger(input.credits),
+      status: "verified",
+    };
+    return this.withTransaction(async (client) => {
+      const customer = await client.query(
+        `SELECT 1 FROM public.stripe_customer_mappings
+          WHERE tenant_id = $1 AND stripe_customer_id = $2`,
+        [candidate.tenant_id, candidate.stripe_customer_id]
+      );
+      if (customer.rowCount !== 1) {
+        throw new StripeBillingResourceUnavailableError();
+      }
+      const inserted = await client.query(
+        `INSERT INTO public.stripe_bolt_on_payment_evidence
+           (payment_reference, stripe_event_id, tenant_id, stripe_customer_id,
+            stripe_price_id, credits, status)
+         VALUES ($1,$2,$3,$4,$5,$6,$7)
+         ON CONFLICT DO NOTHING
+         RETURNING *`,
+        Object.values(candidate)
+      );
+      const row = inserted.rows[0] || (
+        await client.query(
+          `SELECT * FROM public.stripe_bolt_on_payment_evidence
+            WHERE payment_reference = $1 OR stripe_event_id = $2`,
+          [candidate.payment_reference, candidate.stripe_event_id]
+        )
+      ).rows[0];
+      if (
+        !row ||
+        Object.entries(candidate).some(([key, value]) =>
+          key === "credits"
+            ? toSafeInteger(row[key]) !== value
+            : row[key] !== value
+        )
+      ) {
+        throw new StripeBillingConflictError();
+      }
+      return { ...candidate, created_at: toIso(row.created_at) };
+    });
+  }
+
+  async reconcile({ olderThan, limit = 100 }) {
+    const boundedLimit = Math.max(1, Math.min(toSafeInteger(limit), 500));
+    return this.withTransaction(
+      async (client) => {
+        const stale = await client.query(
+          `SELECT reservation.*
+             FROM public.credit_ledger AS reservation
+            WHERE reservation.entry_type = 'reservation'
+              AND reservation.occurred_at < $1::timestamptz
+              AND NOT EXISTS (
+                SELECT 1 FROM public.credit_ledger AS settlement
+                 WHERE settlement.account_id = reservation.account_id
+                   AND settlement.reservation_entry_id = reservation.ledger_entry_id
+                   AND settlement.entry_type IN ('debit', 'reservation_release')
+              )
+            ORDER BY reservation.occurred_at
+            LIMIT $2`,
+          [olderThan, boundedLimit]
+        );
+        const invalidSettlements = await client.query(
+          `SELECT settlement.ledger_entry_id, settlement.tenant_id,
+                  settlement.reservation_entry_id, settlement.entry_type,
+                  'reservation_authority_mismatch' AS reason
+             FROM public.credit_ledger AS settlement
+             LEFT JOIN public.credit_ledger AS reservation
+               ON reservation.ledger_entry_id = settlement.reservation_entry_id
+              AND reservation.account_id = settlement.account_id
+              AND reservation.tenant_id = settlement.tenant_id
+            WHERE settlement.entry_type IN ('debit', 'reservation_release')
+              AND (
+                reservation.entry_type IS DISTINCT FROM 'reservation'
+                OR settlement.amount IS DISTINCT FROM reservation.amount
+                OR settlement.generation_id IS DISTINCT FROM reservation.generation_id
+                OR settlement.project_id IS DISTINCT FROM reservation.project_id
+                OR settlement.execution_id IS DISTINCT FROM reservation.execution_id
+              )
+            LIMIT $1`,
+          [boundedLimit]
+        );
+        const orphanRefunds = await client.query(
+          `SELECT refund.ledger_entry_id, refund.tenant_id, refund.debit_entry_id,
+                  'debit_authority_mismatch' AS reason
+             FROM public.credit_ledger AS refund
+             LEFT JOIN public.credit_ledger AS debit
+               ON debit.ledger_entry_id = refund.debit_entry_id
+              AND debit.account_id = refund.account_id
+              AND debit.tenant_id = refund.tenant_id
+            WHERE refund.entry_type = 'refund'
+              AND (
+                debit.entry_type IS DISTINCT FROM 'debit'
+                OR refund.amount IS DISTINCT FROM debit.amount
+                OR refund.generation_id IS DISTINCT FROM debit.generation_id
+              )
+            LIMIT $1`,
+          [boundedLimit]
+        );
+        const duplicates = await client.query(
+          `WITH effects AS (
+             SELECT account_id,
+                    CASE entry_type
+                      WHEN 'monthly_grant' THEN 'monthly:' || entitlement_id || ':' || reference_period_start::text
+                      WHEN 'bolt_on_grant' THEN 'bolt-on:' || payment_ref
+                      WHEN 'reservation' THEN 'reservation:' || generation_id
+                      WHEN 'reservation_release' THEN 'settlement:' || reservation_entry_id
+                      WHEN 'debit' THEN 'settlement:' || reservation_entry_id
+                      WHEN 'refund' THEN 'refund:' || debit_entry_id
+                    END AS logical_key,
+                    ledger_entry_id
+               FROM public.credit_ledger
+              WHERE entry_type IN (
+                'monthly_grant', 'bolt_on_grant', 'reservation',
+                'reservation_release', 'debit', 'refund'
+              )
+           )
+           SELECT account_id, logical_key,
+                  array_agg(ledger_entry_id ORDER BY ledger_entry_id) AS ledger_entry_ids
+             FROM effects
+            GROUP BY account_id, logical_key
+           HAVING count(*) > 1
+            LIMIT $1`,
+          [boundedLimit]
+        );
+        const monthly = await client.query(
+          `SELECT grant_entry.ledger_entry_id, grant_entry.tenant_id,
+                  grant_entry.entitlement_id,
+                  'grant_authority_mismatch' AS reason
+             FROM public.credit_ledger AS grant_entry
+             LEFT JOIN public.tenant_entitlements AS entitlement
+               ON entitlement.entitlement_id = grant_entry.entitlement_id
+              AND entitlement.tenant_id = grant_entry.tenant_id
+            WHERE grant_entry.entry_type = 'monthly_grant'
+              AND (
+                entitlement.entitlement_id IS NULL
+                OR grant_entry.amount <> entitlement.included_monthly_credit_grant
+                OR grant_entry.reference_period_end <= grant_entry.reference_period_start
+                OR (
+                  grant_entry.reference_period_start = entitlement.reference_period_start
+                  AND grant_entry.reference_period_end IS DISTINCT FROM entitlement.reference_period_end
+                )
+              )
+           UNION ALL
+           SELECT NULL, entitlement.tenant_id, entitlement.entitlement_id,
+                  'current_period_grant_missing'
+             FROM public.tenant_entitlements AS entitlement
+            WHERE entitlement.status = ANY($1::text[])
+              AND NOT EXISTS (
+                SELECT 1 FROM public.credit_ledger AS grant_entry
+                 WHERE grant_entry.entry_type = 'monthly_grant'
+                   AND grant_entry.tenant_id = entitlement.tenant_id
+                   AND grant_entry.entitlement_id = entitlement.entitlement_id
+                   AND grant_entry.reference_period_start = entitlement.reference_period_start
+              )
+            LIMIT $2`,
+          [[...ENTITLED_STATUSES], boundedLimit]
+        );
+        return Object.freeze({
+          stale_reservations: stale.rows.map(mapLedger),
+          invalid_settlements: invalidSettlements.rows,
+          orphan_refunds: orphanRefunds.rows,
+          duplicate_effects: duplicates.rows,
+          monthly_grant_mismatches: monthly.rows,
+        });
+      },
+      { readOnly: true, observe: false }
+    );
+  }
+}
+
+module.exports = {
+  LEDGER_COLUMNS,
+  PostgresBillingRepository,
+  REQUIRED_RELATIONS,
+  mapLedger,
+};

--- a/src/billing/productionComposition.js
+++ b/src/billing/productionComposition.js
@@ -1,0 +1,76 @@
+const { GenerationBillingOrchestrator, UnconfiguredGenerationBillingOrchestrator } = require("../generation-billing");
+const { BillingConfigurationError } = require("./errors");
+const { PostgresBillingRepository } = require("./postgresRepository");
+const { executionClass, identifier } = require("./schema");
+const { BillingService } = require("./service");
+
+function configuredList(env, name, schema) {
+  const raw = env[name];
+  if (typeof raw !== "string" || !raw.trim()) {
+    throw new BillingConfigurationError(`${name} is required`);
+  }
+  const values = [...new Set(raw.split(",").map((value) => value.trim()))];
+  if (values.some((value) => !value)) {
+    throw new BillingConfigurationError(`${name} is invalid`);
+  }
+  try {
+    return values.map((value) => schema.parse(value));
+  } catch {
+    throw new BillingConfigurationError(`${name} is invalid`);
+  }
+}
+
+async function createPostgresBillingProductionComposition({
+  pool,
+  env = process.env,
+  now = () => new Date(),
+  logger = console,
+} = {}) {
+  const activation = env.BILLING_DURABLE_ENABLED;
+  if (activation === undefined || activation === "" || activation === "false") {
+    return Object.freeze({
+      enabled: false,
+      billingRepository: null,
+      billingService: null,
+      generationBillingOrchestrator:
+        new UnconfiguredGenerationBillingOrchestrator(),
+    });
+  }
+  if (activation !== "true") {
+    throw new BillingConfigurationError(
+      "BILLING_DURABLE_ENABLED must be true or false"
+    );
+  }
+
+  const approvedPolicyIds = configuredList(
+    env,
+    "BILLING_APPROVED_POLICY_IDS",
+    identifier
+  );
+  const requiredExecutionClasses = configuredList(
+    env,
+    "BILLING_APPROVED_EXECUTION_CLASSES",
+    executionClass
+  );
+  const billingRepository = new PostgresBillingRepository({ pool, now });
+  await billingRepository.initialize({
+    approvedPolicyIds,
+    requiredExecutionClasses,
+  });
+  const billingService = new BillingService({
+    repository: billingRepository,
+    now,
+  });
+  const generationBillingOrchestrator = new GenerationBillingOrchestrator({
+    billingService,
+    logger,
+  });
+  return Object.freeze({
+    enabled: true,
+    billingRepository,
+    billingService,
+    generationBillingOrchestrator,
+  });
+}
+
+module.exports = { createPostgresBillingProductionComposition };

--- a/src/billing/repository.js
+++ b/src/billing/repository.js
@@ -153,6 +153,10 @@ class BillingRepository {
   recordBoltOnPaymentEvidence(_input) {
     throw new Error("BillingRepository.recordBoltOnPaymentEvidence is not implemented");
   }
+
+  reconcile(_input) {
+    throw new Error("BillingRepository.reconcile is not implemented");
+  }
 }
 
 class InMemoryBillingRepository extends BillingRepository {
@@ -315,10 +319,14 @@ class InMemoryBillingRepository extends BillingRepository {
   }
 
   replayFor(accountId, idempotencyKey, intentHash) {
-    const entryId = this.idempotency.get(`${accountId}\u0000${idempotencyKey}`);
+    const entryId = this.idempotency.get(idempotencyKey);
     if (!entryId) return null;
     const entry = this.entriesById.get(entryId);
-    if (!entry || entry.intent_hash !== intentHash) {
+    if (
+      !entry ||
+      entry.account_id !== accountId ||
+      entry.intent_hash !== intentHash
+    ) {
       throw new IdempotencyConflictError();
     }
     return copy(entry);
@@ -369,10 +377,7 @@ class InMemoryBillingRepository extends BillingRepository {
     const stored = Object.freeze(copy(entry));
     this.entries.push(stored);
     this.entriesById.set(stored.ledger_entry_id, stored);
-    this.idempotency.set(
-      `${account.account_id}\u0000${stored.idempotency_key}`,
-      stored.ledger_entry_id
-    );
+    this.idempotency.set(stored.idempotency_key, stored.ledger_entry_id);
     if (logicalKey) {
       this.logicalEffects.set(
         `${account.account_id}\u0000${logicalKey}`,
@@ -729,6 +734,49 @@ class InMemoryBillingRepository extends BillingRepository {
     }
     this.boltOnPaymentEvidence.set(reference, evidence);
     return copy(evidence);
+  }
+
+  reconcile({ olderThan, limit = 100 }) {
+    const threshold = Date.parse(olderThan);
+    const boundedLimit = Math.max(1, Math.min(limit, 500));
+    const staleReservations = this.entries
+      .filter(
+        (entry) =>
+          entry.entry_type === "reservation" &&
+          Date.parse(entry.occurred_at) < threshold &&
+          !this.entries.some(
+            (candidate) =>
+              ["debit", "reservation_release"].includes(candidate.entry_type) &&
+              candidate.reservation_entry_id === entry.ledger_entry_id
+          )
+      )
+      .slice(0, boundedLimit)
+      .map(copy);
+
+    const duplicateEffects = [];
+    const logical = new Map();
+    for (const entry of this.entries) {
+      const key = logicalKeyFor(entry);
+      if (!key) continue;
+      const scoped = `${entry.account_id}\u0000${key}`;
+      if (logical.has(scoped)) {
+        duplicateEffects.push({
+          account_id: entry.account_id,
+          logical_key: key,
+          ledger_entry_ids: [logical.get(scoped), entry.ledger_entry_id],
+        });
+      } else {
+        logical.set(scoped, entry.ledger_entry_id);
+      }
+    }
+
+    return Object.freeze({
+      stale_reservations: staleReservations,
+      invalid_settlements: [],
+      orphan_refunds: [],
+      duplicate_effects: duplicateEffects.slice(0, boundedLimit),
+      monthly_grant_mismatches: [],
+    });
   }
 }
 

--- a/src/generation-billing/service.js
+++ b/src/generation-billing/service.js
@@ -1,5 +1,5 @@
 const { createHash } = require("node:crypto");
-const { InsufficientCreditsError } = require("../billing");
+const { InsufficientCreditsError } = require("../billing/errors");
 const { freezeGenerationJob } = require("../generation-jobs");
 const {
   GenerationBillingAuthorityError,

--- a/supabase/migrations/20260821000000_create_generation_jobs.sql
+++ b/supabase/migrations/20260821000000_create_generation_jobs.sql
@@ -154,7 +154,7 @@ do $$
 declare
   grantee text;
 begin
-  foreach grantee in array['anon', 'authenticated', 'service_role'] loop
+  foreach grantee in array array['anon', 'authenticated', 'service_role'] loop
     if exists (select 1 from pg_roles where rolname = grantee) then
       execute format(
         'revoke all on table public.generation_jobs from %I',

--- a/supabase/migrations/20260823001722_durable_billing_authority.sql
+++ b/supabase/migrations/20260823001722_durable_billing_authority.sql
@@ -1,0 +1,214 @@
+-- BG-BILL-002D: durable PostgreSQL billing authority.
+-- This additive migration is version-controlled for independent review.
+-- It must not be applied to production by this implementation task.
+
+-- Financial idempotency identities are server-derived and globally unique.
+-- The existing account-scoped constraint remains as defense in depth.
+create unique index if not exists credit_ledger_idempotency_global_unique
+  on public.credit_ledger (idempotency_key);
+
+-- A generation correlation in the ledger must identify the same immutable
+-- tenant/project job established by BG-AUTH-002C.
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+     where conname = 'generation_jobs_job_tenant_project_unique'
+       and conrelid = 'public.generation_jobs'::regclass
+  ) then
+    alter table public.generation_jobs
+      add constraint generation_jobs_job_tenant_project_unique
+      unique (job_id, tenant_id, project_id);
+  end if;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+     where conname = 'credit_ledger_generation_job_fkey'
+       and conrelid = 'public.credit_ledger'::regclass
+  ) then
+    alter table public.credit_ledger
+      add constraint credit_ledger_generation_job_fkey
+      foreign key (generation_id, tenant_id, project_id)
+      references public.generation_jobs (job_id, tenant_id, project_id)
+      on delete restrict
+      not valid;
+  end if;
+end;
+$$;
+
+alter table public.credit_ledger
+  validate constraint credit_ledger_generation_job_fkey;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+     where conname = 'credit_ledger_generation_authority_shape'
+       and conrelid = 'public.credit_ledger'::regclass
+  ) then
+    alter table public.credit_ledger
+      add constraint credit_ledger_generation_authority_shape
+      check (
+        entry_type not in (
+          'reservation', 'reservation_release', 'debit', 'refund'
+        )
+        or (
+          generation_id is not null
+          and project_id is not null
+          and execution_id is not null
+          and transaction_correlation_id is not null
+        )
+      ) not valid;
+  end if;
+end;
+$$;
+
+alter table public.credit_ledger
+  validate constraint credit_ledger_generation_authority_shape;
+
+-- The application repository derives these values before INSERT. This
+-- trigger is the database-level backstop against a privileged application
+-- bug bypassing the repository's tenant/job/amount/reference checks.
+create or replace function billing_private.validate_credit_ledger_authority()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+declare
+  related public.credit_ledger%rowtype;
+  authoritative_cost bigint;
+  evidence_credits bigint;
+begin
+  if new.entry_type = 'reservation' then
+    select price.credit_cost
+      into authoritative_cost
+      from public.generation_jobs as job
+      join public.tenant_entitlements as entitlement
+        on entitlement.tenant_id = job.tenant_id
+       and entitlement.status in ('active', 'grace', 'cancel_pending')
+       and entitlement.starts_at <= new.occurred_at
+       and (entitlement.ends_at is null or new.occurred_at < entitlement.ends_at)
+      join public.commercial_policies as policy
+        on policy.policy_id = entitlement.policy_id
+       and policy.plan_code = entitlement.plan_code
+       and policy.status = 'active'
+       and policy.effective_from <= new.occurred_at
+       and (policy.effective_to is null or new.occurred_at < policy.effective_to)
+      join public.commercial_execution_prices as price
+        on price.policy_id = policy.policy_id
+       and price.execution_class = job.execution_class
+     where job.job_id = new.generation_id
+       and job.tenant_id = new.tenant_id
+       and job.project_id = new.project_id
+       and job.request_correlation_id = new.execution_id
+       and job.request_correlation_id = new.transaction_correlation_id;
+
+    if authoritative_cost is null or authoritative_cost <> new.amount then
+      raise exception 'reservation authority does not match the generation job and policy'
+        using errcode = '23514';
+    end if;
+  elsif new.entry_type in ('reservation_release', 'debit') then
+    select * into related
+      from public.credit_ledger
+     where ledger_entry_id = new.reservation_entry_id
+       and account_id = new.account_id
+       and tenant_id = new.tenant_id;
+
+    if related.entry_type is distinct from 'reservation'
+       or new.amount is distinct from related.amount
+       or new.project_id is distinct from related.project_id
+       or new.generation_id is distinct from related.generation_id
+       or new.execution_id is distinct from related.execution_id
+       or new.transaction_correlation_id is distinct from related.transaction_correlation_id then
+      raise exception 'settlement authority does not match the original reservation'
+        using errcode = '23514';
+    end if;
+  elsif new.entry_type = 'refund' then
+    select * into related
+      from public.credit_ledger
+     where ledger_entry_id = new.debit_entry_id
+       and account_id = new.account_id
+       and tenant_id = new.tenant_id;
+
+    if related.entry_type is distinct from 'debit'
+       or new.amount is distinct from related.amount
+       or new.project_id is distinct from related.project_id
+       or new.generation_id is distinct from related.generation_id
+       or new.execution_id is distinct from related.execution_id
+       or new.transaction_correlation_id is distinct from related.transaction_correlation_id then
+      raise exception 'refund authority does not match the original debit'
+        using errcode = '23514';
+    end if;
+  elsif new.entry_type = 'monthly_grant' then
+    perform 1
+      from public.tenant_entitlements as entitlement
+     where entitlement.entitlement_id = new.entitlement_id
+       and entitlement.tenant_id = new.tenant_id
+       and entitlement.status in ('active', 'grace', 'cancel_pending')
+       and entitlement.starts_at <= new.occurred_at
+       and (entitlement.ends_at is null or new.occurred_at < entitlement.ends_at)
+       and entitlement.included_monthly_credit_grant = new.amount
+       and entitlement.reference_period_start = new.reference_period_start
+       and entitlement.reference_period_end = new.reference_period_end;
+
+    if not found then
+      raise exception 'monthly grant authority does not match the entitlement period'
+        using errcode = '23514';
+    end if;
+  elsif new.entry_type = 'bolt_on_grant' then
+    select evidence.credits
+      into evidence_credits
+      from public.stripe_bolt_on_payment_evidence as evidence
+     where evidence.payment_reference = new.payment_ref
+       and evidence.tenant_id = new.tenant_id
+       and evidence.status = 'verified'
+       and (
+         new.stripe_event_ref is null
+         or evidence.stripe_event_id = new.stripe_event_ref
+       );
+
+    if evidence_credits is null or evidence_credits <> new.amount then
+      raise exception 'bolt-on grant authority does not match verified payment evidence'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists validate_credit_ledger_authority
+  on public.credit_ledger;
+create trigger validate_credit_ledger_authority
+before insert on public.credit_ledger
+for each row execute function billing_private.validate_credit_ledger_authority();
+
+revoke all on function billing_private.validate_credit_ledger_authority()
+  from public;
+
+-- Repeat the financial privilege boundary after adding the authority guard so
+-- future default grants cannot make the journal customer-writable.
+do $$
+declare
+  role_name text;
+begin
+  foreach role_name in array array['anon', 'authenticated', 'service_role']
+  loop
+    if exists (select 1 from pg_roles where rolname = role_name) then
+      execute format('revoke all on table public.credit_ledger from %I', role_name);
+      execute format('revoke all on table public.credit_accounts from %I', role_name);
+      execute format('revoke all on table public.tenant_entitlements from %I', role_name);
+      execute format('revoke all on table public.commercial_policies from %I', role_name);
+      execute format('revoke all on table public.commercial_execution_prices from %I', role_name);
+      execute format('revoke all on table public.credit_account_balances_internal from %I', role_name);
+    end if;
+  end loop;
+end;
+$$;
+
+comment on function billing_private.validate_credit_ledger_authority() is
+  'Database backstop for immutable generation, entitlement, settlement, refund, and bolt-on authority.';

--- a/test/postgres-billing-composition.test.js
+++ b/test/postgres-billing-composition.test.js
@@ -1,0 +1,149 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+const {
+  BillingConfigurationError,
+  PostgresBillingRepository,
+  REQUIRED_RELATIONS,
+  createPostgresBillingProductionComposition,
+} = require("../src/billing");
+const {
+  GenerationBillingOrchestrator,
+  UnconfiguredGenerationBillingOrchestrator,
+} = require("../src/generation-billing");
+
+function initializationPool({
+  infrastructure = {
+    idempotency_index: "credit_ledger_idempotency_global_unique",
+    authority_trigger: true,
+  },
+  unsafePrivileges = [],
+} = {}) {
+  return {
+    connect() {
+      throw new Error("not used during initialization");
+    },
+    async query(sql) {
+      if (sql.includes("AS idempotency_index")) {
+        return {
+          rows: [infrastructure],
+        };
+      }
+      if (sql.includes("to_regclass")) {
+        return {
+          rows: REQUIRED_RELATIONS.map((name) => ({ name, relation: name })),
+        };
+      }
+      if (sql.includes("FROM pg_constraint")) {
+        return {
+          rows: [
+            { conname: "generation_jobs_job_tenant_project_unique" },
+            { conname: "credit_ledger_generation_job_fkey" },
+            { conname: "credit_ledger_generation_authority_shape" },
+          ],
+        };
+      }
+      if (sql.includes("WITH financial_tables")) {
+        return { rowCount: unsafePrivileges.length, rows: unsafePrivileges };
+      }
+      if (sql.includes("FROM public.commercial_policies")) {
+        return {
+          rows: [
+            {
+              policy_id: "policy_reviewed_v1",
+              execution_class: "text.standard",
+              credit_cost: "1",
+            },
+            {
+              policy_id: "policy_reviewed_v1",
+              execution_class: "image.normal",
+              credit_cost: "2",
+            },
+          ],
+        };
+      }
+      throw new Error("unexpected initialization query");
+    },
+  };
+}
+
+describe("durable billing production composition", () => {
+  it("keeps customer generation fail-closed when activation is absent", async () => {
+    const result = await createPostgresBillingProductionComposition({
+      pool: initializationPool(),
+      env: {},
+    });
+    assert.equal(result.enabled, false);
+    assert.equal(result.billingRepository, null);
+    assert.equal(result.billingService, null);
+    assert.ok(
+      result.generationBillingOrchestrator instanceof
+        UnconfiguredGenerationBillingOrchestrator
+    );
+  });
+
+  it("rejects partial or ambiguous activation configuration", async () => {
+    await assert.rejects(
+      createPostgresBillingProductionComposition({
+        pool: initializationPool(),
+        env: { BILLING_DURABLE_ENABLED: "yes" },
+      }),
+      BillingConfigurationError
+    );
+    await assert.rejects(
+      createPostgresBillingProductionComposition({
+        pool: initializationPool(),
+        env: { BILLING_DURABLE_ENABLED: "true" },
+      }),
+      BillingConfigurationError
+    );
+  });
+
+  it("initializes only with reviewed policy rows and positive execution costs", async () => {
+    const result = await createPostgresBillingProductionComposition({
+      pool: initializationPool(),
+      env: {
+        BILLING_DURABLE_ENABLED: "true",
+        BILLING_APPROVED_POLICY_IDS: "policy_reviewed_v1",
+        BILLING_APPROVED_EXECUTION_CLASSES: "text.standard,image.normal",
+      },
+    });
+    assert.equal(result.enabled, true);
+    assert.ok(result.billingRepository instanceof PostgresBillingRepository);
+    assert.ok(
+      result.generationBillingOrchestrator instanceof
+        GenerationBillingOrchestrator
+    );
+  });
+
+  it("fails closed for a missing authority guard or an unsafe customer role", async () => {
+    const env = {
+      BILLING_DURABLE_ENABLED: "true",
+      BILLING_APPROVED_POLICY_IDS: "policy_reviewed_v1",
+      BILLING_APPROVED_EXECUTION_CLASSES: "text.standard,image.normal",
+    };
+    await assert.rejects(
+      createPostgresBillingProductionComposition({
+        pool: initializationPool({
+          infrastructure: {
+            idempotency_index: null,
+            authority_trigger: true,
+          },
+        }),
+        env,
+      }),
+      BillingConfigurationError
+    );
+    await assert.rejects(
+      createPostgresBillingProductionComposition({
+        pool: initializationPool({
+          unsafePrivileges: [{
+            role_name: "authenticated",
+            relation: "public.credit_ledger",
+          }],
+        }),
+        env,
+      }),
+      BillingConfigurationError
+    );
+  });
+});

--- a/test/postgres-billing-migration.test.js
+++ b/test/postgres-billing-migration.test.js
@@ -1,0 +1,69 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { describe, it } = require("node:test");
+
+const migration = fs.readFileSync(
+  path.join(
+    __dirname,
+    "..",
+    "supabase",
+    "migrations",
+    "20260823001722_durable_billing_authority.sql"
+  ),
+  "utf8"
+);
+
+describe("BG-BILL-002D durable billing migration", () => {
+  it("keeps one ledger and makes financial idempotency global", () => {
+    assert.doesNotMatch(migration, /create table[^;]+(?:ledger|balance)/i);
+    assert.match(
+      migration,
+      /create unique index if not exists credit_ledger_idempotency_global_unique[\s\S]*on public\.credit_ledger \(idempotency_key\)/i
+    );
+  });
+
+  it("binds ledger generation authority to the immutable tenant/project job", () => {
+    assert.match(migration, /generation_jobs_job_tenant_project_unique/i);
+    assert.match(
+      migration,
+      /foreign key \(generation_id, tenant_id, project_id\)[\s\S]*references public\.generation_jobs \(job_id, tenant_id, project_id\)[\s\S]*on delete restrict/i
+    );
+    assert.match(migration, /validate constraint credit_ledger_generation_job_fkey/i);
+    assert.match(migration, /credit_ledger_generation_authority_shape/i);
+  });
+
+  it("validates server-derived cost and exact settlement/refund authority", () => {
+    assert.match(migration, /validate_credit_ledger_authority/i);
+    assert.match(migration, /price\.credit_cost/i);
+    assert.match(migration, /job\.request_correlation_id = new\.execution_id/i);
+    assert.match(migration, /new\.amount is distinct from related\.amount/i);
+    assert.match(migration, /new\.generation_id is distinct from related\.generation_id/i);
+    assert.match(migration, /refund authority does not match the original debit/i);
+    assert.match(migration, /monthly grant authority does not match the entitlement period/i);
+    assert.match(migration, /bolt-on grant authority does not match verified payment evidence/i);
+  });
+
+  it("keeps the private function and financial tables outside customer roles", () => {
+    assert.doesNotMatch(migration, /security\s+definer/i);
+    assert.match(migration, /set search_path = ''/i);
+    assert.match(
+      migration,
+      /revoke all on function billing_private\.validate_credit_ledger_authority\(\)[\s\S]*from public/i
+    );
+    assert.match(migration, /array\['anon', 'authenticated', 'service_role'\]/i);
+    for (const table of [
+      "credit_ledger",
+      "credit_accounts",
+      "tenant_entitlements",
+      "commercial_policies",
+      "commercial_execution_prices",
+      "credit_account_balances_internal",
+    ]) {
+      assert.match(
+        migration,
+        new RegExp(`revoke all on table public\\.${table} from %I`, "i")
+      );
+    }
+  });
+});

--- a/test/postgres-billing.integration.test.js
+++ b/test/postgres-billing.integration.test.js
@@ -1,0 +1,834 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { after, before, beforeEach, describe, it } = require("node:test");
+const { Pool } = require("pg");
+const {
+  BillingPersistenceError,
+  BillingService,
+  DuplicateFinancialEffectError,
+  FinancialResourceUnavailableError,
+  IdempotencyConflictError,
+  InsufficientCreditsError,
+  PostgresBillingRepository,
+  StripeBillingConflictError,
+  StripeBillingResourceUnavailableError,
+} = require("../src/billing");
+const {
+  GenerationBillingOrchestrator,
+  GenerationBillingUnavailableError,
+} = require("../src/generation-billing");
+
+const ADMIN_DATABASE_URL = process.env.TEST_DATABASE_URL;
+const postgresDescribe = ADMIN_DATABASE_URL ? describe : describe.skip;
+const NOW = "2026-08-23T12:00:00.000Z";
+const PERIOD_START = "2026-08-01T00:00:00.000Z";
+const PERIOD_END = "2026-09-01T00:00:00.000Z";
+const AUTH_A = "11111111-1111-4111-8111-111111111111";
+const AUTH_B = "22222222-2222-4222-8222-222222222222";
+
+const JOBS = Object.freeze([
+  ["job_reserve_a", "tenant_a", "project_a", "video.normal", "corr_reserve_a", AUTH_A],
+  ["job_reserve_b", "tenant_a", "project_a", "video.normal", "corr_reserve_b", AUTH_A],
+  ["job_same", "tenant_a", "project_a", "video.normal", "corr_same", AUTH_A],
+  ["job_debit", "tenant_a", "project_a", "video.normal", "corr_debit", AUTH_A],
+  ["job_release", "tenant_a", "project_a", "video.normal", "corr_release", AUTH_A],
+  ["job_refund", "tenant_a", "project_a", "video.normal", "corr_refund", AUTH_A],
+  ["job_old", "tenant_a", "project_a", "video.normal", "corr_old", AUTH_A],
+  ["job_text", "tenant_a", "project_a", "text.standard", "corr_text", AUTH_A],
+  ["job_image", "tenant_a", "project_a", "image.normal", "corr_image", AUTH_A],
+  ["job_video", "tenant_a", "project_a", "video.normal", "corr_video", AUTH_A],
+  ["job_tenant_b", "tenant_b", "project_b", "video.normal", "corr_tenant_b", AUTH_B],
+]);
+
+function databaseUrl(databaseName) {
+  const url = new URL(ADMIN_DATABASE_URL);
+  url.pathname = `/${databaseName}`;
+  return url.toString();
+}
+
+function reservationInput(jobId, {
+  tenantId = "tenant_a",
+  projectId = "project_a",
+  amount = 6,
+  idempotencyKey = `reserve_${jobId}`,
+} = {}) {
+  const job = JOBS.find(([candidate]) => candidate === jobId);
+  return {
+    tenant_id: tenantId,
+    amount,
+    project_id: projectId,
+    generation_id: jobId,
+    execution_id: job[4],
+    transaction_correlation_id: job[4],
+    idempotency_key: idempotencyKey,
+  };
+}
+
+function jobObject(jobId) {
+  const [job_id, tenant_id, project_id, execution_class, correlation, authUserId] =
+    JOBS.find(([candidate]) => candidate === jobId);
+  return {
+    job_id,
+    tenant_id,
+    project_id,
+    execution_class,
+    actor_correlation: { kind: "customer", auth_user_id: authUserId },
+    request_correlation_id: correlation,
+    idempotency_key: `job_request_${jobId}`,
+    created_at: NOW,
+    allowed_scopes: ["generation:execute"],
+  };
+}
+
+class FailBeforeCommitRepository extends PostgresBillingRepository {
+  constructor(options) {
+    super(options);
+    this.failNext = false;
+  }
+
+  async beforeCommit() {
+    if (!this.failNext) return;
+    this.failNext = false;
+    throw new Error("fixture failure before commit");
+  }
+}
+
+class FailAfterCommitRepository extends PostgresBillingRepository {
+  constructor(options) {
+    super(options);
+    this.failNext = false;
+  }
+
+  async afterCommit() {
+    if (!this.failNext) return;
+    this.failNext = false;
+    throw new Error("fixture acknowledgement lost after commit");
+  }
+}
+
+postgresDescribe("PostgresBillingRepository real PostgreSQL adversarial proof", {
+  concurrency: 1,
+}, () => {
+  let adminPool;
+  let pool;
+  let testDatabase;
+  let repository;
+  let service;
+
+  async function resetFixture() {
+    await pool.query(`
+      TRUNCATE TABLE
+        public.stripe_bolt_on_payment_evidence,
+        public.stripe_webhook_events,
+        public.stripe_subscription_mappings,
+        public.stripe_customer_mappings,
+        public.credit_ledger,
+        public.generation_jobs,
+        public.credit_accounts,
+        public.tenant_entitlements,
+        public.commercial_execution_prices,
+        public.commercial_policies,
+        public.brand_brains,
+        public.projects,
+        public.tenant_memberships,
+        public.tenants,
+        public.customer_profiles,
+        auth.users
+      RESTART IDENTITY CASCADE
+    `);
+    await pool.query(
+      `INSERT INTO auth.users (id) VALUES ($1), ($2)`,
+      [AUTH_A, AUTH_B]
+    );
+    await pool.query(
+      `INSERT INTO public.customer_profiles (auth_user_id, display_name)
+       VALUES ($1, 'Tenant A owner'), ($2, 'Tenant B owner')`,
+      [AUTH_A, AUTH_B]
+    );
+    await pool.query(
+      `INSERT INTO public.tenants (tenant_id, name, created_by)
+       VALUES ('tenant_a', 'Tenant A', $1), ('tenant_b', 'Tenant B', $2)`,
+      [AUTH_A, AUTH_B]
+    );
+    await pool.query(`
+      INSERT INTO public.projects (project_id, tenant_id, name)
+      VALUES ('project_a', 'tenant_a', 'Project A'),
+             ('project_b', 'tenant_b', 'Project B')
+    `);
+    await pool.query(`
+      INSERT INTO public.commercial_policies
+        (policy_id, plan_code, policy_version, status,
+         included_monthly_credits, bolt_on_eligible, effective_from)
+      VALUES ('policy_standard_v1', 'standard', 1, 'draft', 10, true,
+              '2026-01-01T00:00:00.000Z')
+    `);
+    await pool.query(`
+      INSERT INTO public.commercial_execution_prices
+        (policy_id, execution_class, credit_cost)
+      VALUES
+        ('policy_standard_v1', 'text.standard', 1),
+        ('policy_standard_v1', 'image.normal', 2),
+        ('policy_standard_v1', 'image.premium', 4),
+        ('policy_standard_v1', 'video.normal', 6),
+        ('policy_standard_v1', 'video.premium', 9)
+    `);
+    await pool.query(`
+      UPDATE public.commercial_policies SET status = 'active'
+      WHERE policy_id = 'policy_standard_v1'
+    `);
+    await pool.query(
+      `INSERT INTO public.tenant_entitlements
+        (entitlement_id, tenant_id, policy_id, plan_code, status, starts_at,
+         reference_period_start, reference_period_end,
+         included_monthly_credit_grant)
+       VALUES
+        ('entitlement_a', 'tenant_a', 'policy_standard_v1', 'standard',
+         'active', '2026-01-01T00:00:00.000Z', $1, $2, 10),
+        ('entitlement_b', 'tenant_b', 'policy_standard_v1', 'standard',
+         'active', '2026-01-01T00:00:00.000Z', $1, $2, 10)`,
+      [PERIOD_START, PERIOD_END]
+    );
+    await pool.query(`
+      INSERT INTO public.credit_accounts (account_id, tenant_id)
+      VALUES ('account_a', 'tenant_a'), ('account_b', 'tenant_b')
+    `);
+    for (const [jobId, tenantId, projectId, executionClass, correlation, authUserId] of JOBS) {
+      await pool.query(
+        `INSERT INTO public.generation_jobs
+          (job_id, tenant_id, project_id, execution_class, auth_user_id,
+           request_correlation_id, idempotency_key, allowed_scopes,
+           execution_content, created_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,'["generation:execute"]'::jsonb,
+                 '{}'::jsonb,$8)`,
+        [
+          jobId,
+          tenantId,
+          projectId,
+          executionClass,
+          authUserId,
+          correlation,
+          `job_request_${jobId}`,
+          NOW,
+        ]
+      );
+    }
+    repository = new PostgresBillingRepository({
+      pool,
+      now: () => new Date(NOW),
+    });
+    service = new BillingService({
+      repository,
+      now: () => new Date(NOW),
+    });
+  }
+
+  async function fund(tenantId = "tenant_a", amount = 10, suffix = tenantId) {
+    return service.adjustCredits({
+      tenantId,
+      amount,
+      direction: "credit",
+      transactionCorrelationId: `fund_${suffix}`,
+      idempotencyKey: `fund_${suffix}`,
+    });
+  }
+
+  async function reserve(jobId, options = {}) {
+    const job = JOBS.find(([candidate]) => candidate === jobId);
+    return service.createReservation({
+      tenantId: options.tenantId || job[1],
+      projectId: options.projectId || job[2],
+      generationId: jobId,
+      executionId: job[4],
+      transactionCorrelationId: job[4],
+      executionClass: job[3],
+      idempotencyKey: options.idempotencyKey || `reserve_${jobId}`,
+    });
+  }
+
+  before(async () => {
+    adminPool = new Pool({ connectionString: ADMIN_DATABASE_URL, max: 4 });
+    testDatabase = `bizgenie_billing_${process.pid}_${Date.now()}`.toLowerCase();
+    await adminPool.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+          CREATE ROLE anon NOLOGIN;
+        END IF;
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+          CREATE ROLE authenticated NOLOGIN;
+        END IF;
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+          CREATE ROLE service_role NOLOGIN;
+        END IF;
+      END;
+      $$
+    `);
+    await adminPool.query(`CREATE DATABASE ${testDatabase}`);
+    pool = new Pool({ connectionString: databaseUrl(testDatabase), max: 24 });
+    await pool.query(`
+      CREATE SCHEMA auth;
+      CREATE TABLE auth.users (id uuid PRIMARY KEY);
+      CREATE FUNCTION auth.uid()
+      RETURNS uuid
+      LANGUAGE sql
+      STABLE
+      SET search_path = ''
+      AS 'SELECT NULL::uuid';
+    `);
+    const migrationsDirectory = path.join(__dirname, "..", "supabase", "migrations");
+    const migrations = fs.readdirSync(migrationsDirectory)
+      .filter((filename) => filename.endsWith(".sql"))
+      .sort();
+    for (const filename of migrations) {
+      try {
+        await pool.query(
+          fs.readFileSync(path.join(migrationsDirectory, filename), "utf8")
+        );
+      } catch (error) {
+        error.message = `${filename}: ${error.message}`;
+        throw error;
+      }
+    }
+  });
+
+  after(async () => {
+    await pool?.end();
+    if (adminPool && testDatabase) {
+      await adminPool.query(`DROP DATABASE IF EXISTS ${testDatabase} WITH (FORCE)`);
+    }
+    await adminPool?.end();
+  });
+
+  beforeEach(resetFixture);
+
+  it("runs against a real server with every durable authority guard initialized", async () => {
+    const version = await pool.query("SHOW server_version");
+    assert.match(version.rows[0].server_version, /^1[7-9]\./);
+    assert.equal(
+      await repository.initialize({
+        approvedPolicyIds: ["policy_standard_v1"],
+        requiredExecutionClasses: [
+          "text.standard",
+          "image.normal",
+          "video.normal",
+        ],
+      }),
+      true
+    );
+  });
+
+  it("keeps Stripe mappings, webhook evidence, and bolt-on evidence tenant-bound", async () => {
+    const mapping = await repository.createStripeCustomerMapping({
+      tenant_id: "tenant_a",
+      stripe_customer_id: "cus_tenantA",
+      livemode: false,
+    });
+    assert.equal(mapping.tenant_id, "tenant_a");
+    await assert.rejects(
+      repository.createStripeCustomerMapping({
+        tenant_id: "tenant_b",
+        stripe_customer_id: "cus_tenantA",
+        livemode: false,
+      }),
+      StripeBillingConflictError
+    );
+
+    const subscription = await repository.applyStripeSubscriptionState({
+      tenant_id: "tenant_a",
+      stripe_subscription_id: "sub_tenantA",
+      stripe_customer_id: "cus_tenantA",
+      policy_id: "policy_standard_v1",
+      plan_code: "standard",
+      stripe_price_id: "price_standardTest",
+      stripe_status: "active",
+      entitlement_status: "active",
+      livemode: false,
+      event_created: NOW,
+      event_id: "evt_subscriptionTenantA",
+      starts_at: "2026-01-01T00:00:00.000Z",
+      reference_period_start: PERIOD_START,
+      reference_period_end: PERIOD_END,
+      included_monthly_credit_grant: 10,
+    });
+    assert.equal(subscription.mapping.tenant_id, "tenant_a");
+    await assert.rejects(
+      repository.applyStripeSubscriptionState({
+        tenant_id: "tenant_b",
+        stripe_subscription_id: "sub_tenantA",
+        stripe_customer_id: "cus_tenantA",
+        policy_id: "policy_standard_v1",
+        plan_code: "standard",
+        stripe_price_id: "price_standardTest",
+        stripe_status: "active",
+        entitlement_status: "active",
+        livemode: false,
+        event_created: "2026-08-23T12:00:01.000Z",
+        event_id: "evt_subscriptionCrossTenant",
+        starts_at: "2026-01-01T00:00:00.000Z",
+        reference_period_start: PERIOD_START,
+        reference_period_end: PERIOD_END,
+        included_monthly_credit_grant: 10,
+      }),
+      StripeBillingResourceUnavailableError
+    );
+
+    assert.deepEqual(
+      await repository.beginStripeEvent({
+        event_id: "evt_webhookTenantA",
+        event_type: "invoice.paid",
+        livemode: false,
+        intent_hash: "a".repeat(64),
+      }),
+      { replay: false }
+    );
+    await repository.completeStripeEvent({
+      event_id: "evt_webhookTenantA",
+      result: { tenant_id: "tenant_a", applied: true },
+    });
+    const webhookReplay = await repository.beginStripeEvent({
+      event_id: "evt_webhookTenantA",
+      event_type: "invoice.paid",
+      livemode: false,
+      intent_hash: "a".repeat(64),
+    });
+    assert.equal(webhookReplay.replay, true);
+    assert.equal(webhookReplay.result.tenant_id, "tenant_a");
+
+    await assert.rejects(
+      repository.recordBoltOnPaymentEvidence({
+        payment_reference: "pi_cross_tenant",
+        stripe_event_id: "evt_boltCrossTenant",
+        tenant_id: "tenant_b",
+        stripe_customer_id: "cus_tenantA",
+        stripe_price_id: "price_boltTest",
+        credits: 5,
+      }),
+      StripeBillingResourceUnavailableError
+    );
+    await repository.beginStripeEvent({
+      event_id: "evt_boltTenantA",
+      event_type: "checkout.session.completed",
+      livemode: false,
+      intent_hash: "b".repeat(64),
+    });
+    await repository.recordBoltOnPaymentEvidence({
+      payment_reference: "pi_tenant_a",
+      stripe_event_id: "evt_boltTenantA",
+      tenant_id: "tenant_a",
+      stripe_customer_id: "cus_tenantA",
+      stripe_price_id: "price_boltTest",
+      credits: 5,
+    });
+    const boltOn = await service.grantBoltOnCredits({
+      tenantId: "tenant_a",
+      amount: 5,
+      paymentReference: "pi_tenant_a",
+      stripeEventReference: "evt_boltTenantA",
+      idempotencyKey: "bolt_tenant_a",
+    });
+    assert.equal(boltOn.balance_delta, 5);
+  });
+
+  it("serializes two insufficient-balance reservations on one tenant account", async () => {
+    await fund();
+    const results = await Promise.allSettled([
+      reserve("job_reserve_a"),
+      reserve("job_reserve_b"),
+    ]);
+    assert.equal(results.filter((result) => result.status === "fulfilled").length, 1);
+    const rejected = results.find((result) => result.status === "rejected");
+    assert.ok(rejected.reason instanceof InsufficientCreditsError);
+    const balance = await service.readBalance({ tenantId: "tenant_a" });
+    assert.equal(balance.available_balance, 4);
+    assert.equal(balance.reserved_balance, 6);
+  });
+
+  it("converges concurrent delivery of the same job on one reservation", async () => {
+    await fund();
+    const [first, second] = await Promise.all([
+      reserve("job_same"),
+      reserve("job_same"),
+    ]);
+    assert.equal(first.ledger_entry_id, second.ledger_entry_id);
+    const entries = await repository.listLedger("tenant_a");
+    assert.equal(entries.filter((entry) => entry.entry_type === "reservation").length, 1);
+  });
+
+  it("fails closed for concurrent global idempotency reuse across immutable authority", async () => {
+    await fund("tenant_a", 10, "a");
+    await fund("tenant_b", 10, "b");
+    const results = await Promise.allSettled([
+      repository.createReservation(
+        reservationInput("job_reserve_a", { idempotencyKey: "global_identity" })
+      ),
+      repository.createReservation(
+        reservationInput("job_tenant_b", {
+          tenantId: "tenant_b",
+          projectId: "project_b",
+          idempotencyKey: "global_identity",
+        })
+      ),
+    ]);
+    assert.equal(results.filter((result) => result.status === "fulfilled").length, 1);
+    assert.ok(
+      results.find((result) => result.status === "rejected").reason instanceof
+        IdempotencyConflictError
+    );
+    const count = await pool.query(
+      "SELECT count(*)::integer AS count FROM public.credit_ledger WHERE idempotency_key = 'global_identity'"
+    );
+    assert.equal(count.rows[0].count, 1);
+  });
+
+  it("settles concurrent debit and release deliveries exactly once", async () => {
+    await fund();
+    const debitReservation = await reserve("job_debit");
+    const debitInput = {
+      tenantId: "tenant_a",
+      reservationEntryId: debitReservation.ledger_entry_id,
+      idempotencyKey: "debit_job_debit",
+    };
+    const debits = await Promise.all([
+      service.finalizeDebit(debitInput),
+      service.finalizeDebit(debitInput),
+    ]);
+    assert.equal(debits[0].ledger_entry_id, debits[1].ledger_entry_id);
+
+    await fund("tenant_a", 10, "second_fund");
+    const releaseReservation = await reserve("job_release");
+    const releaseInput = {
+      tenantId: "tenant_a",
+      reservationEntryId: releaseReservation.ledger_entry_id,
+      idempotencyKey: "release_job_release",
+    };
+    const releases = await Promise.all([
+      service.releaseReservation(releaseInput),
+      service.releaseReservation(releaseInput),
+    ]);
+    assert.equal(releases[0].ledger_entry_id, releases[1].ledger_entry_id);
+    const entries = await repository.listLedger("tenant_a");
+    assert.equal(entries.filter((entry) => entry.entry_type === "debit").length, 1);
+    assert.equal(
+      entries.filter((entry) => entry.entry_type === "reservation_release").length,
+      1
+    );
+  });
+
+  it("lets only debit or release win a concurrent settlement race", async () => {
+    await fund();
+    const reservation = await reserve("job_same");
+    const results = await Promise.allSettled([
+      service.finalizeDebit({
+        tenantId: "tenant_a",
+        reservationEntryId: reservation.ledger_entry_id,
+        idempotencyKey: "race_debit",
+      }),
+      service.releaseReservation({
+        tenantId: "tenant_a",
+        reservationEntryId: reservation.ledger_entry_id,
+        idempotencyKey: "race_release",
+      }),
+    ]);
+    assert.equal(results.filter((result) => result.status === "fulfilled").length, 1);
+    assert.ok(
+      results.find((result) => result.status === "rejected").reason instanceof
+        DuplicateFinancialEffectError
+    );
+    const entries = await repository.listLedger("tenant_a");
+    assert.equal(
+      entries.filter((entry) =>
+        ["debit", "reservation_release"].includes(entry.entry_type)
+      ).length,
+      1
+    );
+  });
+
+  it("refunds the original tenant-bound debit once under concurrency", async () => {
+    await fund();
+    const reservation = await reserve("job_refund");
+    const debit = await service.finalizeDebit({
+      tenantId: "tenant_a",
+      reservationEntryId: reservation.ledger_entry_id,
+      idempotencyKey: "debit_for_refund",
+    });
+    const input = {
+      tenantId: "tenant_a",
+      debitEntryId: debit.ledger_entry_id,
+      idempotencyKey: "refund_job_refund",
+    };
+    const refunds = await Promise.all([service.refund(input), service.refund(input)]);
+    assert.equal(refunds[0].ledger_entry_id, refunds[1].ledger_entry_id);
+    await assert.rejects(
+      service.refund({ ...input, tenantId: "tenant_b" }),
+      FinancialResourceUnavailableError
+    );
+    assert.equal(
+      (await repository.listLedger("tenant_a")).filter(
+        (entry) => entry.entry_type === "refund"
+      ).length,
+      1
+    );
+  });
+
+  it("grants one monthly effect under concurrency and replay", async () => {
+    const input = {
+      tenantId: "tenant_a",
+      idempotencyKey: "monthly_entitlement_a_2026_08",
+      stripeEventReference: "in_test_monthly_event",
+    };
+    const [first, second] = await Promise.all([
+      service.grantMonthlyCredits(input),
+      service.grantMonthlyCredits(input),
+    ]);
+    const replay = await service.grantMonthlyCredits(input);
+    assert.equal(first.ledger_entry_id, second.ledger_entry_id);
+    assert.equal(first.ledger_entry_id, replay.ledger_entry_id);
+    assert.equal((await service.readBalance({ tenantId: "tenant_a" })).ledger_balance, 10);
+  });
+
+  it("rolls back an inserted entry when failure occurs before COMMIT", async () => {
+    const failing = new FailBeforeCommitRepository({
+      pool,
+      now: () => new Date(NOW),
+    });
+    const failingService = new BillingService({ repository: failing, now: () => new Date(NOW) });
+    failing.failNext = true;
+    const input = {
+      tenantId: "tenant_a",
+      amount: 10,
+      direction: "credit",
+      transactionCorrelationId: "rollback_fund",
+      idempotencyKey: "rollback_fund",
+    };
+    await assert.rejects(failingService.adjustCredits(input), BillingPersistenceError);
+    assert.equal((await failing.listLedger("tenant_a")).length, 0);
+    await failingService.adjustCredits(input);
+    assert.equal((await failing.listLedger("tenant_a")).length, 1);
+  });
+
+  it("recovers every committed-but-unacknowledged financial effect", async () => {
+    const lostAck = new FailAfterCommitRepository({
+      pool,
+      now: () => new Date(NOW),
+    });
+    const lostAckService = new BillingService({ repository: lostAck, now: () => new Date(NOW) });
+    await fund("tenant_a", 100, "lost_ack_fund");
+
+    lostAck.failNext = true;
+    await assert.rejects(
+      lostAck.createReservation(reservationInput("job_same")),
+      BillingPersistenceError
+    );
+    const reservation = await lostAck.createReservation(reservationInput("job_same"));
+
+    lostAck.failNext = true;
+    await assert.rejects(
+      lostAckService.finalizeDebit({
+        tenantId: "tenant_a",
+        reservationEntryId: reservation.ledger_entry_id,
+        idempotencyKey: "lost_ack_debit",
+      }),
+      BillingPersistenceError
+    );
+    const debit = await lostAckService.finalizeDebit({
+      tenantId: "tenant_a",
+      reservationEntryId: reservation.ledger_entry_id,
+      idempotencyKey: "lost_ack_debit",
+    });
+
+    const releaseReservation = await lostAck.createReservation(
+      reservationInput("job_release")
+    );
+    lostAck.failNext = true;
+    await assert.rejects(
+      lostAckService.releaseReservation({
+        tenantId: "tenant_a",
+        reservationEntryId: releaseReservation.ledger_entry_id,
+        idempotencyKey: "lost_ack_release",
+      }),
+      BillingPersistenceError
+    );
+    await lostAckService.releaseReservation({
+      tenantId: "tenant_a",
+      reservationEntryId: releaseReservation.ledger_entry_id,
+      idempotencyKey: "lost_ack_release",
+    });
+
+    lostAck.failNext = true;
+    await assert.rejects(
+      lostAckService.refund({
+        tenantId: "tenant_a",
+        debitEntryId: debit.ledger_entry_id,
+        idempotencyKey: "lost_ack_refund",
+      }),
+      BillingPersistenceError
+    );
+    await lostAckService.refund({
+      tenantId: "tenant_a",
+      debitEntryId: debit.ledger_entry_id,
+      idempotencyKey: "lost_ack_refund",
+    });
+
+    lostAck.failNext = true;
+    const monthlyInput = {
+      tenantId: "tenant_a",
+      idempotencyKey: "lost_ack_monthly",
+      stripeEventReference: "lost_ack_invoice",
+    };
+    await assert.rejects(
+      lostAckService.grantMonthlyCredits(monthlyInput),
+      BillingPersistenceError
+    );
+    await lostAckService.grantMonthlyCredits(monthlyInput);
+
+    const entries = await lostAck.listLedger("tenant_a");
+    for (const type of [
+      "debit",
+      "reservation_release",
+      "refund",
+      "monthly_grant",
+    ]) {
+      assert.equal(entries.filter((entry) => entry.entry_type === type).length, 1);
+    }
+  });
+
+  it("does not rerun provider execution when a committed debit acknowledgement is lost", async () => {
+    const lostAck = new FailAfterCommitRepository({
+      pool,
+      now: () => new Date(NOW),
+    });
+    const billingService = new BillingService({ repository: lostAck, now: () => new Date(NOW) });
+    const orchestrator = new GenerationBillingOrchestrator({
+      billingService,
+      logger: { error() {} },
+    });
+    await fund();
+    let providerCalls = 0;
+    const input = {
+      job: jobObject("job_text"),
+      expectedExecutionClass: "text.standard",
+      operation: async () => {
+        providerCalls += 1;
+        lostAck.failNext = true;
+        return { text: "durable result" };
+      },
+    };
+    await assert.rejects(orchestrator.execute(input), GenerationBillingUnavailableError);
+    const result = await orchestrator.execute(input);
+    assert.deepEqual(result, { text: "durable result" });
+    assert.equal(providerCalls, 1);
+    assert.equal(
+      (await lostAck.listLedger("tenant_a")).filter(
+        (entry) => entry.entry_type === "debit"
+      ).length,
+      1
+    );
+  });
+
+  it("survives repository reconstruction and prevents cross-tenant settlement", async () => {
+    await fund("tenant_a", 10, "durable_a");
+    await fund("tenant_b", 10, "durable_b");
+    const reservation = await reserve("job_debit");
+    await assert.rejects(
+      service.finalizeDebit({
+        tenantId: "tenant_b",
+        reservationEntryId: reservation.ledger_entry_id,
+        idempotencyKey: "cross_tenant_debit",
+      }),
+      FinancialResourceUnavailableError
+    );
+    await assert.rejects(
+      reserve("job_reserve_b", { projectId: "project_b" }),
+      FinancialResourceUnavailableError
+    );
+    const reconstructed = new PostgresBillingRepository({
+      pool,
+      now: () => new Date(NOW),
+    });
+    assert.equal((await reconstructed.readBalance("tenant_a")).reserved_balance, 6);
+    assert.equal((await reconstructed.readBalance("tenant_b")).available_balance, 10);
+  });
+
+  it("rejects authoritative ledger mutation by customer-facing database roles", async () => {
+    for (const role of ["anon", "authenticated"]) {
+      const client = await pool.connect();
+      try {
+        await client.query("BEGIN");
+        await client.query(`SET LOCAL ROLE ${role}`);
+        await assert.rejects(
+          client.query(`
+            INSERT INTO public.credit_ledger
+              (ledger_entry_id, account_id, tenant_id, entry_type, amount,
+               balance_delta, reserved_delta, idempotency_key, intent_hash,
+               transaction_correlation_id, occurred_at)
+            VALUES
+              ('unauthorized_entry', 'account_a', 'tenant_a',
+               'admin_adjustment', 1, 1, 0, 'unauthorized_key',
+               repeat('a', 64), 'unauthorized', now())
+          `),
+          (error) => error.code === "42501"
+        );
+        await client.query("ROLLBACK");
+      } finally {
+        client.release();
+      }
+    }
+  });
+
+  it("reports old unfinished reservations without mutating them", async () => {
+    await fund();
+    const reservation = await reserve("job_old");
+    const report = await repository.reconcile({
+      olderThan: "2026-08-24T00:00:00.000Z",
+      limit: 20,
+    });
+    assert.ok(
+      report.stale_reservations.some(
+        (entry) => entry.ledger_entry_id === reservation.ledger_entry_id
+      )
+    );
+    assert.deepEqual(report.invalid_settlements, []);
+    assert.deepEqual(report.orphan_refunds, []);
+    assert.deepEqual(report.duplicate_effects, []);
+    assert.equal(
+      (await repository.listLedger("tenant_a")).filter(
+        (entry) => entry.entry_type === "reservation"
+      ).length,
+      1
+    );
+  });
+
+  it("preserves Text, Image, and Video accounting through the durable adapter", async () => {
+    await fund();
+    const orchestrator = new GenerationBillingOrchestrator({
+      billingService: service,
+      logger: { error() {} },
+    });
+    await orchestrator.execute({
+      job: jobObject("job_text"),
+      expectedExecutionClass: "text.standard",
+      operation: async () => "text",
+    });
+    await orchestrator.execute({
+      job: jobObject("job_image"),
+      expectedExecutionClass: "image.normal",
+      operation: async () => "image",
+    });
+    await orchestrator.beginExecution({
+      job: jobObject("job_video"),
+      expectedExecutionClass: "video.normal",
+      operation: async () => "video",
+    });
+    await orchestrator.settleSuccessfulExecution({ job: jobObject("job_video") });
+    const entries = await repository.listLedger("tenant_a");
+    assert.deepEqual(
+      entries
+        .filter((entry) => entry.entry_type === "debit")
+        .map((entry) => entry.amount)
+        .sort((left, right) => left - right),
+      [1, 2, 6]
+    );
+    assert.equal((await service.readBalance({ tenantId: "tenant_a" })).available_balance, 1);
+  });
+});


### PR DESCRIPTION
## Summary

Implements BG-BILL-002D on the exact canonical baseline `feace193d4197a5ba9e98682c2abaf6fa7e3d68e` (tree `c127196016bba3d5d1911b29df0617787bd1e349`).

- adds the durable `PostgresBillingRepository` over the existing pool and immutable ledger
- uses short explicit transactions plus per-credit-account row locks
- enforces global durable idempotency and reservation/settlement/refund/monthly/bolt-on authority
- keeps debit and release mutually exclusive
- adds bounded read-only reconciliation
- wires fail-closed production composition with explicit activation/policy/execution-class gates
- adds PostgreSQL 17 CI coverage
- fixes the pre-existing `FOREACH ... IN ARRAY` syntax error in the generation-jobs migration discovered by applying the full migration chain to a disposable database

## Real PostgreSQL evidence

Disposable PostgreSQL 18.4 local proof (CI is configured for PostgreSQL 17):

- clean `npm ci --no-audit --no-fund`: 167 packages installed
- complete Node 22.23.2 suite: **360 passed, 0 failed**
- explicit real-PostgreSQL adversarial suite: **16 passed, 0 failed**
- Billing focused: **55 passed, 0 failed**
- BG-BILL-002C: **24 passed, 0 failed**
- Stripe lifecycle: **35 passed, 0 failed**
- AUTH-002C: **95 passed, 0 failed**
- syntax: **136 JavaScript files passed**
- `git diff --check`, SQL static checks, real migration execution, secret scan, and final diff review: passed

The real-database suite proves insufficient-balance reservation serialization, same-job convergence, cross-authority idempotency rejection, duplicate debit/release/refund/monthly effects, debit-v-release exclusion, rollback, every required lost-ack retry, provider non-reexecution after debit recovery, repository reconstruction, tenant isolation, customer-role mutation denial, Stripe evidence isolation, reconciliation, and Text/Image/Video accounting.

## Locking rationale

Every ledger mutation locks only the target tenant's canonical `credit_accounts` row before deriving ledger and reserved balances and inserting an effect. Same-account operations therefore serialize through the balance decision, while unrelated tenants do not. Database uniqueness and lineage constraints remain the final exactly-once and lifecycle authority.

## Migration and production state

`20260823001722_durable_billing_authority.sql` is committed but **not applied to Supabase/production**. It was applied only to disposable test databases.

No deployment, Stripe activation/call, provider activation/call, production secret change, commercial price hardcoding, or production data mutation was performed. Production remains fail-closed unless the separately authorized migration is applied and `BILLING_DURABLE_ENABLED`, approved policy IDs, and approved execution classes are explicitly configured with complete active database rows.

Closes #37 only when merged.