### PR TITLE
BG-ACT-001E: add dedicated Stripe webhook ingress

### DIFF
--- a/stripe-webhook-ingress.js
+++ b/stripe-webhook-ingress.js
@@ -1,0 +1,120 @@
+const express = require("express");
+const { createPostgresBrandBrainRepositoryFromEnv } = require("./src/brand-brain");
+const {
+  createPostgresBillingProductionComposition,
+  createStripeProductionComposition,
+} = require("./src/billing");
+const {
+  StripeBillingError,
+  sendStripeBillingError,
+} = require("./src/billing/stripe/errors");
+
+function createStripeWebhookIngress({ service, logger = console } = {}) {
+  if (!service || typeof service.handleWebhook !== "function") {
+    throw new TypeError("A Stripe subscription service is required");
+  }
+
+  const app = express();
+
+  app.get("/", (_req, res) => {
+    res.status(200).json({ status: "ok", service: "stripe-webhook-ingress" });
+  });
+
+  app.post(
+    "/webhook",
+    express.raw({ type: "application/json", limit: "1mb" }),
+    async (req, res, next) => {
+      try {
+        const result = await service.handleWebhook({
+          rawBody: req.body,
+          signature: req.header("stripe-signature"),
+        });
+        logger.info?.("stripe ingress webhook processed", {
+          event_id: result.event_id,
+          event_type: result.event_type,
+          handled: result.handled,
+          replay: result.replay,
+          stale: result.stale,
+        });
+        return res.json({
+          received: true,
+          handled: result.handled,
+          replay: result.replay,
+        });
+      } catch (error) {
+        logger.warn?.("stripe ingress webhook rejected", {
+          code: error?.code || "STRIPE_WEBHOOK_INTERNAL_ERROR",
+        });
+        return next(error);
+      }
+    }
+  );
+
+  app.use((error, _req, res, _next) => {
+    if (sendStripeBillingError(error, res)) return;
+    if (!(error instanceof StripeBillingError)) {
+      logger.error?.("stripe ingress internal error", {
+        code: error?.code || "STRIPE_WEBHOOK_INTERNAL_ERROR",
+      });
+    }
+    return res.status(500).json({
+      error: {
+        code: "STRIPE_WEBHOOK_INTERNAL_ERROR",
+        message: "Webhook processing failed",
+      },
+    });
+  });
+
+  return app;
+}
+
+async function createProductionStripeWebhookIngress({ env = process.env, logger = console } = {}) {
+  const database = createPostgresBrandBrainRepositoryFromEnv({ env });
+  const billing = await createPostgresBillingProductionComposition({
+    pool: database.pool,
+    env,
+    logger,
+  });
+  const stripe = createStripeProductionComposition({
+    billingRepository: billing.billingRepository,
+    billingService: billing.billingService,
+    env,
+  });
+  if (!stripe.enabled || !stripe.stripeSubscriptionService) {
+    throw new Error("Stripe webhook ingress is not configured");
+  }
+  return {
+    app: createStripeWebhookIngress({
+      service: stripe.stripeSubscriptionService,
+      logger,
+    }),
+    database,
+    billing,
+    stripe,
+  };
+}
+
+async function startStripeWebhookIngress({ env = process.env, logger = console } = {}) {
+  const production = await createProductionStripeWebhookIngress({ env, logger });
+  const port = env.PORT || 8080;
+  const server = production.app.listen(port, () => {
+    logger.log?.("Stripe webhook ingress listening on", port);
+  });
+  return { ...production, server };
+}
+
+if (require.main === module) {
+  startStripeWebhookIngress().catch((error) => {
+    console.error("Stripe webhook ingress startup failed", {
+      name: error?.name || "Error",
+      code: error?.code || "STARTUP_ERROR",
+    });
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  createProductionStripeWebhookIngress,
+  createStripeWebhookIngress,
+  startStripeWebhookIngress,
+};

--- a/test/stripe-webhook-ingress.test.js
+++ b/test/stripe-webhook-ingress.test.js
@@ -1,0 +1,119 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const request = require("supertest");
+
+const {
+  createStripeWebhookIngress,
+} = require("../stripe-webhook-ingress");
+const {
+  StripeSignatureVerificationError,
+} = require("../src/billing/stripe/errors");
+
+test("ingress exposes health and only dedicated webhook surface", async () => {
+  const app = createStripeWebhookIngress({
+    service: {
+      async handleWebhook() {
+        return { handled: true, replay: false };
+      },
+    },
+    logger: { info() {}, warn() {}, error() {} },
+  });
+
+  const health = await request(app).get("/");
+  assert.equal(health.status, 200);
+  assert.deepEqual(health.body, {
+    status: "ok",
+    service: "stripe-webhook-ingress",
+  });
+
+  assert.equal((await request(app).post("/billing/stripe/checkout")).status, 404);
+  assert.equal((await request(app).get("/_admin/ping")).status, 404);
+  assert.equal((await request(app).post("/customer/generate-script")).status, 404);
+});
+
+test("webhook preserves exact raw bytes and Stripe signature header", async () => {
+  const seen = [];
+  const app = createStripeWebhookIngress({
+    service: {
+      async handleWebhook(input) {
+        seen.push(input);
+        return {
+          event_id: "evt_test_001",
+          event_type: "invoice.paid",
+          handled: true,
+          replay: false,
+          stale: false,
+        };
+      },
+    },
+    logger: { info() {}, warn() {}, error() {} },
+  });
+  const payload = Buffer.from('{"id":"evt_test_001","type":"invoice.paid"}');
+
+  const response = await request(app)
+    .post("/webhook")
+    .set("Content-Type", "application/json")
+    .set("stripe-signature", "t=1,v1=test")
+    .send(payload);
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(response.body, {
+    received: true,
+    handled: true,
+    replay: false,
+  });
+  assert.equal(seen.length, 1);
+  assert.equal(Buffer.isBuffer(seen[0].rawBody), true);
+  assert.deepEqual(seen[0].rawBody, payload);
+  assert.equal(seen[0].signature, "t=1,v1=test");
+});
+
+test("invalid Stripe signature is fail-closed and sanitized", async () => {
+  const app = createStripeWebhookIngress({
+    service: {
+      async handleWebhook() {
+        throw new StripeSignatureVerificationError();
+      },
+    },
+    logger: { info() {}, warn() {}, error() {} },
+  });
+
+  const response = await request(app)
+    .post("/webhook")
+    .set("Content-Type", "application/json")
+    .send('{"id":"evt_bad"}');
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(response.body, {
+    error: {
+      code: "STRIPE_SIGNATURE_INVALID",
+      message: "Webhook signature verification failed",
+    },
+  });
+});
+
+test("unexpected ingress failures do not expose internals", async () => {
+  const app = createStripeWebhookIngress({
+    service: {
+      async handleWebhook() {
+        throw new Error("database password should never leak");
+      },
+    },
+    logger: { info() {}, warn() {}, error() {} },
+  });
+
+  const response = await request(app)
+    .post("/webhook")
+    .set("Content-Type", "application/json")
+    .set("stripe-signature", "t=1,v1=test")
+    .send('{"id":"evt_internal"}');
+
+  assert.equal(response.status, 500);
+  assert.deepEqual(response.body, {
+    error: {
+      code: "STRIPE_WEBHOOK_INTERNAL_ERROR",
+      message: "Webhook processing failed",
+    },
+  });
+  assert.equal(JSON.stringify(response.body).includes("database password"), false);
+});

--- a/test/stripe-webhook-ingress.test.js
+++ b/test/stripe-webhook-ingress.test.js
@@ -48,7 +48,8 @@ test("webhook preserves exact raw bytes and Stripe signature header", async () =
     },
     logger: { info() {}, warn() {}, error() {} },
   });
