### PR TITLE
BG-ACT-001B: close staging activation gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
+.npm-cache/
 npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -492,6 +492,10 @@ field types fail fast rather than silently applying partial branding.
 
 ## Environment variables
 
+The fail-closed non-production activation variables and safe staging sequence
+are documented in
+[`docs/activation/STAGING_ACTIVATION.md`](docs/activation/STAGING_ACTIVATION.md).
+
 - `ADMIN_KEY` — required for all administration and script-generation routes.
 - `BRAND_BRAIN_DATABASE_URL` — required server-only Supabase/PostgreSQL
   session-pooler connection string used by production startup.
@@ -515,10 +519,11 @@ remains process-local and is reset whenever the process restarts.
 
 ## Generation completion protection
 
-The administration-only Video foundation and asynchronous contract are documented
+The Video foundation and asynchronous contract are documented
 in [`docs/video-generation.md`](docs/video-generation.md). The production
-application factory does not configure or activate a video provider, durable asset
-store, or rights-aware reference loader. Video input/reference locations are
+application factory configures a video provider, durable asset store, and
+rights-aware reference loader only when every explicit staging/production gate
+passes; they remain unconfigured by default. Video input/reference locations are
 resolved server-side from BizGenie asset identities; caller-supplied provider
 locations are never authoritative. Every Veo submission explicitly sends
 `generateAudio: false` and exposes no customer audio control.
@@ -681,17 +686,17 @@ polling, and raw responses remain adapter concerns. Results must normalize to
 provider, provider job identifier, and an externally stored image asset. Large
 binary assets are never accepted in the request or media record.
 
-The approved provider adapter is complete, but production activation still
-requires:
+The approved provider adapter and fail-closed durable media composition are
+complete, but any environment activation still requires:
 
 - an OpenAI project/API key with GPT Image 2 access and any required
   organization verification;
-- a durable image-generation/media repository and asset-storage adapter;
-- a rights- and tenant-aware reference asset loader;
+- the unapplied durable media migration and an existing private storage bucket;
+- explicit Image, media, Billing, environment, and CORS activation gates;
 - approved execution-cost policy data and the durable Billing production
   adapter; or
 - approval, rejection, variation, or regeneration endpoints.
 
-Those dependencies require explicit storage, commercial, and production
-configuration tasks. The in-memory repository is for deterministic tests and
-dependency injection only; it must not become the production system of record.
+Those dependencies require explicit storage, commercial, and environment
+configuration tasks. The in-memory repositories remain deterministic test
+dependencies and never become the production system of record.

--- a/docs/activation/STAGING_ACTIVATION.md
+++ b/docs/activation/STAGING_ACTIVATION.md
@@ -1,0 +1,107 @@
+# Staging activation layer
+
+BG-ACT-001B adds only the repository seams proven missing by the BG-ACT-001
+reconnaissance. It does not activate or deploy any environment and it does not
+change canonical Auth, Billing, generation-job, provider-selection, or
+commercial policy authority.
+
+## Default state
+
+Every new capability is OFF when its activation variable is absent, empty, or
+`false`. Any other value fails startup. An enabled capability also requires
+`BIZGENIE_ENVIRONMENT=staging` or `production`. Production additionally
+requires `PRODUCTION_ACTIVATION_ENABLED=true`; that variable is absent by
+default and is not set by this repository.
+
+No source value contains a staging URL, secret, Stripe Price, provider cost,
+or execution-credit value.
+
+## Durable media authority
+
+Migration `20260823133000_create_durable_media_assets.sql` creates the
+server-only `public.media_assets` table. It binds generated assets to the
+canonical tenant/project pair and immutable generation job, records a private
+storage bucket/key, media metadata, status, and explicit allowed-use rights,
+and prevents updates from changing ownership or storage identity. RLS is
+enabled and all table authority is revoked from `anon`, `authenticated`, and
+`service_role`; the existing trusted direct PostgreSQL application connection
+is the only writer.
+
+Storage keys are created from SHA-256 ownership partitions plus a
+server-generated UUID. Request bodies cannot select a bucket, key, output
+prefix, provider location, or stored asset location. Image and Video reference
+loaders query by the complete `(asset_id, tenant_id, project_id)` authority and
+require an active asset plus the exact server-owned right before returning
+bytes or a provider-readable GCS location.
+
+The staging storage bucket must already exist. Startup verifies that uniform
+bucket-level access and public-access prevention are enforced. The runtime
+identity needs only the bucket metadata, object create/read/delete permissions
+needed for the configured private media bucket, plus read access to the
+separately configured Veo output prefix. No bucket or provider resource is
+created by the application.
+
+Generated image assets are explicitly eligible for
+`image.generate.reference` and `video.generate.reference`. Generated videos
+receive no reference right. Revocation/deletion is represented by the durable
+asset status; there is no customer delete endpoint in this activation layer.
+Bucket retention/lifecycle rules remain an operator-owned staging resource and
+must be reviewed before activation.
+
+## Customer Video
+
+The customer endpoints are:
+
+- `POST /customer/generate-video`
+- `POST /customer/generate-video/:generationId/poll`
+- `GET /customer/generate-video/:generationId`
+
+Submission uses the existing verified customer authorization chain, creates
+the existing immutable generation job with `video.normal` or `video.premium`,
+and reserves credits before provider submission. A processing result remains
+reserved. Completion debits only after durable asset persistence. A terminal
+provider failure releases the reservation. Repeated poll/get calls reuse the
+existing idempotent settlement promise and durable Billing effect. Status and
+poll authority is derived from the stored Video record and immutable job;
+customer query/body values cannot reinterpret it for another tenant.
+
+## Activation variables
+
+| Variable | Contract |
+| --- | --- |
+| `BIZGENIE_ENVIRONMENT` | Required for enabled activation; `staging` or `production` only |
+| `PRODUCTION_ACTIVATION_ENABLED` | Separate explicit production gate; OFF by default |
+| `MEDIA_STORAGE_ENABLED` | Enables durable media repository/storage composition |
+| `MEDIA_STORAGE_BUCKET` | Existing private GCS bucket; never customer supplied |
+| `IMAGE_GENERATION_ENABLED` | Enables the approved OpenAI Image adapter; requires media storage |
+| `OPENAI_API_KEY` | Server-only Image credential |
+| `VIDEO_GENERATION_ENABLED` | Enables the approved Google Vertex Veo adapter; requires media storage |
+| `VIDEO_PROVIDER_OUTPUT_STORAGE_URI` | Existing server-controlled GCS output prefix ending in `/` |
+| `VIDEO_PROVIDER_TIMEOUT_MS` | Optional bounded provider transport timeout |
+| `STRIPE_BILLING_ENABLED` | Composes Stripe only with active durable Billing |
+| `STRIPE_MODE` | Must be `test` in staging and `live` in production |
+| `CORS_ENABLED` | Enables separate-frontend CORS; otherwise requests carrying `Origin` are denied |
+| `CORS_ALLOWED_ORIGINS` | Comma-separated exact URL origins; `*`, paths, queries, and fragments are rejected |
+
+All pre-existing Billing approval variables, Stripe server values, Auth values,
+Google project credentials, OpenAI options, service-principal values, and
+PostgreSQL configuration remain authoritative and must also pass their existing
+fail-closed startup checks.
+
+## Safe staging sequence
+
+1. Provision or select a dedicated non-production project outside this change.
+2. Review and apply the complete version-controlled migration chain there.
+3. Create/configure the private media bucket and provider output prefix outside
+   the application; do not reuse production resources.
+4. Configure approved non-production commercial policies and positive test
+   execution prices outside source control.
+5. Set `BIZGENIE_ENVIRONMENT=staging`, then enable durable Billing, media,
+   selected providers, Stripe test mode, and CORS individually.
+6. Start the application and require every initialization check to pass before
+   exposing staging traffic.
+7. Run the two-tenant Golden Journey and failure drills. Do not treat repository
+   tests alone as paid-launch or production-activation approval.
+
+No migration, provider request, Stripe object, deployment, or production state
+is created by this repository change.

--- a/docs/billing/GENERATION_CREDIT_ACCOUNTING.md
+++ b/docs/billing/GENERATION_CREDIT_ACCOUNTING.md
@@ -93,8 +93,9 @@ provider/model selection, ledger identity, or internal error detail.
   agreement with the bounded quality request. Submission reserves and executes
   once but does not debit. The separate idempotent success/failure settlement
   methods debit only after a later completed asset qualifies, or release after
-  a terminal failure. No customer Video route, Veo configuration, asset store,
-  or real provider is activated by this task.
+  a terminal failure. BG-ACT-001B now mounts that router behind canonical
+  customer authorization and immutable-job recording and composes Veo/storage
+  only when their explicit fail-closed activation gates pass.
 - Existing `ADMIN_KEY` Text, Image, and Video routes remain operational
   internal paths and are not reinterpreted as tenant-billable customer jobs.
 

--- a/docs/video-generation.md
+++ b/docs/video-generation.md
@@ -2,11 +2,11 @@
 
 ## Status
 
-This is a provider-neutral, administration-only foundation. Production activation,
-credentials, deployment, a customer JWT-authenticated Video route, durable Billing
-activation, and provider calls are intentionally absent. BG-BILL-002C supplies the
-immutable-job-driven `video.normal` / `video.premium` accounting contract without
-activating this provider path.
+This remains a provider-neutral foundation. BG-ACT-001B adds a fail-closed,
+JWT-authenticated customer route and staging composition for the existing
+immutable-job-driven `video.normal` / `video.premium` Billing contract. Provider,
+storage, Billing, Stripe, and CORS activation remain OFF by default; no credential,
+deployment, migration application, provider call, or production state is included.
 
 ## Verified Google contract
 
@@ -88,15 +88,16 @@ The request retains the existing ownership-readiness fields (`user_id`,
 `project_id`, optional `brand_id`, campaign and content lineage), but the admin
 key remains the only authentication boundary. Request `user_id` is metadata, not
 proof of identity. Customer-facing production activation remains blocked on the
-canonical tenant authorization work.
+separate production gate. The customer endpoints and staging requirements are
+documented in `docs/activation/STAGING_ACTIVATION.md`.
 
 ## Durable asset boundary
 
 Video bytes are never stored in the application database. The service uses an
 injected asset store with the same `save()` shape already used by Image. It passes
 a provider output location plus lineage and expects normalized durable metadata
-back. No production asset store is configured by this task, so the default route
-fails closed before production use.
+back. BG-ACT-001B supplies the private GCS and PostgreSQL media-asset adapters
+behind explicit environment gates; the default route still fails closed.
 
 Input and reference locations use a separate injected
 `VideoReferenceAssetLoader`. Public requests identify BizGenie assets by

--- a/index.js
+++ b/index.js
@@ -15,8 +15,14 @@ const {
   UnconfiguredCustomerTokenVerifier,
   createCustomerBillingTenantResolver,
   createCustomerGenerationBoundary,
+  createCustomerVideoStatusBoundary,
   createSupabaseCustomerTokenVerifierFromEnv,
 } = require("./src/authentication");