-  const payload = Buffer.from('{"id":"evt_test_001","type":"invoice.paid"}');
+  const payload = '{"id":"evt_test_001","type":"invoice.paid"}';
+  const expectedBytes = Buffer.from(payload, "utf8");
 
   const response = await request(app)
     .post("/webhook")
@@ -64,7 +65,7 @@ test("webhook preserves exact raw bytes and Stripe signature header", async () =
   });
   assert.equal(seen.length, 1);
   assert.equal(Buffer.isBuffer(seen[0].rawBody), true);
-  assert.deepEqual(seen[0].rawBody, payload);
+  assert.deepEqual(seen[0].rawBody, expectedBytes);
   assert.equal(seen[0].signature, "t=1,v1=test");
 });
 


### PR DESCRIPTION
## Scope
Implements the narrow staging blocker exposed by BG-ACT-001 (#39): Stripe webhook deliveries are rejected by Cloud Run IAM before reaching the private API.

## Change
- Adds a separate `stripe-webhook-ingress.js` entrypoint intended for a dedicated public Cloud Run service.
- Exposes only `GET /` health and `POST /webhook`.
- Reuses the canonical durable Billing + Stripe subscription service and existing raw-body signature verification/idempotency paths.
- Does **not** expose checkout, admin, generation, customer, or service-principal routes.
- Keeps the canonical main API architecture unchanged and suitable to remain IAM-private.
- Adds tests for route minimization, exact raw-body preservation, signature failure, and sanitized unexpected failures.

## Deployment intent
Staging only first. Deploy this same image with command `node stripe-webhook-ingress.js` as a separate Cloud Run service, allow unauthenticated invocation only on that service, mount the existing staging DB/Stripe test secrets and policy config, then repoint the Stripe sandbox webhook destination to `/webhook` and replay existing failed events.

No production deployment or live Stripe activation is authorized by this PR.