+const {
+  createCorsMiddleware,
+  createMediaProductionComposition,
+  loadCorsConfig,
+} = require("./src/activation");
 const {
   InMemoryBrandBrainRepository,
   createPostgresBrandBrainRepositoryFromEnv,
@@ -74,6 +80,7 @@ const GENERATION_EXECUTE_SCOPE = "generation:execute";
 const {
   createPostgresBillingProductionComposition,
   createStripeBillingRouter,
+  createStripeProductionComposition,
 } = require("./src/billing");
 
 function requireAdmin(req, res, next) {
@@ -237,6 +244,7 @@ function createApp({
   generationBillingOrchestrator = new UnconfiguredGenerationBillingOrchestrator(),
   servicePrincipalVerifier = new UnconfiguredServiceCredentialVerifier(),
   stripeSubscriptionService,
+  corsConfig = { enabled: false, allowedOrigins: [] },
   logger = console,
 } = {}) {
   const resolvedBranding = BrandingConfigSchema.parse(branding);
@@ -260,6 +268,7 @@ function createApp({
     brandBrainRepository,
   });
   const app = express();
+  app.use(createCorsMiddleware({ config: corsConfig }));
 
   // Stripe signature verification must see the exact request bytes. Mount
   // this isolated router before the normal JSON parser; its Checkout handler
@@ -298,6 +307,19 @@ function createApp({
     kind: "image",
     logger,
   });
+  const customerVideoBoundary = createCustomerGenerationBoundary({
+    tokenVerifier: customerTokenVerifier,
+    authorizationService: resolvedAuthorizationService,
+    kind: "video",
+    logger,
+  });
+  const customerVideoStatusBoundary = createCustomerVideoStatusBoundary({
+    tokenVerifier: customerTokenVerifier,
+    authorizationService: resolvedAuthorizationService,
+    videoGenerationService,
+    generationJobRepository,
+    logger,
+  });
   const recordScriptGenerationJob = createGenerationJobRecorder({
     generationJobService: resolvedGenerationJobService,
     executionClass: "text.standard",
@@ -310,6 +332,13 @@ function createApp({
     executionClass: "image.normal",
     allowedScopes: [GENERATION_EXECUTE_SCOPE],
     kind: "image",
+    logger,
+  });
+  const recordVideoGenerationJob = createGenerationJobRecorder({
+    generationJobService: resolvedGenerationJobService,
+    executionClass: (body) => `video.${body?.quality}`,
+    allowedScopes: [GENERATION_EXECUTE_SCOPE],
+    kind: "video",
     logger,
   });
 
@@ -373,6 +402,28 @@ function createApp({
     })
   );
 
+  const customerVideoRouter = createVideoGenerationRouter({
+    service: videoGenerationService,
+    generationBillingOrchestrator,
+    logger,
+  });
+  app.use(
+    "/customer/generate-video",
+    (req, res, next) =>
+      req.method === "POST" && req.path === "/"
+        ? customerVideoBoundary(req, res, next)
+        : next(),
+    (req, res, next) =>
+      req.method === "POST" && req.path === "/"
+        ? recordVideoGenerationJob(req, res, next)
+        : next(),
+    (req, res, next) =>
+      req.path !== "/"
+        ? customerVideoStatusBoundary(req, res, next)
+        : next(),
+    customerVideoRouter
+  );
+
   // Future bounded server-to-server execution seam. Customer generation is
   // currently executed in-process only after the mandatory job recorder
   // above succeeds; this route does not dispatch to Make or a provider.
@@ -393,6 +444,7 @@ function createApp({
         req.path.startsWith("/generate-image") ||
         req.path.startsWith("/generate-video") ||
         req.path.startsWith("/customer/generate-image") ||
+        req.path.startsWith("/customer/generate-video") ||
         req.path.startsWith("/customer/generate-script")) &&
       error instanceof SyntaxError &&
       error.status === 400 &&
@@ -419,7 +471,10 @@ function createApp({
         });
       }
 
-      if (req.path.startsWith("/generate-video")) {
+      if (
+        req.path.startsWith("/generate-video") ||
+        req.path.startsWith("/customer/generate-video")
+      ) {
         return res.status(400).json({
           status: "failed",
           error: {
@@ -484,6 +539,15 @@ async function createProductionApp({ env = process.env, logger = console } = {})
     env,
     logger,
   });
+  const media = await createMediaProductionComposition({
+    pool: brandBrainRepository.pool,
+    env,
+  });
+  const stripe = createStripeProductionComposition({
+    billingRepository: billing.billingRepository,
+    billingService: billing.billingService,
+    env,
+  });
   const servicePrincipalVerifier = createServiceCredentialVerifierFromEnv({
     env,
   });
@@ -494,7 +558,13 @@ async function createProductionApp({ env = process.env, logger = console } = {})
       customerTokenVerifier,
       generationJobRepository,
       generationBillingOrchestrator: billing.generationBillingOrchestrator,
+      imageProvider: media.imageProvider,
       servicePrincipalVerifier,
+      stripeSubscriptionService: stripe.stripeSubscriptionService,
+      videoProvider: media.videoProvider,
+      videoAssetStore: media.videoAssetStore,
+      videoReferenceAssetLoader: media.videoReferenceAssetLoader,
+      corsConfig: loadCorsConfig({ env }),
       logger,
     }),
     authorizationRepository,
@@ -504,7 +574,11 @@ async function createProductionApp({ env = process.env, logger = console } = {})
     billingRepository: billing.billingRepository,
     billingService: billing.billingService,
     generationBillingOrchestrator: billing.generationBillingOrchestrator,
+    mediaAssetRepository: media.mediaAssetRepository,
+    media,
     servicePrincipalVerifier,
+    stripeSubscriptionService: stripe.stripeSubscriptionService,
+    stripe,
   };
 }
 

--- a/src/activation/config.js
+++ b/src/activation/config.js
@@ -1,0 +1,38 @@
+class ActivationConfigurationError extends Error {
+  constructor(message = "Staging activation configuration is invalid") {
+    super(message);
+    this.name = "ActivationConfigurationError";
+    this.code = "ACTIVATION_CONFIGURATION_INVALID";
+  }
+}
+
+function activationFlag(env, name) {
+  const value = env[name];
+  if (value === undefined || value === "" || value === "false") return false;
+  if (value === "true") return true;
+  throw new ActivationConfigurationError(`${name} must be true or false`);
+}
+
+function requireActivationEnvironment(env) {
+  const environment = env.BIZGENIE_ENVIRONMENT;
+  if (!new Set(["staging", "production"]).has(environment)) {
+    throw new ActivationConfigurationError(
+      "BIZGENIE_ENVIRONMENT must be staging or production"
+    );
+  }
+  if (
+    environment === "production" &&
+    !activationFlag(env, "PRODUCTION_ACTIVATION_ENABLED")
+  ) {
+    throw new ActivationConfigurationError(
+      "Production activation is disabled"
+    );
+  }
+  return environment;
+}
+
+module.exports = {
+  ActivationConfigurationError,
+  activationFlag,
+  requireActivationEnvironment,
+};

--- a/src/activation/cors.js
+++ b/src/activation/cors.js
@@ -1,0 +1,78 @@
+const {
+  ActivationConfigurationError,
+  activationFlag,
+  requireActivationEnvironment,
+} = require("./config");
+
+const ALLOWED_METHODS = "GET,POST,OPTIONS";
+const ALLOWED_HEADERS = "authorization,content-type";
+const allowedMethods = new Set(ALLOWED_METHODS.split(","));
+const allowedHeaders = new Set(ALLOWED_HEADERS.split(","));
+
+function parseOrigin(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new ActivationConfigurationError("CORS origin is invalid");
+  }
+  if (
+    !new Set(["http:", "https:"]).has(url.protocol) ||
+    url.origin !== value ||
+    value === "*"
+  ) {
+    throw new ActivationConfigurationError("CORS origin is invalid");
+  }
+  return url.origin;
+}
+
+function loadCorsConfig({ env = process.env } = {}) {
+  const enabled = activationFlag(env, "CORS_ENABLED");
+  if (!enabled) return Object.freeze({ enabled: false, allowedOrigins: [] });
+  requireActivationEnvironment(env);
+  if (typeof env.CORS_ALLOWED_ORIGINS !== "string") {
+    throw new ActivationConfigurationError("CORS_ALLOWED_ORIGINS is required");
+  }
+  const values = env.CORS_ALLOWED_ORIGINS.split(",").map((value) => value.trim());
+  if (!values.length || values.some((value) => !value)) {
+    throw new ActivationConfigurationError("CORS_ALLOWED_ORIGINS is invalid");
+  }
+  const allowedOrigins = [...new Set(values.map(parseOrigin))];
+  return Object.freeze({ enabled: true, allowedOrigins: Object.freeze(allowedOrigins) });
+}
+
+function createCorsMiddleware({ config }) {
+  const allowed = new Set(config.allowedOrigins);
+  return function strictCors(req, res, next) {
+    const origin = req.header("origin");
+    if (!origin) return next();
+    res.vary("Origin");
+    if (!config.enabled || !allowed.has(origin)) {
+      return res.status(403).json({ error: "Forbidden" });
+    }
+    const requestedMethod = req.header("access-control-request-method");
+    const requestedHeaders = (req.header("access-control-request-headers") || "")
+      .split(",")
+      .map((value) => value.trim().toLowerCase())
+      .filter(Boolean);
+    if (
+      !allowedMethods.has(requestedMethod || req.method) ||
+      requestedHeaders.some((header) => !allowedHeaders.has(header))
+    ) {
+      return res.status(403).json({ error: "Forbidden" });
+    }
+    res.set("Access-Control-Allow-Origin", origin);
+    res.set("Access-Control-Allow-Methods", ALLOWED_METHODS);
+    res.set("Access-Control-Allow-Headers", ALLOWED_HEADERS);
+    res.set("Access-Control-Max-Age", "600");
+    if (req.method === "OPTIONS") return res.status(204).end();
+    return next();
+  };
+}
+
+module.exports = {
+  ALLOWED_HEADERS,
+  ALLOWED_METHODS,
+  createCorsMiddleware,
+  loadCorsConfig,
+};

--- a/src/activation/index.js
+++ b/src/activation/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  ...require("./config"),
+  ...require("./cors"),
+  ...require("./productionComposition"),
+};

--- a/src/activation/productionComposition.js
+++ b/src/activation/productionComposition.js
@@ -1,0 +1,143 @@
+const { VertexAI } = require("@google-cloud/vertexai");
+const {
+  UnconfiguredImageGenerationProvider,
+  createOpenAIImageProviderFromEnv,
+} = require("../image-generation");
+const {
+  GoogleVertexRestTransport,
+  GoogleVertexVeoProvider,
+  UnconfiguredVideoAssetStore,
+  UnconfiguredVideoGenerationProvider,
+  UnconfiguredVideoReferenceAssetLoader,
+} = require("../video-generation");
+const {
+  DurableMediaAssetStore,
+  GoogleCloudMediaStorage,
+  PostgresMediaAssetRepository,
+  RightsAwareMediaReferenceLoader,
+  MediaConfigurationError,
+} = require("../media");
+const { activationFlag, requireActivationEnvironment } = require("./config");
+
+function googleProject(env) {
+  return env.GOOGLE_CLOUD_PROJECT || env.GCLOUD_PROJECT || env.GCP_PROJECT;
+}
+
+function createAccessTokenProvider({ env, vertexFactory = (options) => new VertexAI(options) }) {
+  const project = googleProject(env);
+  if (typeof project !== "string" || !project) throw new MediaConfigurationError();
+  const vertex = vertexFactory({ project, location: "us-central1" });
+  if (!vertex?.googleAuth || typeof vertex.googleAuth.getAccessToken !== "function") {
+    throw new MediaConfigurationError();
+  }
+  return async () => vertex.googleAuth.getAccessToken();
+}
+
+async function createMediaProductionComposition({
+  pool,
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+  vertexFactory,
+  accessTokenProvider,
+  now = () => new Date(),
+} = {}) {
+  const mediaEnabled = activationFlag(env, "MEDIA_STORAGE_ENABLED");
+  const imageEnabled = activationFlag(env, "IMAGE_GENERATION_ENABLED");
+  const videoEnabled = activationFlag(env, "VIDEO_GENERATION_ENABLED");
+  if (!mediaEnabled && (imageEnabled || videoEnabled)) {
+    throw new MediaConfigurationError("Provider activation requires durable media storage");
+  }
+  if (!mediaEnabled) {
+    return Object.freeze({
+      mediaEnabled: false,
+      imageEnabled: false,
+      videoEnabled: false,
+      mediaAssetRepository: null,
+      imageProvider: new UnconfiguredImageGenerationProvider(),
+      videoProvider: new UnconfiguredVideoGenerationProvider(),
+      videoAssetStore: new UnconfiguredVideoAssetStore(),
+      videoReferenceAssetLoader: new UnconfiguredVideoReferenceAssetLoader(),
+    });
+  }
+
+  requireActivationEnvironment(env);
+  const tokenProvider = accessTokenProvider || createAccessTokenProvider({ env, vertexFactory });
+  const mediaAssetRepository = new PostgresMediaAssetRepository({ pool });
+  const storage = new GoogleCloudMediaStorage({
+    bucket: env.MEDIA_STORAGE_BUCKET,
+    accessTokenProvider: tokenProvider,
+    fetchImpl,
+  });
+  await mediaAssetRepository.initialize();
+  await storage.initialize();
+
+  const imageReferenceAssetLoader = new RightsAwareMediaReferenceLoader({
+    repository: mediaAssetRepository,
+    storage,
+    delivery: "bytes",
+  });
+  const videoReferenceAssetLoader = new RightsAwareMediaReferenceLoader({
+    repository: mediaAssetRepository,
+    storage,
+    delivery: "gcs",
+  });
+  const imageAssetStore = new DurableMediaAssetStore({
+    mediaKind: "image",
+    repository: mediaAssetRepository,
+    storage,
+    now,
+  });
+  const videoAssetStore = new DurableMediaAssetStore({
+    mediaKind: "video",
+    repository: mediaAssetRepository,
+    storage,
+    videoSourcePrefix: env.VIDEO_PROVIDER_OUTPUT_STORAGE_URI,
+    now,
+  });
+
+  let imageProvider = new UnconfiguredImageGenerationProvider();
+  if (imageEnabled) {
+    imageProvider = createOpenAIImageProviderFromEnv({
+      env,
+      assetStore: imageAssetStore,
+      referenceAssetLoader: imageReferenceAssetLoader,
+      fetchImpl,
+    });
+  }
+
+  let videoProvider = new UnconfiguredVideoGenerationProvider();
+  if (videoEnabled) {
+    const projectId = googleProject(env);
+    const transport = new GoogleVertexRestTransport({
+      accessTokenProvider: tokenProvider,
+      fetchImpl,
+      timeoutMs: env.VIDEO_PROVIDER_TIMEOUT_MS
+        ? Number(env.VIDEO_PROVIDER_TIMEOUT_MS)
+        : undefined,
+    });
+    videoProvider = new GoogleVertexVeoProvider({
+      projectId,
+      outputStorageUri: env.VIDEO_PROVIDER_OUTPUT_STORAGE_URI,
+      transport,
+    });
+  }
+
+  return Object.freeze({
+    mediaEnabled: true,
+    imageEnabled,
+    videoEnabled,
+    mediaAssetRepository,
+    imageAssetStore,
+    imageReferenceAssetLoader,
+    imageProvider,
+    videoAssetStore,
+    videoReferenceAssetLoader,
+    videoProvider,
+  });
+}
+
+module.exports = {
+  createAccessTokenProvider,
+  createMediaProductionComposition,
+  googleProject,
+};

--- a/src/authentication/customerGenerationBoundary.js
+++ b/src/authentication/customerGenerationBoundary.js
@@ -36,6 +36,9 @@ function responseBody(kind, error) {
       script_body: "",
     };
   }
+  if (kind === "video") {
+    return { status: "failed", error, video: null };
+  }
   return {
     status: "failed",
     error,
@@ -54,8 +57,8 @@ function createCustomerGenerationBoundary({
       "Customer generation requires token verification and authorization dependencies"
     );
   }
-  if (!new Set(["script", "image"]).has(kind)) {
-    throw new TypeError("Customer generation kind must be script or image");
+  if (!new Set(["script", "image", "video"]).has(kind)) {
+    throw new TypeError("Customer generation kind must be script, image, or video");
   }
 
   return async function requireAuthorizedCustomer(req, res, next) {
@@ -120,4 +123,5 @@ module.exports = {
   AUTHORIZATION_UNAVAILABLE_ERROR,
   createCustomerGenerationBoundary,
   extractBearerToken,
+  responseBody,
 };

--- a/src/authentication/customerVideoStatusBoundary.js
+++ b/src/authentication/customerVideoStatusBoundary.js
@@ -1,0 +1,74 @@
+const {
+  AuthenticationRequiredError,
+  AuthorizationDeniedError,
+} = require("../authorization");
+const {
+  AUTHENTICATION_ERROR,
+  AUTHORIZATION_ERROR,
+  AUTHORIZATION_UNAVAILABLE_ERROR,
+  extractBearerToken,
+  responseBody,
+} = require("./customerGenerationBoundary");
+
+function createCustomerVideoStatusBoundary({
+  tokenVerifier,
+  authorizationService,
+  videoGenerationService,
+  generationJobRepository,
+  logger = console,
+}) {
+  return async function authorizeCustomerVideoStatus(req, res, next) {
+    try {
+      const pathMatch = req.path.match(/^\/([^/]+)(?:\/poll)?$/);
+      if (!pathMatch) throw new AuthorizationDeniedError();
+      const generationId = pathMatch[1];
+      const actor = await tokenVerifier.verifyAccessToken(
+        extractBearerToken(req.header("authorization"))
+      );
+      const record = videoGenerationService.get(generationId);
+      if (!record.tenant_id || !record.generation_job_id) {
+        throw new AuthorizationDeniedError();
+      }
+      const authorization = record.brand_id
+        ? await authorizationService.authorizeProjectBrand({
+            actor,
+            tenantId: record.tenant_id,
+            projectId: record.project_id,
+            brandId: record.brand_id,
+            action: "generation:create",
+          })
+        : await authorizationService.authorizeProject({
+            actor,
+            tenantId: record.tenant_id,
+            projectId: record.project_id,
+            action: "generation:create",
+          });
+      const job = await generationJobRepository.getById(record.generation_job_id);
+      if (
+        !job ||
+        job.tenant_id !== authorization.tenant_id ||
+        job.project_id !== authorization.project_id ||
+        job.actor_correlation?.auth_user_id !== actor.auth_user_id
+      ) {
+        throw new AuthorizationDeniedError();
+      }
+      res.locals.customerAuthorization = authorization;
+      res.locals.generationJob = job;
+      return next();
+    } catch (error) {
+      if (error instanceof AuthenticationRequiredError) {
+        return res.status(401).json(responseBody("video", AUTHENTICATION_ERROR));
+      }
+      if (error instanceof AuthorizationDeniedError || error?.code === "VIDEO_GENERATION_NOT_FOUND") {
+        return res.status(404).json(responseBody("video", AUTHORIZATION_ERROR));
+      }
+      logger.error?.("customer video authorization unavailable", {
+        code: AUTHORIZATION_UNAVAILABLE_ERROR.code,
+        path: req.path,
+      });
+      return res.status(503).json(responseBody("video", AUTHORIZATION_UNAVAILABLE_ERROR));
+    }
+  };
+}
+
+module.exports = { createCustomerVideoStatusBoundary };

--- a/src/authentication/index.js
+++ b/src/authentication/index.js
@@ -1,9 +1,11 @@
 const boundary = require("./customerGenerationBoundary");
 const billingTenantResolver = require("./customerBillingTenantResolver");
+const videoStatusBoundary = require("./customerVideoStatusBoundary");
 const tokenVerifier = require("./tokenVerifier");
 
 module.exports = {
   ...boundary,
   ...billingTenantResolver,
+  ...videoStatusBoundary,
   ...tokenVerifier,
 };

--- a/src/billing/stripe/index.js
+++ b/src/billing/stripe/index.js
@@ -1,6 +1,7 @@
 const config = require("./config");
 const errors = require("./errors");
 const { createStripeBillingRouter } = require("./router");
+const { createStripeProductionComposition } = require("./productionComposition");
 const lifecycle = require("./service");
 
 module.exports = {
@@ -8,4 +9,5 @@ module.exports = {
   ...errors,
   ...lifecycle,
   createStripeBillingRouter,
+  createStripeProductionComposition,
 };

--- a/src/billing/stripe/productionComposition.js
+++ b/src/billing/stripe/productionComposition.js
@@ -1,0 +1,38 @@
+const { activationFlag, requireActivationEnvironment } = require("../../activation/config");
+const { StripeBillingConfigurationError } = require("./errors");
+const { createStripeClient, loadStripeBillingConfig } = require("./config");
+const { StripeSubscriptionService } = require("./service");
+
+function createStripeProductionComposition({
+  billingRepository,
+  billingService,
+  env = process.env,
+  stripeFactory = createStripeClient,
+  now = () => new Date(),
+} = {}) {
+  const enabled = activationFlag(env, "STRIPE_BILLING_ENABLED");
+  if (!enabled) return Object.freeze({ enabled: false, stripeSubscriptionService: null });
+  const environment = requireActivationEnvironment(env);
+  if (!billingRepository || !billingService) throw new StripeBillingConfigurationError();
+  const config = loadStripeBillingConfig({ env });
+  if (
+    (environment === "staging" && config.mode !== "test") ||
+    (environment === "production" && config.mode !== "live")
+  ) {
+    throw new StripeBillingConfigurationError();
+  }
+  const stripe = stripeFactory({ config });
+  return Object.freeze({
+    enabled: true,
+    config,
+    stripeSubscriptionService: new StripeSubscriptionService({
+      stripe,
+      repository: billingRepository,
+      billingService,
+      config,
+      now,
+    }),
+  });
+}
+
+module.exports = { createStripeProductionComposition };

--- a/src/generation-jobs/middleware.js
+++ b/src/generation-jobs/middleware.js
@@ -13,6 +13,9 @@ function failureBody(kind) {
       script_body: "",
     };
   }
+  if (kind === "video") {
+    return { status: "failed", error: GENERATION_JOB_UNAVAILABLE_ERROR, video: null };
+  }
   return {
     status: "failed",
     error: GENERATION_JOB_UNAVAILABLE_ERROR,
@@ -38,14 +41,17 @@ function createGenerationJobRecorder({
   if (!generationJobService) {
     throw new TypeError("A generation job service is required");
   }
-  if (typeof executionClass !== "string" || !executionClass.trim()) {
+  if (
+    typeof executionClass !== "function" &&
+    (typeof executionClass !== "string" || !executionClass.trim())
+  ) {
     throw new TypeError("An execution class is required");
   }
   if (!Array.isArray(allowedScopes) || allowedScopes.length === 0) {
     throw new TypeError("At least one allowed scope is required");
   }
-  if (!new Set(["script", "image"]).has(kind)) {
-    throw new TypeError("Generation job response kind must be script or image");
+  if (!new Set(["script", "image", "video"]).has(kind)) {
+    throw new TypeError("Generation job response kind must be script, image, or video");
   }
 
   return async function recordGenerationJob(req, res, next) {
@@ -66,9 +72,15 @@ function createGenerationJobRecorder({
           ? body.execution_id
           : randomUUID();
 
+      const resolvedExecutionClass = typeof executionClass === "function"
+        ? executionClass(body)
+        : executionClass;
+      if (typeof resolvedExecutionClass !== "string" || !resolvedExecutionClass.trim()) {
+        throw new TypeError("An execution class is required");
+      }
       const job = await generationJobService.authorizeAndCreateJob({
         authorization,
-        executionClass,
+        executionClass: resolvedExecutionClass,
         requestCorrelationId,
         idempotencyKey: requestCorrelationId,
         allowedScopes,

--- a/src/image-generation/openaiProvider.js
+++ b/src/image-generation/openaiProvider.js
@@ -177,6 +177,8 @@ function sanitizeLineage(metadata = {}) {
     "generation_id",
     "execution_id",
     "user_id",
+    "tenant_id",
+    "generation_job_id",
     "project_id",
     "brand_id",
     "campaign_id",
@@ -419,6 +421,7 @@ class OpenAIImageProvider extends ImageGenerationProvider {
     }
 
     const parsed = NormalizedImageAssetSchema.safeParse({
+      ...(stored?.asset_id ? { asset_id: stored.asset_id } : {}),
       location: stored?.location,
       mime_type: mimeType,
       width: output.width,

--- a/src/image-generation/repository.js
+++ b/src/image-generation/repository.js
@@ -6,6 +6,8 @@ const IMMUTABLE_FIELDS = new Set([
   "parent_generation_id",
   "execution_id",
   "user_id",
+  "tenant_id",
+  "generation_job_id",
   "project_id",
   "brand_id",
   "campaign_id",

--- a/src/image-generation/router.js
+++ b/src/image-generation/router.js
@@ -32,7 +32,9 @@ function createImageGenerationRouter({
     let input;
     try {
       input = parseRequest(req.body);
-      const operation = () => service.generate(input);
+      const operation = () => service.generate(input, {
+        job: res.locals.generationJob,
+      });
       const record = res.locals.generationJob
         ? await generationBillingOrchestrator.execute({
             job: res.locals.generationJob,

--- a/src/image-generation/schema.js
+++ b/src/image-generation/schema.js
@@ -33,7 +33,10 @@ const imageAspectRatios = ["1:1", "4:5", "9:16", "16:9"];
 const ReferenceAssetSchema = z
   .object({
     asset_id: identifier,
-    location: assetLocation,
+    // Kept optional for backwards-compatible parsing only. The service never
+    // forwards a customer-supplied location; providers resolve the durable
+    // asset_id through the rights-aware server-side loader.
+    location: assetLocation.optional(),
     mime_type: mimeType.optional(),
     width: dimension.optional(),
     height: dimension.optional(),
@@ -68,6 +71,7 @@ const ImageGenerationRequestSchema = z
 
 const NormalizedImageAssetSchema = z
   .object({
+    asset_id: identifier.optional(),
     location: assetLocation,
     mime_type: mimeType,
     width: dimension.optional(),
@@ -89,6 +93,8 @@ const ImageGenerationRecordSchema = z
     parent_generation_id: identifier.optional(),
     execution_id: identifier,
     user_id: identifier,
+    tenant_id: identifier.optional(),
+    generation_job_id: identifier.optional(),
     project_id: identifier,
     brand_id: identifier.optional(),
     campaign_id: identifier.optional(),

--- a/src/image-generation/service.js
+++ b/src/image-generation/service.js
@@ -9,6 +9,8 @@ const { compileImagePrompt } = require("./promptCompiler");
 const { normalizeProviderResult } = require("./provider");
 const { ImageGenerationRequestSchema } = require("./schema");
 
+const IMAGE_REFERENCE_RIGHT = "image.generate.reference";
+
 class ImageGenerationService {
   constructor({
     repository,
@@ -72,14 +74,22 @@ class ImageGenerationService {
     }
   }
 
-  async generate(value) {
+  async generate(value, { job } = {}) {
     const request = ImageGenerationRequestSchema.parse(value);
+    if (
+      job &&
+      (job.project_id !== request.project_id ||
+        job.actor_correlation?.auth_user_id !== request.user_id)
+    ) {
+      throw new ImageGenerationInternalError();
+    }
     const createdAt = this.timestamp();
     this.repository.create({
       generation_id: request.generation_id,
       parent_generation_id: request.parent_generation_id,
       execution_id: request.execution_id,
       user_id: request.user_id,
+      ...(job ? { tenant_id: job.tenant_id, generation_job_id: job.job_id } : {}),
       project_id: request.project_id,
       brand_id: request.brand_id,
       campaign_id: request.campaign_id,
@@ -99,14 +109,27 @@ class ImageGenerationService {
         updated_at: this.timestamp(),
       });
 
+      const referenceAssets = (request.reference_assets || []).map((asset) => ({
+        asset_id: asset.asset_id,
+        ...(job ? { tenant_id: job.tenant_id } : {}),
+        project_id: request.project_id,
+        requested_by_user_id: request.user_id,
+        required_right: IMAGE_REFERENCE_RIGHT,
+        generation_id: request.generation_id,
+        execution_id: request.execution_id,
+      }));
       const result = await this.callProvider({
         prompt,
         aspect_ratio: request.aspect_ratio,
-        reference_assets: request.reference_assets || [],
+        reference_assets: referenceAssets,
         metadata: {
           generation_id: request.generation_id,
           execution_id: request.execution_id,
           user_id: request.user_id,
+          ...(job ? {
+            tenant_id: job.tenant_id,
+            generation_job_id: job.job_id,
+          } : {}),
           project_id: request.project_id,
           brand_id: request.brand_id,
           campaign_id: request.campaign_id,

--- a/src/media/errors.js
+++ b/src/media/errors.js
@@ -1,0 +1,32 @@
+class MediaError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = this.constructor.name;
+    this.code = code;
+  }
+}
+
+class MediaConfigurationError extends MediaError {
+  constructor(message = "Media storage is not configured") {
+    super("MEDIA_STORAGE_NOT_CONFIGURED", message);
+  }
+}
+
+class MediaPersistenceError extends MediaError {
+  constructor() {
+    super("MEDIA_PERSISTENCE_UNAVAILABLE", "Media persistence is temporarily unavailable");
+  }
+}
+
+class MediaAssetUnavailableError extends MediaError {
+  constructor() {
+    super("MEDIA_ASSET_NOT_AVAILABLE", "The requested media asset is not available");
+  }
+}
+
+module.exports = {
+  MediaAssetUnavailableError,
+  MediaConfigurationError,
+  MediaError,
+  MediaPersistenceError,
+};

--- a/src/media/index.js
+++ b/src/media/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+  ...require("./errors"),
+  ...require("./repository"),
+  ...require("./schema"),
+  ...require("./storage"),
+};

--- a/src/media/repository.js
+++ b/src/media/repository.js
@@ -1,0 +1,162 @@
+const { MediaAssetUnavailableError, MediaConfigurationError, MediaPersistenceError } = require("./errors");
+const { MediaAssetSchema } = require("./schema");
+
+function copy(value) {
+  return value ? structuredClone(value) : value;
+}
+
+class MediaAssetRepository {
+  async initialize() {}
+  async create(_asset) { throw new Error("MediaAssetRepository.create is not implemented"); }
+  async findOwned(_input) { throw new Error("MediaAssetRepository.findOwned is not implemented"); }
+  async findAuthorizedReference(_input) { throw new Error("MediaAssetRepository.findAuthorizedReference is not implemented"); }
+}
+
+class InMemoryMediaAssetRepository extends MediaAssetRepository {
+  constructor({ assets = [] } = {}) {
+    super();
+    this.assets = new Map();
+    for (const asset of assets) this.create(asset);
+  }
+
+  async create(value) {
+    const asset = MediaAssetSchema.parse(value);
+    if (this.assets.has(asset.asset_id)) throw new MediaPersistenceError();
+    if ([...this.assets.values()].some((row) => row.storage_bucket === asset.storage_bucket && row.storage_key === asset.storage_key)) {
+      throw new MediaPersistenceError();
+    }
+    this.assets.set(asset.asset_id, copy(asset));
+    return copy(asset);
+  }
+
+  async findOwned({ assetId, tenantId, projectId }) {
+    const asset = this.assets.get(assetId);
+    if (!asset || asset.tenant_id !== tenantId || asset.project_id !== projectId || asset.status !== "active") return null;
+    return copy(asset);
+  }
+
+  async findAuthorizedReference({ assetId, tenantId, projectId, requiredRight, mediaKind = "image" }) {
+    const asset = await this.findOwned({ assetId, tenantId, projectId });
+    if (!asset || asset.media_kind !== mediaKind || !asset.allowed_uses.includes(requiredRight)) return null;
+    return asset;
+  }
+}
+
+class PostgresMediaAssetRepository extends MediaAssetRepository {
+  constructor({ pool }) {
+    super();
+    if (!pool || typeof pool.query !== "function") throw new TypeError("A PostgreSQL pool is required");
+    this.pool = pool;
+  }
+
+  async initialize() {
+    try {
+      const result = await this.pool.query(`
+        SELECT to_regclass('public.media_assets') AS relation,
+               EXISTS (
+                 SELECT 1 FROM pg_constraint
+                  WHERE conrelid = 'public.media_assets'::regclass
+                    AND conname = 'media_assets_generation_authority_fkey'
+               ) AS generation_authority,
+               EXISTS (
+                 SELECT 1 FROM pg_trigger
+                  WHERE tgrelid = 'public.media_assets'::regclass
+                    AND tgname = 'protect_media_asset_authority'
+                    AND NOT tgisinternal
+               ) AS authority_trigger`);
+      const row = result.rows[0];
+      if (!row?.relation || row.generation_authority !== true || row.authority_trigger !== true) {
+        throw new MediaConfigurationError();
+      }
+      const unsafe = await this.pool.query(`
+        SELECT grantee FROM information_schema.role_table_grants
+         WHERE table_schema = 'public' AND table_name = 'media_assets'
+           AND grantee IN ('anon', 'authenticated', 'service_role')`);
+      if (unsafe.rowCount > 0) throw new MediaConfigurationError();
+    } catch (error) {
+      if (error instanceof MediaConfigurationError) throw error;
+      throw new MediaConfigurationError();
+    }
+  }
+
+  async create(value) {
+    const asset = MediaAssetSchema.parse(value);
+    try {
+      const result = await this.pool.query(
+        `INSERT INTO public.media_assets
+          (asset_id, tenant_id, project_id, generation_job_id, generation_id,
+           source_kind, media_kind, storage_bucket, storage_key, mime_type,
+           width, height, duration_seconds, byte_size, allowed_uses, status, created_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)
+         RETURNING *`,
+        [asset.asset_id, asset.tenant_id, asset.project_id,
+          asset.generation_job_id || null, asset.generation_id || null,
+          asset.source_kind, asset.media_kind, asset.storage_bucket,
+          asset.storage_key, asset.mime_type, asset.width || null,
+          asset.height || null, asset.duration_seconds || null,
+          asset.byte_size || null, asset.allowed_uses, asset.status,
+          asset.created_at]
+      );
+      return this.toAsset(result.rows[0]);
+    } catch (_error) {
+      throw new MediaPersistenceError();
+    }
+  }
+
+  async findOwned({ assetId, tenantId, projectId }) {
+    try {
+      const result = await this.pool.query(
+        `SELECT * FROM public.media_assets
+          WHERE asset_id = $1 AND tenant_id = $2 AND project_id = $3
+            AND status = 'active'`,
+        [assetId, tenantId, projectId]
+      );
+      return result.rows[0] ? this.toAsset(result.rows[0]) : null;
+    } catch (_error) {
+      throw new MediaPersistenceError();
+    }
+  }
+
+  async findAuthorizedReference({ assetId, tenantId, projectId, requiredRight, mediaKind = "image" }) {
+    try {
+      const result = await this.pool.query(
+        `SELECT * FROM public.media_assets
+          WHERE asset_id = $1 AND tenant_id = $2 AND project_id = $3
+            AND media_kind = $4 AND status = 'active' AND $5 = ANY(allowed_uses)`,
+        [assetId, tenantId, projectId, mediaKind, requiredRight]
+      );
+      return result.rows[0] ? this.toAsset(result.rows[0]) : null;
+    } catch (_error) {
+      throw new MediaPersistenceError();
+    }
+  }
+
+  toAsset(row) {
+    if (!row) throw new MediaAssetUnavailableError();
+    return MediaAssetSchema.parse({
+      asset_id: row.asset_id,
+      tenant_id: row.tenant_id,
+      project_id: row.project_id,
+      ...(row.generation_job_id ? { generation_job_id: row.generation_job_id } : {}),
+      ...(row.generation_id ? { generation_id: row.generation_id } : {}),
+      source_kind: row.source_kind,
+      media_kind: row.media_kind,
+      storage_bucket: row.storage_bucket,
+      storage_key: row.storage_key,
+      mime_type: row.mime_type,
+      ...(row.width ? { width: Number(row.width) } : {}),
+      ...(row.height ? { height: Number(row.height) } : {}),
+      ...(row.duration_seconds ? { duration_seconds: Number(row.duration_seconds) } : {}),
+      ...(row.byte_size ? { byte_size: Number(row.byte_size) } : {}),
+      allowed_uses: row.allowed_uses || [],
+      status: row.status,
+      created_at: row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at,
+    });
+  }
+}
+
+module.exports = {
+  InMemoryMediaAssetRepository,
+  MediaAssetRepository,
+  PostgresMediaAssetRepository,
+};

--- a/src/media/schema.js
+++ b/src/media/schema.js
@@ -1,0 +1,50 @@
+const { z } = require("zod");
+
+const identifier = z.string().trim().min(1).max(128).regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/);
+const uuid = z.string().uuid();
+const storageBucket = z.string().trim().min(3).max(222).regex(/^[a-z0-9][a-z0-9._-]+[a-z0-9]$/);
+const storageKey = z.string().trim().min(1).max(1024).regex(/^assets\/[a-f0-9]{64}\/[a-f0-9]{64}\/(image|video)\/[0-9a-f-]{36}\.[a-z0-9]+$/);
+const mimeType = z.enum(["image/jpeg", "image/png", "image/webp", "video/mp4"]);
+const mediaReferenceRights = Object.freeze([
+  "image.generate.reference",
+  "video.generate.reference",
+]);
+
+const MediaAssetSchema = z.object({
+  asset_id: uuid,
+  tenant_id: identifier,
+  project_id: identifier,
+  generation_job_id: identifier.optional(),
+  generation_id: identifier.optional(),
+  source_kind: z.enum(["generated", "reference"]),
+  media_kind: z.enum(["image", "video"]),
+  storage_bucket: storageBucket,
+  storage_key: storageKey,
+  mime_type: mimeType,
+  width: z.number().int().positive().max(50_000).optional(),
+  height: z.number().int().positive().max(50_000).optional(),
+  duration_seconds: z.number().positive().max(60).optional(),
+  byte_size: z.number().int().positive().optional(),
+  allowed_uses: z.array(z.enum(mediaReferenceRights)).max(mediaReferenceRights.length),
+  status: z.enum(["active", "revoked", "deleted"]),
+  created_at: z.string().datetime({ offset: true }),
+}).strict().superRefine((asset, ctx) => {
+  if (asset.source_kind === "generated" && (!asset.generation_job_id || !asset.generation_id)) {
+    ctx.addIssue({ code: "custom", path: ["generation_job_id"], message: "Generated media requires immutable generation authority" });
+  }
+  if (asset.media_kind === "image" && !asset.mime_type.startsWith("image/")) {
+    ctx.addIssue({ code: "custom", path: ["mime_type"], message: "Image media requires an image MIME type" });
+  }
+  if (asset.media_kind === "video" && asset.mime_type !== "video/mp4") {
+    ctx.addIssue({ code: "custom", path: ["mime_type"], message: "Video media requires video/mp4" });
+  }
+});
+
+module.exports = {
+  MediaAssetSchema,
+  identifier,
+  mediaReferenceRights,
+  mimeType,
+  storageBucket,
+  storageKey,
+};

--- a/src/media/storage.js
+++ b/src/media/storage.js
@@ -1,0 +1,272 @@
+const { createHash, randomUUID } = require("node:crypto");
+const { MediaAssetUnavailableError, MediaConfigurationError, MediaPersistenceError } = require("./errors");
+
+const MAX_IMAGE_BYTES = 50 * 1024 * 1024;
+const MAX_VIDEO_BYTES = 1024 * 1024 * 1024;
+const MIME_EXTENSIONS = Object.freeze({
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+  "video/mp4": "mp4",
+});
+
+function sha(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function objectKey({ tenantId, projectId, mediaKind, assetId, extension }) {
+  return `assets/${sha(tenantId)}/${sha(projectId)}/${mediaKind}/${assetId}.${extension}`;
+}
+
+function parseGcsLocation(value) {
+  const match = typeof value === "string" && value.match(/^gs:\/\/([^/]+)\/(.+)$/i);
+  if (!match || !match[2] || match[2].includes("..")) throw new MediaPersistenceError();
+  return { bucket: match[1], key: match[2] };
+}
+
+class GoogleCloudMediaStorage {
+  constructor({ bucket, accessTokenProvider, fetchImpl = globalThis.fetch }) {
+    if (typeof bucket !== "string" || !/^[a-z0-9][a-z0-9._-]+[a-z0-9]$/.test(bucket)) {
+      throw new MediaConfigurationError("MEDIA_STORAGE_BUCKET is invalid");
+    }
+    if (typeof accessTokenProvider !== "function" || typeof fetchImpl !== "function") {
+      throw new MediaConfigurationError();
+    }
+    this.bucket = bucket;
+    this.accessTokenProvider = accessTokenProvider;
+    this.fetchImpl = fetchImpl;
+  }
+
+  async request(url, init = {}) {
+    let token;
+    try {
+      token = await this.accessTokenProvider();
+    } catch {
+      throw new MediaPersistenceError();
+    }
+    if (typeof token !== "string" || !token.trim()) throw new MediaPersistenceError();
+    let response;
+    try {
+      response = await this.fetchImpl(url, {
+        ...init,
+        headers: { authorization: `Bearer ${token}`, ...(init.headers || {}) },
+      });
+    } catch {
+      throw new MediaPersistenceError();
+    }
+    if (!response?.ok) throw new MediaPersistenceError();
+    return response;
+  }
+
+  async initialize() {
+    try {
+      const response = await this.request(
+        `https://storage.googleapis.com/storage/v1/b/${encodeURIComponent(this.bucket)}`
+      );
+      const metadata = await response.json();
+      if (
+        metadata?.name !== this.bucket ||
+        metadata?.iamConfiguration?.uniformBucketLevelAccess?.enabled !== true ||
+        metadata?.iamConfiguration?.publicAccessPrevention !== "enforced"
+      ) {
+        throw new MediaConfigurationError();
+      }
+    } catch (error) {
+      if (error instanceof MediaConfigurationError) throw error;
+      throw new MediaConfigurationError();
+    }
+  }
+
+  async putObject({ key, data, mimeType }) {
+    const url = new URL(
+      `https://storage.googleapis.com/upload/storage/v1/b/${encodeURIComponent(this.bucket)}/o`
+    );
+    url.searchParams.set("uploadType", "media");
+    url.searchParams.set("name", key);
+    url.searchParams.set("ifGenerationMatch", "0");
+    const body = Buffer.isBuffer(data) ? data : Buffer.from(data);
+    const response = await this.request(url, {
+      method: "POST",
+      headers: { "content-type": mimeType, "content-length": String(body.length) },
+      body,
+    });
+    const result = await response.json();
+    if (result?.bucket !== this.bucket || result?.name !== key) throw new MediaPersistenceError();
+    return { byteSize: Number(result.size || body.length) };
+  }
+
+  async copyObject({ source, destinationKey, allowedSourcePrefix }) {
+    if (typeof allowedSourcePrefix !== "string" || !source.startsWith(allowedSourcePrefix)) {
+      throw new MediaPersistenceError();
+    }
+    const parsed = parseGcsLocation(source);
+    const url = new URL(
+      `https://storage.googleapis.com/storage/v1/b/${encodeURIComponent(parsed.bucket)}/o/${encodeURIComponent(parsed.key)}/rewriteTo/b/${encodeURIComponent(this.bucket)}/o/${encodeURIComponent(destinationKey)}`
+    );
+    url.searchParams.set("ifGenerationMatch", "0");
+    let token;
+    do {
+      if (token) url.searchParams.set("rewriteToken", token);
+      const response = await this.request(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      const result = await response.json();
+      if (result?.done === true) {
+        if (result.resource?.bucket !== this.bucket || result.resource?.name !== destinationKey) {
+          throw new MediaPersistenceError();
+        }
+        return { byteSize: Number(result.resource.size) || undefined };
+      }
+      token = result?.rewriteToken;
+      if (typeof token !== "string" || !token) throw new MediaPersistenceError();
+    } while (token);
+    throw new MediaPersistenceError();
+  }
+
+  async download({ key, maximumBytes }) {
+    const url = `https://storage.googleapis.com/download/storage/v1/b/${encodeURIComponent(this.bucket)}/o/${encodeURIComponent(key)}?alt=media`;
+    const response = await this.request(url);
+    const declared = Number(response.headers?.get?.("content-length"));
+    if (Number.isFinite(declared) && declared > maximumBytes) throw new MediaAssetUnavailableError();
+    const data = Buffer.from(await response.arrayBuffer());
+    if (!data.length || data.length > maximumBytes) throw new MediaAssetUnavailableError();
+    return data;
+  }
+
+  async delete({ key }) {
+    try {
+      await this.request(
+        `https://storage.googleapis.com/storage/v1/b/${encodeURIComponent(this.bucket)}/o/${encodeURIComponent(key)}`,
+        { method: "DELETE" }
+      );
+    } catch {
+      // Orphan cleanup is best effort; the authoritative write still fails.
+    }
+  }
+}
+
+function requireTrustedLineage(lineage) {
+  for (const field of ["tenant_id", "project_id", "generation_job_id", "generation_id"]) {
+    if (typeof lineage?.[field] !== "string" || !lineage[field]) throw new MediaPersistenceError();
+  }
+  return lineage;
+}
+
+class DurableMediaAssetStore {
+  constructor({ mediaKind, repository, storage, videoSourcePrefix, now = () => new Date() }) {
+    this.mediaKind = mediaKind;
+    this.repository = repository;
+    this.storage = storage;
+    this.videoSourcePrefix = videoSourcePrefix;
+    this.now = now;
+  }
+
+  async save(input) {
+    const lineage = requireTrustedLineage(input?.lineage);
+    const mimeType = input.mime_type || input.source?.mime_type;
+    const extension = MIME_EXTENSIONS[mimeType];
+    if (!extension || (this.mediaKind === "image") !== mimeType.startsWith("image/")) {
+      throw new MediaPersistenceError();
+    }
+    const assetId = randomUUID();
+    const key = objectKey({
+      tenantId: lineage.tenant_id,
+      projectId: lineage.project_id,
+      mediaKind: this.mediaKind,
+      assetId,
+      extension,
+    });
+    let stored;
+    if (this.mediaKind === "image") {
+      stored = await this.storage.putObject({ key, data: input.data, mimeType });
+    } else {
+      stored = await this.storage.copyObject({
+        source: input.source?.location,
+        destinationKey: key,
+        allowedSourcePrefix: this.videoSourcePrefix,
+      });
+    }
+    try {
+      const asset = await this.repository.create({
+        asset_id: assetId,
+        tenant_id: lineage.tenant_id,
+        project_id: lineage.project_id,
+        generation_job_id: lineage.generation_job_id,
+        generation_id: lineage.generation_id,
+        source_kind: "generated",
+        media_kind: this.mediaKind,
+        storage_bucket: this.storage.bucket,
+        storage_key: key,
+        mime_type: mimeType,
+        ...(input.width || input.source?.width ? { width: input.width || input.source.width } : {}),
+        ...(input.height || input.source?.height ? { height: input.height || input.source.height } : {}),
+        ...(input.source?.duration_seconds ? { duration_seconds: input.source.duration_seconds } : {}),
+        ...(stored.byteSize ? { byte_size: stored.byteSize } : {}),
+        allowed_uses: this.mediaKind === "image"
+          ? ["image.generate.reference", "video.generate.reference"]
+          : [],
+        status: "active",
+        created_at: this.now().toISOString(),
+      });
+      return {
+        asset_id: asset.asset_id,
+        location: `gs://${asset.storage_bucket}/${asset.storage_key}`,
+        mime_type: asset.mime_type,
+        ...(asset.width ? { width: asset.width } : {}),
+        ...(asset.height ? { height: asset.height } : {}),
+        ...(asset.duration_seconds ? { duration_seconds: asset.duration_seconds } : {}),
+        ...(asset.byte_size ? { byte_size: asset.byte_size } : {}),
+        ...(this.mediaKind === "video" ? { container: "mp4" } : {}),
+      };
+    } catch (error) {
+      await this.storage.delete({ key });
+      if (error instanceof MediaPersistenceError) throw error;
+      throw new MediaPersistenceError();
+    }
+  }
+}
+
+class RightsAwareMediaReferenceLoader {
+  constructor({ repository, storage, delivery }) {
+    this.repository = repository;
+    this.storage = storage;
+    this.delivery = delivery;
+  }
+
+  async load(request) {
+    const asset = await this.repository.findAuthorizedReference({
+      assetId: request?.asset_id,
+      tenantId: request?.tenant_id,
+      projectId: request?.project_id,
+      requiredRight: request?.required_right,
+      mediaKind: "image",
+    });
+    if (!asset) throw new MediaAssetUnavailableError();
+    if (this.delivery === "gcs") {
+      return {
+        asset_id: asset.asset_id,
+        location: `gs://${asset.storage_bucket}/${asset.storage_key}`,
+        mime_type: asset.mime_type,
+        ...(asset.width ? { width: asset.width } : {}),
+        ...(asset.height ? { height: asset.height } : {}),
+      };
+    }
+    return {
+      asset_id: asset.asset_id,
+      data: await this.storage.download({ key: asset.storage_key, maximumBytes: MAX_IMAGE_BYTES }),
+      mime_type: asset.mime_type,
+    };
+  }
+}
+
+module.exports = {
+  DurableMediaAssetStore,
+  GoogleCloudMediaStorage,
+  MAX_IMAGE_BYTES,
+  MAX_VIDEO_BYTES,
+  RightsAwareMediaReferenceLoader,
+  objectKey,
+  parseGcsLocation,
+};

--- a/src/video-generation/repository.js
+++ b/src/video-generation/repository.js
@@ -4,6 +4,7 @@ const { VideoGenerationRecordSchema } = require("./schema");
 const IMMUTABLE_FIELDS = new Set([
   "generation_id", "parent_generation_id", "transaction_correlation_id",
   "execution_id", "user_id", "project_id", "brand_id", "campaign_id",
+  "tenant_id", "generation_job_id",
   "content_item_id", "video_purpose", "quality", "aspect_ratio",
   "duration_seconds", "created_at",
 ]);

--- a/src/video-generation/router.js
+++ b/src/video-generation/router.js
@@ -48,7 +48,9 @@ function createVideoGenerationRouter({
     let input;
     try {
       input = parse(VideoGenerationRequestSchema, req.body);
-      const operation = () => service.submit(input);
+      const operation = () => service.submit(input, {
+        job: res.locals.generationJob,
+      });
       const record = res.locals.generationJob
         ? await generationBillingOrchestrator.beginExecution({
             job: res.locals.generationJob,
@@ -76,6 +78,11 @@ function createVideoGenerationRouter({
     try {
       const generationId = parse(identifier, req.params.generationId);
       const record = await service.poll(generationId);
+      if (res.locals.generationJob && record.status === "completed") {
+        await generationBillingOrchestrator.settleSuccessfulExecution({
+          job: res.locals.generationJob,
+        });
+      }
       logger.info?.("video generation status checked", {
         execution_id: record.execution_id,
         generation_id: record.generation_id,
@@ -83,6 +90,18 @@ function createVideoGenerationRouter({
       });
       return res.status(responseStatus(record)).json(publicRecord(record));
     } catch (error) {
+      if (res.locals.generationJob) {
+        try {
+          const failed = service.get(req.params.generationId);
+          if (failed.status === "failed") {
+            await generationBillingOrchestrator.releaseFailedExecution({
+              job: res.locals.generationJob,
+            });
+          }
+        } catch (_settlementError) {
+          // Preserve the original sanitized Video failure contract.
+        }
+      }
       logger.warn?.("video generation poll failed", {
         generation_id: req.params.generationId,
         code: error?.code || "VIDEO_GENERATION_INTERNAL_ERROR",
@@ -91,10 +110,20 @@ function createVideoGenerationRouter({
     }
   });
 
-  router.get("/:generationId", (req, res, next) => {
+  router.get("/:generationId", async (req, res, next) => {
     try {
       const generationId = parse(identifier, req.params.generationId);
       const record = service.get(generationId);
+      if (res.locals.generationJob && record.status === "completed") {
+        await generationBillingOrchestrator.settleSuccessfulExecution({
+          job: res.locals.generationJob,
+        });
+      }
+      if (res.locals.generationJob && record.status === "failed") {
+        await generationBillingOrchestrator.releaseFailedExecution({
+          job: res.locals.generationJob,
+        });
+      }
       return res.status(responseStatus(record)).json(publicRecord(record));
     } catch (error) {
       return next(error);

--- a/src/video-generation/schema.js
+++ b/src/video-generation/schema.js
@@ -76,6 +76,7 @@ const NormalizedVideoAssetSourceSchema = z.object({
 }).strict();
 
 const NormalizedVideoAssetSchema = NormalizedVideoAssetSourceSchema.extend({
+  asset_id: identifier.optional(),
   byte_size: z.number().int().positive().optional(),
 }).strict();
 
@@ -125,6 +126,8 @@ const VideoGenerationRecordSchema = z.object({
   transaction_correlation_id: identifier.optional(),
   execution_id: identifier,
   user_id: identifier,
+  tenant_id: identifier.optional(),
+  generation_job_id: identifier.optional(),
   project_id: identifier,
   brand_id: identifier.optional(),
   campaign_id: identifier.optional(),

--- a/src/video-generation/service.js
+++ b/src/video-generation/service.js
@@ -74,6 +74,7 @@ class VideoGenerationService {
     try {
       loaded = await this.referenceAssetLoader.load({
         asset_id: asset.asset_id,
+        ...(request.tenant_id ? { tenant_id: request.tenant_id } : {}),
         project_id: request.project_id,
         requested_by_user_id: request.user_id,
         required_right: VIDEO_REFERENCE_RIGHT,
@@ -106,8 +107,19 @@ class VideoGenerationService {
     return { inputImage: undefined, referenceAssets };
   }
 
-  async submit(value) {
+  async submit(value, { job } = {}) {
     const request = VideoGenerationRequestSchema.parse(value);
+    if (
+      job &&
+      (job.project_id !== request.project_id ||
+        job.actor_correlation?.auth_user_id !== request.user_id)
+    ) {
+      throw new VideoGenerationInternalError();
+    }
+    const authorizedRequest = {
+      ...request,
+      ...(job ? { tenant_id: job.tenant_id } : {}),
+    };
     const createdAt = this.timestamp();
     this.repository.create({
       generation_id: request.generation_id,
@@ -115,6 +127,7 @@ class VideoGenerationService {
       transaction_correlation_id: request.transaction_correlation_id,
       execution_id: request.execution_id,
       user_id: request.user_id,
+      ...(job ? { tenant_id: job.tenant_id, generation_job_id: job.job_id } : {}),
       project_id: request.project_id,
       brand_id: request.brand_id,
       campaign_id: request.campaign_id,
@@ -130,7 +143,7 @@ class VideoGenerationService {
 
     try {
       const brandContext = await this.resolveContext(request);
-      const { inputImage, referenceAssets } = await this.resolveProviderInputs(request);
+      const { inputImage, referenceAssets } = await this.resolveProviderInputs(authorizedRequest);
       const prompt = compileVideoPrompt({
         ...request,
         input_image: inputImage,
@@ -149,6 +162,10 @@ class VideoGenerationService {
             generation_id: request.generation_id,
             execution_id: request.execution_id,
             user_id: request.user_id,
+            ...(job ? {
+              tenant_id: job.tenant_id,
+              generation_job_id: job.job_id,
+            } : {}),
             project_id: request.project_id,
             brand_id: request.brand_id,
             campaign_id: request.campaign_id,
@@ -187,6 +204,8 @@ class VideoGenerationService {
           parent_generation_id: record.parent_generation_id,
           execution_id: record.execution_id,
           user_id: record.user_id,
+          tenant_id: record.tenant_id,
+          generation_job_id: record.generation_job_id,
           project_id: record.project_id,
           brand_id: record.brand_id,
           campaign_id: record.campaign_id,

--- a/supabase/migrations/20260823133000_create_durable_media_assets.sql
+++ b/supabase/migrations/20260823133000_create_durable_media_assets.sql
@@ -1,0 +1,125 @@
+create table if not exists public.media_assets (
+  asset_id uuid primary key,
+  tenant_id text not null,
+  project_id text not null,
+  generation_job_id text,
+  generation_id text,
+  source_kind text not null,
+  media_kind text not null,
+  storage_bucket text not null,
+  storage_key text not null,
+  mime_type text not null,
+  width integer,
+  height integer,
+  duration_seconds numeric(6, 3),
+  byte_size bigint,
+  allowed_uses text[] not null default '{}',
+  status text not null default 'active',
+  created_at timestamptz not null default current_timestamp,
+  constraint media_assets_project_tenant_fkey
+    foreign key (project_id, tenant_id)
+    references public.projects (project_id, tenant_id)
+    on delete restrict,
+  constraint media_assets_generation_authority_fkey
+    foreign key (generation_job_id, tenant_id, project_id)
+    references public.generation_jobs (job_id, tenant_id, project_id)
+    on delete restrict,
+  constraint media_assets_storage_unique unique (storage_bucket, storage_key),
+  constraint media_assets_source_kind_allowed
+    check (source_kind in ('generated', 'reference')),
+  constraint media_assets_media_kind_allowed
+    check (media_kind in ('image', 'video')),
+  constraint media_assets_status_allowed
+    check (status in ('active', 'revoked', 'deleted')),
+  constraint media_assets_generated_authority_shape check (
+    source_kind <> 'generated'
+    or (generation_job_id is not null and generation_id is not null)
+  ),
+  constraint media_assets_storage_bucket_format check (
+    length(storage_bucket) between 3 and 222
+    and storage_bucket ~ '^[a-z0-9][a-z0-9._-]+[a-z0-9]$'
+  ),
+  constraint media_assets_storage_key_format check (
+    storage_key ~ '^assets/[a-f0-9]{64}/[a-f0-9]{64}/(image|video)/[0-9a-f-]{36}\.[a-z0-9]+$'
+  ),
+  constraint media_assets_mime_kind check (
+    (media_kind = 'image' and mime_type in ('image/jpeg', 'image/png', 'image/webp'))
+    or (media_kind = 'video' and mime_type = 'video/mp4')
+  ),
+  constraint media_assets_dimensions_positive check (
+    (width is null or width > 0)
+    and (height is null or height > 0)
+    and (duration_seconds is null or duration_seconds > 0)
+    and (byte_size is null or byte_size > 0)
+  ),
+  constraint media_assets_allowed_uses_bounded check (
+    allowed_uses <@ array[
+      'image.generate.reference',
+      'video.generate.reference'
+    ]::text[]
+    and cardinality(allowed_uses) <= 2
+  )
+);
+
+create index if not exists media_assets_tenant_project_asset_idx
+  on public.media_assets (tenant_id, project_id, asset_id)
+  where status = 'active';
+create index if not exists media_assets_generation_job_idx
+  on public.media_assets (generation_job_id)
+  where generation_job_id is not null;
+create index if not exists media_assets_allowed_uses_idx
+  on public.media_assets using gin (allowed_uses);
+
+create or replace function public.protect_media_asset_authority()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if new.asset_id is distinct from old.asset_id
+    or new.tenant_id is distinct from old.tenant_id
+    or new.project_id is distinct from old.project_id
+    or new.generation_job_id is distinct from old.generation_job_id
+    or new.generation_id is distinct from old.generation_id
+    or new.source_kind is distinct from old.source_kind
+    or new.media_kind is distinct from old.media_kind
+    or new.storage_bucket is distinct from old.storage_bucket
+    or new.storage_key is distinct from old.storage_key
+    or new.mime_type is distinct from old.mime_type
+    or new.width is distinct from old.width
+    or new.height is distinct from old.height
+    or new.duration_seconds is distinct from old.duration_seconds
+    or new.byte_size is distinct from old.byte_size
+    or new.created_at is distinct from old.created_at then
+    raise exception 'media asset authority and storage identity are immutable'
+      using errcode = '23514';
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists protect_media_asset_authority on public.media_assets;
+create trigger protect_media_asset_authority
+before update on public.media_assets
+for each row execute function public.protect_media_asset_authority();
+
+alter table public.media_assets enable row level security;
+
+do $$
+begin
+  if exists (select 1 from pg_roles where rolname = 'anon') then
+    revoke all on table public.media_assets from anon;
+  end if;
+  if exists (select 1 from pg_roles where rolname = 'authenticated') then
+    revoke all on table public.media_assets from authenticated;
+  end if;
+  if exists (select 1 from pg_roles where rolname = 'service_role') then
+    revoke all on table public.media_assets from service_role;
+  end if;
+end;
+$$;
+
+comment on table public.media_assets is
+  'Server-only durable Image/Video asset authority. Storage keys and generation ownership are immutable and never customer-selected.';
+comment on column public.media_assets.allowed_uses is
+  'Explicit server-owned rights allowlist checked before reference media is made provider-readable.';

--- a/test/activation-composition.test.js
+++ b/test/activation-composition.test.js
@@ -1,0 +1,222 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+const request = require("supertest");
+
+const {
+  ActivationConfigurationError,
+  createMediaProductionComposition,
+  loadCorsConfig,
+} = require("../src/activation");
+const {
+  StripeBillingConfigurationError,
+  StripeSubscriptionService,
+  createStripeProductionComposition,
+} = require("../src/billing");
+const {
+  OpenAIImageProvider,
+  UnconfiguredImageGenerationProvider,
+} = require("../src/image-generation");
+const {
+  GoogleVertexVeoProvider,
+  UnconfiguredVideoGenerationProvider,
+} = require("../src/video-generation");
+const { createApp } = require("../index");
+
+function mediaPool() {
+  return {
+    async query(sql) {
+      if (sql.includes("to_regclass('public.media_assets')")) {
+        return { rows: [{ relation: "media_assets", generation_authority: true, authority_trigger: true }] };
+      }
+      if (sql.includes("information_schema.role_table_grants")) {
+        return { rowCount: 0, rows: [] };
+      }
+      throw new Error("unexpected media initialization query");
+    },
+  };
+}
+
+function bucketFetch() {
+  return Promise.resolve({
+    ok: true,
+    async json() {
+      return {
+        name: "bizgenie-staging-media",
+        iamConfiguration: {
+          uniformBucketLevelAccess: { enabled: true },
+          publicAccessPrevention: "enforced",
+        },
+      };
+    },
+  });
+}
+
+function mediaEnv(overrides = {}) {
+  return {
+    BIZGENIE_ENVIRONMENT: "staging",
+    MEDIA_STORAGE_ENABLED: "true",
+    MEDIA_STORAGE_BUCKET: "bizgenie-staging-media",
+    IMAGE_GENERATION_ENABLED: "true",
+    VIDEO_GENERATION_ENABLED: "true",
+    OPENAI_API_KEY: "test-openai-key",
+    GOOGLE_CLOUD_PROJECT: "bizgenie-staging-12345",
+    VIDEO_PROVIDER_OUTPUT_STORAGE_URI: "gs://bizgenie-veo-staging/output/",
+    ...overrides,
+  };
+}
+
+function stripeEnv(overrides = {}) {
+  return {
+    BIZGENIE_ENVIRONMENT: "staging",
+    STRIPE_BILLING_ENABLED: "true",
+    STRIPE_MODE: "test",
+    STRIPE_SECRET_KEY: "sk_test_staging",
+    STRIPE_WEBHOOK_SECRET: "whsec_staging",
+    STRIPE_SUCCESS_URL: "https://staging-frontend.example/billing/success",
+    STRIPE_CANCEL_URL: "https://staging-frontend.example/billing/cancel",
+    STRIPE_PRICE_STANDARD: "price_StagingStandard",
+    STRIPE_POLICY_STANDARD: "policy_staging_standard_v1",
+    ...overrides,
+  };
+}
+
+describe("Image/Video production composition gates", () => {
+  it("keeps both providers disabled by default", async () => {
+    const result = await createMediaProductionComposition({ pool: mediaPool(), env: {} });
+    assert.equal(result.mediaEnabled, false);
+    assert.ok(result.imageProvider instanceof UnconfiguredImageGenerationProvider);
+    assert.ok(result.videoProvider instanceof UnconfiguredVideoGenerationProvider);
+  });
+
+  it("rejects provider activation without durable storage", async () => {
+    await assert.rejects(
+      createMediaProductionComposition({
+        pool: mediaPool(),
+        env: { IMAGE_GENERATION_ENABLED: "true" },
+      }),
+      /durable media storage/i
+    );
+  });
+
+  it("composes approved Image and Video providers only with explicit staging storage", async () => {
+    const result = await createMediaProductionComposition({
+      pool: mediaPool(),
+      env: mediaEnv(),
+      fetchImpl: bucketFetch,
+      accessTokenProvider: async () => "staging-access-token",
+    });
+    assert.equal(result.mediaEnabled, true);
+    assert.equal(result.imageEnabled, true);
+    assert.equal(result.videoEnabled, true);
+    assert.ok(result.imageProvider instanceof OpenAIImageProvider);
+    assert.ok(result.videoProvider instanceof GoogleVertexVeoProvider);
+  });
+
+  it("does not permit production activation without the separate production gate", async () => {
+    await assert.rejects(
+      createMediaProductionComposition({
+        pool: mediaPool(),
+        env: mediaEnv({ BIZGENIE_ENVIRONMENT: "production" }),
+        fetchImpl: bucketFetch,
+        accessTokenProvider: async () => "token",
+      }),
+      ActivationConfigurationError
+    );
+  });
+});
+
+describe("Stripe production composition gates", () => {
+  const dependencies = {
+    billingRepository: {},
+    billingService: {},
+    stripeFactory: () => ({}),
+  };
+
+  it("keeps Stripe routes disabled by default", () => {
+    const result = createStripeProductionComposition({ env: {} });
+    assert.equal(result.enabled, false);
+    assert.equal(result.stripeSubscriptionService, null);
+  });
+
+  it("enables test-mode Stripe only for explicit staging composition", () => {
+    const result = createStripeProductionComposition({
+      ...dependencies,
+      env: stripeEnv(),
+    });
+    assert.equal(result.enabled, true);
+    assert.ok(result.stripeSubscriptionService instanceof StripeSubscriptionService);
+    assert.equal(result.config.mode, "test");
+  });
+
+  it("rejects live Stripe in staging and production without production activation", () => {
+    assert.throws(
+      () => createStripeProductionComposition({
+        ...dependencies,
+        env: stripeEnv({
+          STRIPE_MODE: "live",
+          STRIPE_SECRET_KEY: "sk_live_staging",
+        }),
+      }),
+      StripeBillingConfigurationError
+    );
+    assert.throws(
+      () => createStripeProductionComposition({
+        ...dependencies,
+        env: stripeEnv({ BIZGENIE_ENVIRONMENT: "production" }),
+      }),
+      ActivationConfigurationError
+    );
+  });
+});
+
+describe("strict staging CORS allowlist", () => {
+  it("rejects cross-origin requests when CORS is disabled", async () => {
+    const response = await request(createApp()).get("/").set("origin", "https://frontend.example");
+    assert.equal(response.status, 403);
+    assert.equal(response.headers["access-control-allow-origin"], undefined);
+  });
+
+  it("echoes only an explicitly configured allowed origin", async () => {
+    const config = loadCorsConfig({
+      env: {
+        BIZGENIE_ENVIRONMENT: "staging",
+        CORS_ENABLED: "true",
+        CORS_ALLOWED_ORIGINS: "https://frontend-a.example,https://frontend-b.example",
+      },
+    });
+    const app = createApp({ corsConfig: config });
+    const allowed = await request(app).get("/").set("origin", "https://frontend-a.example");
+    assert.equal(allowed.status, 200);
+    assert.equal(allowed.headers["access-control-allow-origin"], "https://frontend-a.example");
+    const denied = await request(app).get("/").set("origin", "https://attacker.example");
+    assert.equal(denied.status, 403);
+
+    const preflight = await request(app)
+      .options("/customer/generate-video")
+      .set("origin", "https://frontend-a.example")
+      .set("access-control-request-method", "POST")
+      .set("access-control-request-headers", "authorization, content-type");
+    assert.equal(preflight.status, 204);
+    const widened = await request(app)
+      .options("/customer/generate-video")
+      .set("origin", "https://frontend-a.example")
+      .set("access-control-request-method", "POST")
+      .set("access-control-request-headers", "x-admin-key");
+    assert.equal(widened.status, 403);
+  });
+
+  it("rejects wildcard, path-bearing, and partial allowlist configuration", () => {
+    for (const allowedOrigins of ["*", "https://frontend.example/path", ""]) {
+      assert.throws(
+        () => loadCorsConfig({
+          env: {
+            BIZGENIE_ENVIRONMENT: "staging",
+            CORS_ENABLED: "true",
+            CORS_ALLOWED_ORIGINS: allowedOrigins,
+          },
+        }),
+        ActivationConfigurationError
+      );
+    }
+  });
+});

--- a/test/customer-video-activation.test.js
+++ b/test/customer-video-activation.test.js
@@ -1,0 +1,246 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+const request = require("supertest");
+
+const {
+  AuthenticationRequiredError,
+  InMemoryAuthorizationRepository,
+  createCustomerActorFromVerifiedIdentity,
+} = require("../src/authorization");
+const { InMemoryBrandBrainRepository } = require("../src/brand-brain");
+const { GenerationBillingOrchestrator } = require("../src/generation-billing");
+const { InMemoryGenerationJobRepository } = require("../src/generation-jobs");
+const {
+  InMemoryVideoGenerationRepository,
+  VideoGenerationProvider,
+} = require("../src/video-generation");
+const { createApp } = require("../index");
+
+const USER_A = "11111111-1111-4111-8111-111111111111";
+const USER_B = "22222222-2222-4222-8222-222222222222";
+
+class Tokens {
+  async verifyAccessToken(token) {
+    if (token === "token-a") return createCustomerActorFromVerifiedIdentity({ verifiedAuthUserId: USER_A });
+    if (token === "token-b") return createCustomerActorFromVerifiedIdentity({ verifiedAuthUserId: USER_B });
+    throw new AuthenticationRequiredError();
+  }
+}
+
+class FixtureVideoProvider extends VideoGenerationProvider {
+  constructor({ fail = false } = {}) {
+    super();
+    this.fail = fail;
+    this.submissions = 0;
+    this.polls = 0;
+  }
+  async submit() {
+    this.submissions += 1;
+    return {
+      provider: "fixture",
+      provider_job_id: "operation_video_001",
+      provider_model: "fixture-video-model",
+    };
+  }
+  async poll() {
+    this.polls += 1;
+    if (this.fail) {
+      return {
+        provider: "fixture",
+        provider_job_id: "operation_video_001",
+        provider_model: "fixture-video-model",
+        status: "failed",
+        error_code: "VIDEO_PROVIDER_FAILED",
+      };
+    }
+    return {
+      provider: "fixture",
+      provider_job_id: "operation_video_001",
+      provider_model: "fixture-video-model",
+      status: "completed",
+      asset_source: {
+        location: "gs://provider-staging/output/video.mp4",
+        mime_type: "video/mp4",
+        width: 1280,
+        height: 720,
+        duration_seconds: 4,
+        container: "mp4",
+      },
+    };
+  }
+}
+
+function authorizationRepository() {
+  return new InMemoryAuthorizationRepository({
+    customerProfiles: [
+      { auth_user_id: USER_A, display_name: "A" },
+      { auth_user_id: USER_B, display_name: "B" },
+    ],
+    tenants: [
+      { tenant_id: "tenant_a", name: "A", created_by: USER_A },
+      { tenant_id: "tenant_b", name: "B", created_by: USER_B },
+    ],
+    memberships: [
+      { tenant_id: "tenant_a", auth_user_id: USER_A, role: "owner" },
+      { tenant_id: "tenant_b", auth_user_id: USER_B, role: "owner" },
+    ],
+    projects: [
+      { project_id: "project_a", tenant_id: "tenant_a", name: "A" },
+      { project_id: "project_b", tenant_id: "tenant_b", name: "B" },
+    ],
+  });
+}
+
+function videoRequest(overrides = {}) {
+  return {
+    tenant_id: "tenant_a",
+    project_id: "project_a",
+    execution_id: "execution_video_001",
+    generation_id: "generation_video_001",
+    topic: "Staging launch",
+    video_purpose: "Golden Journey proof",
+    quality: "normal",
+    aspect_ratio: "16:9",
+    duration_seconds: 4,
+    ...overrides,
+  };
+}
+
+function fixture({ fail = false } = {}) {
+  const effects = { reserve: 0, debit: 0, release: 0 };
+  const billingService = {
+    async createReservation(input) {
+      effects.reserve += 1;
+      effects.reservationInput = input;
+      return { ledger_entry_id: "reservation_video_001", generation_id: input.generationId };
+    },
+    async finalizeDebit(input) {
+      effects.debit += 1;
+      effects.debitInput = input;
+      return { ledger_entry_id: "debit_video_001", generation_id: "unused" };
+    },
+    async releaseReservation(input) {
+      effects.release += 1;
+      effects.releaseInput = input;
+      return { ledger_entry_id: "release_video_001" };
+    },
+  };
+  const generationBillingOrchestrator = new GenerationBillingOrchestrator({
+    billingService,
+    logger: { error() {} },
+  });
+  const provider = new FixtureVideoProvider({ fail });
+  const generationJobRepository = new InMemoryGenerationJobRepository();
+  const videoGenerationRepository = new InMemoryVideoGenerationRepository();
+  const app = createApp({
+    authorizationRepository: authorizationRepository(),
+    brandBrainRepository: new InMemoryBrandBrainRepository(),
+    customerTokenVerifier: new Tokens(),
+    generationBillingOrchestrator,
+    generationJobRepository,
+    videoGenerationRepository,
+    videoProvider: provider,
+    videoAssetStore: {
+      async save({ lineage, source }) {
+        assert.equal(lineage.tenant_id, "tenant_a");
+        assert.match(lineage.generation_job_id, /^[0-9a-f-]{36}$/);
+        return {
+          asset_id: "33333333-3333-4333-8333-333333333333",
+          location: "gs://bizgenie-staging-media/durable/video.mp4",
+          mime_type: source.mime_type,
+          width: source.width,
+          height: source.height,
+          duration_seconds: source.duration_seconds,
+          container: "mp4",
+          byte_size: 1024,
+        };
+      },
+    },
+    videoReferenceAssetLoader: { async load() { throw new Error("not used"); } },
+    logger: { info() {}, warn() {}, error() {} },
+  });
+  return { app, effects, provider, generationJobRepository, videoGenerationRepository };
+}
+
+function customer(client, token = "token-a") {
+  return client.set("authorization", `Bearer ${token}`);
+}
+
+describe("customer Video Auth -> immutable job -> Billing -> async settlement", () => {
+  it("authorizes and reserves submission, then debits only after durable completion", async () => {
+    const f = fixture();
+    const submitted = await customer(
+      request(f.app).post("/customer/generate-video")
+    ).send(videoRequest({ user_id: USER_B }));
+    assert.equal(submitted.status, 202);
+    assert.equal(f.effects.reserve, 1);
+    assert.equal(f.effects.debit, 0);
+    assert.equal(f.provider.submissions, 1);
+
+    const [job] = [...f.generationJobRepository.jobsById.values()];
+    assert.equal(job.tenant_id, "tenant_a");
+    assert.equal(job.project_id, "project_a");
+    assert.equal(job.actor_correlation.auth_user_id, USER_A);
+    assert.equal(job.execution_class, "video.normal");
+
+    const completed = await customer(
+      request(f.app).post("/customer/generate-video/generation_video_001/poll")
+    );
+    assert.equal(completed.status, 200);
+    assert.equal(completed.body.status, "completed");
+    assert.equal(f.effects.debit, 1);
+    assert.equal(f.effects.release, 0);
+    assert.equal(completed.body.video.asset.asset_id, "33333333-3333-4333-8333-333333333333");
+
+    const repeated = await customer(
+      request(f.app).post("/customer/generate-video/generation_video_001/poll")
+    );
+    assert.equal(repeated.status, 200);
+    assert.equal(f.effects.debit, 1);
+    assert.equal(f.provider.submissions, 1);
+  });
+
+  it("denies cross-tenant status/poll access before provider or Billing settlement", async () => {
+    const f = fixture();
+    await customer(request(f.app).post("/customer/generate-video")).send(videoRequest());
+    const denied = await customer(
+      request(f.app).post("/customer/generate-video/generation_video_001/poll"),
+      "token-b"
+    );
+    assert.equal(denied.status, 404);
+    assert.equal(denied.body.error.code, "RESOURCE_NOT_AVAILABLE");
+    assert.equal(f.provider.polls, 0);
+    assert.equal(f.effects.debit, 0);
+    assert.equal(f.effects.release, 0);
+  });
+
+  it("releases the reservation exactly once after a terminal provider failure", async () => {
+    const f = fixture({ fail: true });
+    await customer(request(f.app).post("/customer/generate-video")).send(videoRequest());
+    const failed = await customer(
+      request(f.app).post("/customer/generate-video/generation_video_001/poll")
+    );
+    assert.equal(failed.status, 502);
+    assert.equal(f.effects.reserve, 1);
+    assert.equal(f.effects.debit, 0);
+    assert.equal(f.effects.release, 1);
+
+    const repeated = await customer(
+      request(f.app).get("/customer/generate-video/generation_video_001")
+    );
+    assert.equal(repeated.status, 200);
+    assert.equal(repeated.body.status, "failed");
+    assert.equal(f.effects.release, 1);
+  });
+
+  it("rejects cross-tenant submission before job, reservation, or provider access", async () => {
+    const f = fixture();
+    const denied = await customer(
+      request(f.app).post("/customer/generate-video")
+    ).send(videoRequest({ tenant_id: "tenant_b", project_id: "project_b" }));
+    assert.equal(denied.status, 404);
+    assert.equal(f.generationJobRepository.size(), 0);
+    assert.equal(f.effects.reserve, 0);
+    assert.equal(f.provider.submissions, 0);
+  });
+});

--- a/test/media-activation.test.js
+++ b/test/media-activation.test.js
@@ -1,0 +1,243 @@
+const assert = require("node:assert/strict");
+const { readFileSync } = require("node:fs");
+const { join } = require("node:path");
+const { describe, it } = require("node:test");
+
+const { InMemoryBrandBrainRepository } = require("../src/brand-brain");
+const {
+  ImageGenerationService,
+  InMemoryImageGenerationRepository,
+  OpenAIImageProvider,
+  ImageProviderRejectedError,
+} = require("../src/image-generation");
+const {
+  InMemoryMediaAssetRepository,
+  MediaAssetUnavailableError,
+  RightsAwareMediaReferenceLoader,
+  objectKey,
+} = require("../src/media");
+
+const MIGRATION = readFileSync(
+  join(__dirname, "..", "supabase", "migrations", "20260823133000_create_durable_media_assets.sql"),
+  "utf8"
+);
+const ASSET_ID = "11111111-1111-4111-8111-111111111111";
+const JOB_ID = "22222222-2222-4222-8222-222222222222";
+
+function asset(overrides = {}) {
+  return {
+    asset_id: ASSET_ID,
+    tenant_id: "tenant_a",
+    project_id: "project_a",
+    generation_job_id: JOB_ID,
+    generation_id: "generation_source_001",
+    source_kind: "generated",
+    media_kind: "image",
+    storage_bucket: "bizgenie-staging-media",
+    storage_key: objectKey({
+      tenantId: "tenant_a",
+      projectId: "project_a",
+      mediaKind: "image",
+      assetId: ASSET_ID,
+      extension: "png",
+    }),
+    mime_type: "image/png",
+    width: 1024,
+    height: 1024,
+    byte_size: 100,
+    allowed_uses: ["image.generate.reference", "video.generate.reference"],
+    status: "active",
+    created_at: "2026-08-23T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("durable media authority migration", () => {
+  it("binds generated assets to immutable tenant, project, and generation-job authority", () => {
+    assert.match(MIGRATION, /create table if not exists public\.media_assets/i);
+    assert.match(MIGRATION, /foreign key \(project_id, tenant_id\)/i);
+    assert.match(MIGRATION, /foreign key \(generation_job_id, tenant_id, project_id\)/i);
+    assert.match(MIGRATION, /protect_media_asset_authority/i);
+    assert.match(MIGRATION, /storage_key ~ '\^assets\//i);
+  });
+
+  it("keeps the table server-only with RLS and explicit customer-role revocation", () => {
+    assert.match(MIGRATION, /enable row level security/i);
+    for (const role of ["anon", "authenticated", "service_role"]) {
+      assert.match(MIGRATION, new RegExp(`revoke all on table public\\.media_assets from ${role}`, "i"));
+    }
+  });
+});
+
+describe("tenant/project media ownership and rights", () => {
+  it("denies cross-tenant and cross-project reference access without enumeration", async () => {
+    const repository = new InMemoryMediaAssetRepository();
+    await repository.create(asset());
+    const loader = new RightsAwareMediaReferenceLoader({
+      repository,
+      storage: {},
+      delivery: "gcs",
+    });
+
+    for (const request of [
+      { tenant_id: "tenant_b", project_id: "project_a" },
+      { tenant_id: "tenant_a", project_id: "project_b" },
+    ]) {
+      await assert.rejects(
+        loader.load({
+          asset_id: ASSET_ID,
+          required_right: "video.generate.reference",
+          ...request,
+        }),
+        MediaAssetUnavailableError
+      );
+    }
+  });
+
+  it("denies revoked or disallowed reference use before storage access", async () => {
+    const repository = new InMemoryMediaAssetRepository();
+    await repository.create(asset({ allowed_uses: ["video.generate.reference"] }));
+    let downloads = 0;
+    const loader = new RightsAwareMediaReferenceLoader({
+      repository,
+      storage: { async download() { downloads += 1; } },
+      delivery: "bytes",
+    });
+    await assert.rejects(
+      loader.load({
+        asset_id: ASSET_ID,
+        tenant_id: "tenant_a",
+        project_id: "project_a",
+        required_right: "image.generate.reference",
+      }),
+      MediaAssetUnavailableError
+    );
+    assert.equal(downloads, 0);
+  });
+
+  it("derives storage keys from trusted ownership and never from a requested location", () => {
+    const first = objectKey({
+      tenantId: "tenant_a",
+      projectId: "project_a",
+      mediaKind: "image",
+      assetId: ASSET_ID,
+      extension: "png",
+    });
+    const second = objectKey({
+      tenantId: "tenant_a",
+      projectId: "project_b",
+      mediaKind: "image",
+      assetId: ASSET_ID,
+      extension: "png",
+    });
+    assert.match(first, /^assets\/[a-f0-9]{64}\/[a-f0-9]{64}\/image\//);
+    assert.notEqual(first, second);
+    assert.doesNotMatch(first, /attacker|https?:|gs:\/\//);
+  });
+});
+
+describe("Image reference-rights boundary", () => {
+  it("denies a cross-project reference before any OpenAI request", async () => {
+    const repository = new InMemoryMediaAssetRepository();
+    await repository.create(asset());
+    let providerCalls = 0;
+    const provider = new OpenAIImageProvider({
+      apiKey: "test-key",
+      assetStore: { async save() { throw new Error("must not store"); } },
+      referenceAssetLoader: new RightsAwareMediaReferenceLoader({
+        repository,
+        storage: { async download() { throw new Error("must not download"); } },
+        delivery: "bytes",
+      }),
+      fetchImpl: async () => {
+        providerCalls += 1;
+        throw new Error("must not call provider");
+      },
+    });
+    const service = new ImageGenerationService({
+      repository: new InMemoryImageGenerationRepository(),
+      provider,
+      brandBrainRepository: new InMemoryBrandBrainRepository(),
+    });
+    await assert.rejects(
+      service.generate({
+        execution_id: "execution_cross_project_001",
+        generation_id: "generation_cross_project_001",
+        user_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        project_id: "project_b",
+        topic: "Safe media",
+        image_purpose: "reference rights test",
+        aspect_ratio: "1:1",
+        reference_assets: [{ asset_id: ASSET_ID }],
+      }, {
+        job: {
+          job_id: JOB_ID,
+          tenant_id: "tenant_a",
+          project_id: "project_b",
+          actor_correlation: {
+            kind: "customer",
+            auth_user_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          },
+        },
+      }),
+      ImageProviderRejectedError
+    );
+    assert.equal(providerCalls, 0);
+  });
+
+  it("strips arbitrary locations and supplies only job-derived ownership to the provider", async () => {
+    let providerRequest;
+    const service = new ImageGenerationService({
+      repository: new InMemoryImageGenerationRepository(),
+      provider: { async generate(request) {
+        providerRequest = request;
+        return {
+          provider: "fixture",
+          provider_job_id: "provider_job_001",
+          asset: {
+            location: "gs://bizgenie-staging-media/generated.png",
+            mime_type: "image/png",
+            width: 1024,
+            height: 1024,
+          },
+        };
+      } },
+      brandBrainRepository: new InMemoryBrandBrainRepository(),
+    });
+    await service.generate({
+      execution_id: "execution_image_001",
+      generation_id: "generation_image_001",
+      user_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      project_id: "project_a",
+      topic: "Safe media",
+      image_purpose: "reference rights test",
+      aspect_ratio: "1:1",
+      reference_assets: [{
+        asset_id: ASSET_ID,
+        location: "https://attacker.example/asset.png",
+        mime_type: "image/png",
+      }],
+    }, {
+      job: {
+        job_id: JOB_ID,
+        tenant_id: "tenant_a",
+        project_id: "project_a",
+        actor_correlation: {
+          kind: "customer",
+          auth_user_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        },
+      },
+    });
+
+    assert.deepEqual(providerRequest.reference_assets, [{
+      asset_id: ASSET_ID,
+      tenant_id: "tenant_a",
+      project_id: "project_a",
+      requested_by_user_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      required_right: "image.generate.reference",
+      generation_id: "generation_image_001",
+      execution_id: "execution_image_001",
+    }]);
+    assert.doesNotMatch(JSON.stringify(providerRequest.reference_assets), /attacker\.example/);
+  });
+});

--- a/test/postgres-billing.integration.test.js
+++ b/test/postgres-billing.integration.test.js
@@ -18,6 +18,10 @@ const {
   GenerationBillingOrchestrator,
   GenerationBillingUnavailableError,
 } = require("../src/generation-billing");
+const {
+  PostgresMediaAssetRepository,
+  objectKey,
+} = require("../src/media");
 
 const ADMIN_DATABASE_URL = process.env.TEST_DATABASE_URL;
 const postgresDescribe = ADMIN_DATABASE_URL ? describe : describe.skip;
@@ -119,6 +123,7 @@ postgresDescribe("PostgresBillingRepository real PostgreSQL adversarial proof", 
   async function resetFixture() {
     await pool.query(`
       TRUNCATE TABLE
+        public.media_assets,
         public.stripe_bolt_on_payment_evidence,
         public.stripe_webhook_events,
         public.stripe_subscription_mappings,
@@ -774,6 +779,48 @@ postgresDescribe("PostgresBillingRepository real PostgreSQL adversarial proof", 
         client.release();
       }
     }
+  });
+
+  it("persists tenant/project media authority and denies cross-boundary lookup", async () => {
+    const media = new PostgresMediaAssetRepository({ pool });
+    await media.initialize();
+    const assetId = "33333333-3333-4333-8333-333333333333";
+    await media.create({
+      asset_id: assetId,
+      tenant_id: "tenant_a",
+      project_id: "project_a",
+      generation_job_id: "job_image",
+      generation_id: "generation_image_001",
+      source_kind: "generated",
+      media_kind: "image",
+      storage_bucket: "bizgenie-staging-media",
+      storage_key: objectKey({
+        tenantId: "tenant_a",
+        projectId: "project_a",
+        mediaKind: "image",
+        assetId,
+        extension: "png",
+      }),
+      mime_type: "image/png",
+      width: 1024,
+      height: 1024,
+      byte_size: 1024,
+      allowed_uses: ["image.generate.reference"],
+      status: "active",
+      created_at: NOW,
+    });
+    assert.ok(await media.findAuthorizedReference({
+      assetId,
+      tenantId: "tenant_a",
+      projectId: "project_a",
+      requiredRight: "image.generate.reference",
+    }));
+    assert.equal(await media.findAuthorizedReference({
+      assetId,
+      tenantId: "tenant_b",
+      projectId: "project_b",
+      requiredRight: "image.generate.reference",
+    }), null);
   });
 
   it("reports old unfinished reservations without mutating them", async () => {


### PR DESCRIPTION
## Summary

Closes only the staging activation gaps proved by Issue #39 and the Phase-A reconnaissance:

- adds server-owned durable Image/Video asset authority with immutable tenant, project, generation-job, rights, and storage metadata
- derives private Cloud Storage object keys server-side and resolves reference assets only after exact ownership and allowed-use checks
- composes Image, Veo/Video, and Stripe behind independent fail-closed activation flags with explicit staging/production mode separation
- adds the customer Video Auth → immutable job → Billing reservation → asynchronous debit/release path
- adds strict opt-in CORS with an exact configured origin allowlist
- documents a non-production-only staging activation sequence; production remains off by default

Canonical Auth, Billing, generation-job, commercial-credit, and provider-cost authority are preserved. This PR does not deploy, apply migrations, provision resources, or activate production.

## Deterministic coverage

- cross-tenant media and customer Video denial
- cross-project Image/Video reference denial
- arbitrary asset-location injection denial
- Image allowed-use enforcement before provider access
- customer Video authorization, immutable job creation, reservation, debit, release, and idempotent settlement
- Stripe disabled/enabled, test/live separation, and production gate
- Image/Video disabled/enabled and missing dependency fail-closed behavior
- strict CORS origin, method, and header allowlisting
- existing Text/Image/Video/Auth/Billing/Stripe regressions

## Validation

- Node.js v22.23.2
- JavaScript syntax: 150 files passed
- complete suite: 365 passed, 0 failed
- PostgreSQL migrations parsed successfully
- `git diff --check`: passed
- GitHub Actions CI #64: passed
  - Node 22 tests and syntax, including PostgreSQL 17 adversarial tests
  - Node 22 Docker and Google Buildpack artifact checks

Refs #39