### PR TITLE
BG-ACT-001H: restart-safe Billing settlement reconstruction

### DIFF
--- a/docs/activation/STAGING_ACTIVATION.md
+++ b/docs/activation/STAGING_ACTIVATION.md
@@ -60,10 +60,13 @@ Submission uses the existing verified customer authorization chain, creates
 the existing immutable generation job with `video.normal` or `video.premium`,
 and reserves credits before provider submission. A processing result remains
 reserved. Completion debits only after durable asset persistence. A terminal
-provider failure releases the reservation. Repeated poll/get calls reuse the
-existing idempotent settlement promise and durable Billing effect. Status and
-poll authority is derived from the stored Video record and immutable job;
-customer query/body values cannot reinterpret it for another tenant.
+provider failure releases the reservation. A fresh process reconstructs the
+reservation and any debit/release from the canonical Billing ledger by the
+immutable generation job and deterministic financial keys; process-local
+promises remain only a coalescing cache. Repeated poll/get calls reuse the
+durable exactly-once Billing effect. Status and poll authority is derived from
+the stored Video record and immutable job; customer query/body values cannot
+reinterpret it for another tenant.
 
 ## Activation variables
 

--- a/src/authentication/customerVideoStatusBoundary.js
+++ b/src/authentication/customerVideoStatusBoundary.js
@@ -7,7 +7,16 @@ function createCustomerVideoStatusBoundary({tokenVerifier,authorizationService,v
       const actor=await tokenVerifier.verifyAccessToken(extractBearerToken(req.header("authorization")));
       const record=await videoGenerationService.get(generationId); if(!record.tenant_id||!record.generation_job_id) throw new AuthorizationDeniedError();
       const authorization=record.brand_id?await authorizationService.authorizeProjectBrand({actor,tenantId:record.tenant_id,projectId:record.project_id,brandId:record.brand_id,action:"generation:create"}):await authorizationService.authorizeProject({actor,tenantId:record.tenant_id,projectId:record.project_id,action:"generation:create"});
-      const job=await generationJobRepository.getById(record.generation_job_id); if(!job||job.tenant_id!==authorization.tenant_id||job.project_id!==authorization.project_id||job.actor_correlation?.auth_user_id!==actor.auth_user_id) throw new AuthorizationDeniedError();
+      const job=await generationJobRepository.getById(record.generation_job_id); if(
+        !job||
+        job.job_id!==record.generation_job_id||
+        job.tenant_id!==authorization.tenant_id||
+        job.project_id!==authorization.project_id||
+        job.request_correlation_id!==record.execution_id||
+        job.execution_class!==`video.${record.quality}`||
+        job.actor_correlation?.auth_user_id!==actor.auth_user_id||
+        record.user_id!==actor.auth_user_id
+      ) throw new AuthorizationDeniedError();
       res.locals.customerAuthorization=authorization; res.locals.generationJob=job; return next();
     }catch(error){
       if(error instanceof AuthenticationRequiredError) return res.status(401).json(responseBody("video",AUTHENTICATION_ERROR));

--- a/src/billing/postgresRepository.js
+++ b/src/billing/postgresRepository.js
@@ -532,6 +532,53 @@ class PostgresBillingRepository extends BillingRepository {
     });
   }
 
+  async findGenerationBillingState(input) {
+    return this.read(async () => {
+      const result = await this.pool.query(
+        `SELECT row_to_json(reservation) AS reservation,
+                job.execution_class,
+                row_to_json(settlement) AS settlement
+           FROM public.credit_ledger AS reservation
+           LEFT JOIN public.generation_jobs AS job
+             ON job.job_id = reservation.generation_id
+            AND job.tenant_id = reservation.tenant_id
+            AND job.project_id = reservation.project_id
+            AND job.execution_class = $3
+           LEFT JOIN public.credit_ledger AS settlement
+             ON settlement.account_id = reservation.account_id
+            AND settlement.tenant_id = reservation.tenant_id
+            AND settlement.reservation_entry_id = reservation.ledger_entry_id
+            AND settlement.entry_type IN ('debit', 'reservation_release')
+          WHERE reservation.entry_type = 'reservation'
+            AND (
+              reservation.idempotency_key = $1
+              OR reservation.generation_id = $2
+            )`,
+        [
+          input.reservation_idempotency_key,
+          input.generation_id,
+          input.execution_class,
+        ]
+      );
+      if (result.rows.length === 0) return null;
+      if (result.rows.length !== 1) {
+        throw new FinancialResourceUnavailableError();
+      }
+      const row = result.rows[0];
+      const reservation = mapLedger(row.reservation);
+      if (row.execution_class !== input.execution_class) {
+        throw new FinancialResourceUnavailableError();
+      }
+      return Object.freeze({
+        execution_class: row.execution_class,
+        reservation,
+        settlement: row.settlement?.ledger_entry_id
+          ? mapLedger(row.settlement)
+          : null,
+      });
+    });
+  }
+
   async requireLockedAccount(client, tenantId) {
     const result = await client.query(
       `SELECT account_id, tenant_id, status, created_at
@@ -732,7 +779,7 @@ class PostgresBillingRepository extends BillingRepository {
     });
   }
 
-  async createReservation(input) {
+  async createReservation({ execution_class: _executionClass, ...input }) {
     return this.withTransaction(async (client) => {
       const account = await this.requireLockedAccount(client, input.tenant_id);
       return this.appendLocked(client, account, {

--- a/src/billing/repository.js
+++ b/src/billing/repository.js
@@ -96,6 +96,12 @@ class BillingRepository {
     throw new Error("BillingRepository.readBalance is not implemented");
   }
 
+  findGenerationBillingState(_input) {
+    throw new Error(
+      "BillingRepository.findGenerationBillingState is not implemented"
+    );
+  }
+
   appendFinancialTransaction(_input) {
     throw new Error(
       "BillingRepository.appendFinancialTransaction is not implemented"
@@ -200,6 +206,7 @@ class InMemoryBillingRepository extends BillingRepository {
     this.entriesById = new Map();
     this.idempotency = new Map();
     this.logicalEffects = new Map();
+    this.reservationExecutionClasses = new Map();
     this.accountLocks = new Map();
     this.stripeCustomersByTenant = new Map();
     this.stripeCustomersById = new Map();
@@ -252,6 +259,41 @@ class InMemoryBillingRepository extends BillingRepository {
     return this.entries
       .filter((entry) => entry.tenant_id === tenantId)
       .map(copy);
+  }
+
+  findGenerationBillingState(input) {
+    const reservations = this.entries.filter(
+      (entry) =>
+        entry.entry_type === "reservation" &&
+        (entry.idempotency_key === input.reservation_idempotency_key ||
+          entry.generation_id === input.generation_id)
+    );
+    if (reservations.length === 0) return null;
+    if (reservations.length !== 1) {
+      throw new FinancialResourceUnavailableError();
+    }
+
+    const reservation = reservations[0];
+    const authoritativeExecutionClass = this.reservationExecutionClasses.get(
+      reservation.ledger_entry_id
+    );
+    if (authoritativeExecutionClass !== input.execution_class) {
+      throw new FinancialResourceUnavailableError();
+    }
+
+    const settlements = this.entries.filter(
+      (entry) =>
+        ["debit", "reservation_release"].includes(entry.entry_type) &&
+        entry.reservation_entry_id === reservation.ledger_entry_id
+    );
+    if (settlements.length > 1) {
+      throw new FinancialResourceUnavailableError();
+    }
+    return Object.freeze({
+      execution_class: authoritativeExecutionClass,
+      reservation: copy(reservation),
+      settlement: copy(settlements[0] || null),
+    });
   }
 
   readBalance(tenantId) {
@@ -399,16 +441,29 @@ class InMemoryBillingRepository extends BillingRepository {
     );
   }
 
-  async createReservation(input) {
+  async createReservation({ execution_class, ...input }) {
     const account = this.requireAccount(input.tenant_id);
-    return this.withAccountLock(account.account_id, () =>
-      this.appendLocked(account, {
+    return this.withAccountLock(account.account_id, () => {
+      const reservation = this.appendLocked(account, {
         ...input,
         entry_type: "reservation",
         balance_delta: 0,
         reserved_delta: input.amount,
-      })
-    );
+      });
+      if (execution_class) {
+        const existing = this.reservationExecutionClasses.get(
+          reservation.ledger_entry_id
+        );
+        if (existing && existing !== execution_class) {
+          throw new FinancialResourceUnavailableError();
+        }
+        this.reservationExecutionClasses.set(
+          reservation.ledger_entry_id,
+          execution_class
+        );
+      }
+      return reservation;
+    });
   }
 
   requireRelatedEntry(tenantId, entryId, expectedType) {

--- a/src/billing/service.js
+++ b/src/billing/service.js
@@ -2,6 +2,7 @@ const {
   CommercialPolicyUnavailableError,
   EntitlementInactiveError,
   ExecutionPriceUnavailableError,
+  FinancialResourceUnavailableError,
   InvalidFinancialOperationError,
 } = require("./errors");
 const { executionClass, identifier } = require("./schema");
@@ -17,6 +18,52 @@ function parseAmount(value) {
     );
   }
   return value;
+}
+
+function requireGenerationBillingAuthority(state, expected) {
+  if (!state) return null;
+  const reservation = state.reservation;
+  if (
+    state.execution_class !== expected.execution_class ||
+    !reservation ||
+    reservation.entry_type !== "reservation" ||
+    reservation.tenant_id !== expected.tenant_id ||
+    reservation.project_id !== expected.project_id ||
+    reservation.generation_id !== expected.generation_id ||
+    reservation.execution_id !== expected.execution_id ||
+    reservation.transaction_correlation_id !==
+      expected.transaction_correlation_id ||
+    reservation.idempotency_key !== expected.reservation_idempotency_key
+  ) {
+    throw new FinancialResourceUnavailableError();
+  }
+
+  const settlement = state.settlement || null;
+  if (!settlement) {
+    return Object.freeze({ reservation, settlement: null });
+  }
+  const settlementKey =
+    settlement.entry_type === "debit"
+      ? expected.debit_idempotency_key
+      : settlement.entry_type === "reservation_release"
+        ? expected.release_idempotency_key
+        : null;
+  if (
+    !settlementKey ||
+    settlement.account_id !== reservation.account_id ||
+    settlement.tenant_id !== reservation.tenant_id ||
+    settlement.amount !== reservation.amount ||
+    settlement.project_id !== reservation.project_id ||
+    settlement.generation_id !== reservation.generation_id ||
+    settlement.execution_id !== reservation.execution_id ||
+    settlement.transaction_correlation_id !==
+      reservation.transaction_correlation_id ||
+    settlement.reservation_entry_id !== reservation.ledger_entry_id ||
+    settlement.idempotency_key !== settlementKey
+  ) {
+    throw new FinancialResourceUnavailableError();
+  }
+  return Object.freeze({ reservation, settlement });
 }
 
 class BillingService {
@@ -67,6 +114,34 @@ class BillingService {
 
   async readBalance({ tenantId }) {
     return this.repository.readBalance(parseIdentifier(tenantId));
+  }
+
+  async findGenerationBillingState({
+    tenantId,
+    projectId,
+    generationId,
+    executionId,
+    transactionCorrelationId,
+    executionClass: requestedClass,
+    reservationIdempotencyKey,
+    debitIdempotencyKey,
+    releaseIdempotencyKey,
+  }) {
+    const expected = Object.freeze({
+      tenant_id: parseIdentifier(tenantId),
+      project_id: parseIdentifier(projectId),
+      generation_id: parseIdentifier(generationId),
+      execution_id: parseIdentifier(executionId),
+      transaction_correlation_id: parseIdentifier(transactionCorrelationId),
+      execution_class: executionClass.parse(requestedClass),
+      reservation_idempotency_key: parseIdentifier(
+        reservationIdempotencyKey
+      ),
+      debit_idempotency_key: parseIdentifier(debitIdempotencyKey),
+      release_idempotency_key: parseIdentifier(releaseIdempotencyKey),
+    });
+    const state = await this.repository.findGenerationBillingState(expected);
+    return requireGenerationBillingAuthority(state, expected);
   }
 
   async appendFinancialTransaction(input) {
@@ -150,6 +225,7 @@ class BillingService {
     return this.repository.createReservation({
       tenant_id: price.tenant_id,
       amount: price.credit_cost,
+      execution_class: price.execution_class,
       project_id: parseIdentifier(projectId),
       generation_id: parseIdentifier(generationId),
       execution_id: parseIdentifier(executionId),

--- a/src/generation-billing/service.js
+++ b/src/generation-billing/service.js
@@ -66,6 +66,7 @@ class GenerationBillingOrchestrator {
     const state = {
       job,
       fingerprint,
+      reconstructionPromise: null,
       reservationPromise: null,
       executionPromise: null,
       debitPromise: null,
@@ -105,6 +106,55 @@ class GenerationBillingOrchestrator {
         });
     }
     return state.reservationPromise;
+  }
+
+  reconstruct(state) {
+    if (!state.reconstructionPromise) {
+      const job = state.job;
+      state.reconstructionPromise = Promise.resolve()
+        .then(() =>
+          this.billingService.findGenerationBillingState({
+            tenantId: job.tenant_id,
+            projectId: job.project_id,
+            generationId: job.job_id,
+            executionId: job.request_correlation_id,
+            transactionCorrelationId: job.request_correlation_id,
+            executionClass: job.execution_class,
+            reservationIdempotencyKey: financialIdempotencyKey(
+              "reserve",
+              job.job_id
+            ),
+            debitIdempotencyKey: financialIdempotencyKey("debit", job.job_id),
+            releaseIdempotencyKey: financialIdempotencyKey(
+              "release",
+              job.job_id
+            ),
+          })
+        )
+        .then((durable) => {
+          if (!durable?.reservation) {
+            throw new GenerationBillingAuthorityError();
+          }
+          if (!state.reservationPromise) {
+            state.reservationPromise = Promise.resolve(durable.reservation);
+          }
+          if (durable.settlement?.entry_type === "debit") {
+            state.debit = durable.settlement;
+            state.debitPromise = Promise.resolve(durable.settlement);
+          } else if (
+            durable.settlement?.entry_type === "reservation_release"
+          ) {
+            state.releasePromise = Promise.resolve(durable.settlement);
+          }
+          return durable;
+        })
+        .catch((error) => {
+          state.reconstructionPromise = null;
+          if (error instanceof GenerationBillingAuthorityError) throw error;
+          throw new GenerationBillingUnavailableError();
+        });
+    }
+    return state.reconstructionPromise;
   }
 
   executeOnce(state, operation) {
@@ -184,24 +234,29 @@ class GenerationBillingOrchestrator {
 
   async settleSuccessfulExecution({ job }) {
     const state = this.stateFor(job);
-    if (
-      !state.reservationPromise ||
-      !state.executionPromise ||
-      state.releasePromise
-    ) {
+    if (!state.reservationPromise || !state.executionPromise) {
+      await this.reconstruct(state);
+    }
+    if (state.releasePromise) {
       throw new GenerationBillingAuthorityError();
     }
     const reservation = await state.reservationPromise;
-    const outcome = await state.executionPromise;
-    if (!outcome.ok) throw new GenerationBillingAuthorityError();
+    let outcome;
+    if (state.executionPromise) {
+      outcome = await state.executionPromise;
+      if (!outcome.ok) throw new GenerationBillingAuthorityError();
+    }
 
     await this.debitOnce(state, reservation);
-    return outcome.value;
+    return outcome?.value;
   }
 
   async releaseFailedExecution({ job }) {
     const state = this.stateFor(job);
-    if (!state.reservationPromise || state.debit) {
+    if (!state.reservationPromise) {
+      await this.reconstruct(state);
+    }
+    if (state.debit) {
       throw new GenerationBillingAuthorityError();
     }
     const reservation = await state.reservationPromise;

--- a/test/customer-video-activation.test.js
+++ b/test/customer-video-activation.test.js
@@ -8,6 +8,7 @@ const {
   createCustomerActorFromVerifiedIdentity,
 } = require("../src/authorization");
 const { InMemoryBrandBrainRepository } = require("../src/brand-brain");
+const { BillingService, InMemoryBillingRepository } = require("../src/billing");
 const { GenerationBillingOrchestrator } = require("../src/generation-billing");
 const { InMemoryGenerationJobRepository } = require("../src/generation-jobs");
 const {
@@ -28,9 +29,10 @@ class Tokens {
 }
 
 class FixtureVideoProvider extends VideoGenerationProvider {
-  constructor({ fail = false } = {}) {
+  constructor({ fail = false, processingPolls = 0 } = {}) {
     super();
     this.fail = fail;
+    this.processingPolls = processingPolls;
     this.submissions = 0;
     this.polls = 0;
   }
@@ -44,6 +46,15 @@ class FixtureVideoProvider extends VideoGenerationProvider {
   }
   async poll() {
     this.polls += 1;
+    if (this.processingPolls > 0) {
+      this.processingPolls -= 1;
+      return {
+        provider: "fixture",
+        provider_job_id: "operation_video_001",
+        provider_model: "fixture-video-model",
+        status: "processing",
+      };
+    }
     if (this.fail) {
       return {
         provider: "fixture",
@@ -166,6 +177,104 @@ function customer(client, token = "token-a") {
   return client.set("authorization", `Bearer ${token}`);
 }
 
+async function durableRestartFixture({ fail = false, processingPolls = 0 } = {}) {
+  const now = () => new Date("2026-08-29T20:00:00.000Z");
+  const billingRepository = new InMemoryBillingRepository({
+    policies: [{
+      policy_id: "restart_policy",
+      plan_code: "test",
+      policy_version: 1,
+      status: "active",
+      included_monthly_credits: 100,
+      bolt_on_eligible: false,
+      effective_from: "2026-01-01T00:00:00.000Z",
+      execution_costs: { "video.normal": 5, "video.premium": 9 },
+    }],
+    entitlements: [{
+      entitlement_id: "restart_entitlement",
+      tenant_id: "tenant_a",
+      policy_id: "restart_policy",
+      plan_code: "test",
+      status: "active",
+      starts_at: "2026-01-01T00:00:00.000Z",
+      reference_period_start: "2026-08-01T00:00:00.000Z",
+      reference_period_end: "2026-09-01T00:00:00.000Z",
+      included_monthly_credit_grant: 100,
+    }],
+    accounts: [{
+      account_id: "restart_account",
+      tenant_id: "tenant_a",
+      status: "active",
+      created_at: "2026-01-01T00:00:00.000Z",
+    }],
+    projects: [{ project_id: "project_a", tenant_id: "tenant_a" }],
+    now,
+  });
+  const billingService = new BillingService({ repository: billingRepository, now });
+  await billingService.adjustCredits({
+    tenantId: "tenant_a",
+    amount: 100,
+    direction: "credit",
+    transactionCorrelationId: "restart_fixture_funding",
+    idempotencyKey: "restart_fixture_funding",
+  });
+
+  const videoGenerationRepository = new InMemoryVideoGenerationRepository();
+  const generationJobRepository = new InMemoryGenerationJobRepository();
+  const provider = new FixtureVideoProvider({ fail, processingPolls });
+  let assetSaves = 0;
+  function freshApp() {
+    const generationBillingOrchestrator = new GenerationBillingOrchestrator({
+      billingService,
+      logger: { error() {} },
+    });
+    return createApp({
+      authorizationRepository: authorizationRepository(),
+      brandBrainRepository: new InMemoryBrandBrainRepository(),
+      customerTokenVerifier: new Tokens(),
+      generationBillingOrchestrator,
+      generationJobRepository,
+      videoGenerationRepository,
+      videoProvider: provider,
+      videoAssetStore: {
+        async save({ source }) {
+          assetSaves += 1;
+          return {
+            asset_id: "44444444-4444-4444-8444-444444444444",
+            location: "gs://bizgenie-staging-media/reconstructed/video.mp4",
+            mime_type: source.mime_type,
+            width: source.width,
+            height: source.height,
+            duration_seconds: source.duration_seconds,
+            container: "mp4",
+            byte_size: 2048,
+          };
+        },
+      },
+      videoReferenceAssetLoader: { async load() { throw new Error("not used"); } },
+      logger: { info() {}, warn() {}, error() {} },
+    });
+  }
+  return {
+    billingRepository,
+    billingService,
+    freshApp,
+    generationJobRepository,
+    provider,
+    assetSaves: () => assetSaves,
+  };
+}
+
+function financialEffects(repository) {
+  const ledger = repository.listLedger("tenant_a");
+  return Object.fromEntries(
+    ["reservation", "debit", "reservation_release"].map((type) => [
+      type,
+      ledger.filter((entry) => entry.entry_type === type).length,
+    ])
+  );
+}
+
 describe("customer Video Auth -> immutable job -> Billing -> async settlement", () => {
   it("authorizes and reserves submission, then debits only after durable completion", async () => {
     const f = fixture();
@@ -201,67 +310,8 @@ describe("customer Video Auth -> immutable job -> Billing -> async settlement", 
   });
 
   it("reconstructs an accepted async Video in a fresh app instance without resubmission", async () => {
-    const durableVideoRepository = new InMemoryVideoGenerationRepository();
-    const durableJobRepository = new InMemoryGenerationJobRepository();
-    const provider = new FixtureVideoProvider();
-    const effects = { reserve: 0, debit: 0, release: 0 };
-
-    const billingService = {
-      async createReservation(input) {
-        effects.reserve += 1;
-        return {
-          ledger_entry_id: "reservation_restart_001",
-          generation_id: input.generationId,
-        };
-      },
-      async finalizeDebit() {
-        effects.debit += 1;
-        return { ledger_entry_id: "debit_restart_001" };
-      },
-      async releaseReservation() {
-        effects.release += 1;
-        return { ledger_entry_id: "release_restart_001" };
-      },
-    };
-
-    const generationBillingOrchestrator = new GenerationBillingOrchestrator({
-      billingService,
-      logger: { error() {} },
-    });
-
-    function freshApp() {
-      return createApp({
-        authorizationRepository: authorizationRepository(),
-        brandBrainRepository: new InMemoryBrandBrainRepository(),
-        customerTokenVerifier: new Tokens(),
-        generationBillingOrchestrator,
-        generationJobRepository: durableJobRepository,
-        videoGenerationRepository: durableVideoRepository,
-        videoProvider: provider,
-        videoAssetStore: {
-          async save({ source }) {
-            return {
-              asset_id: "44444444-4444-4444-8444-444444444444",
-              location: "gs://bizgenie-staging-media/reconstructed/video.mp4",
-              mime_type: source.mime_type,
-              width: source.width,
-              height: source.height,
-              duration_seconds: source.duration_seconds,
-              container: "mp4",
-              byte_size: 2048,
-            };
-          },
-        },
-        videoReferenceAssetLoader: {
-          async load() {
-            throw new Error("not used");
-          },
-        },
-        logger: { info() {}, warn() {}, error() {} },
-      });
-    }
-
-    const firstApp = freshApp();
+    const f = await durableRestartFixture();
+    const firstApp = f.freshApp();
 
     const submitted = await customer(
       request(firstApp).post("/customer/generate-video")
@@ -271,13 +321,16 @@ describe("customer Video Auth -> immutable job -> Billing -> async settlement", 
     }));
 
     assert.equal(submitted.status, 202);
-    assert.equal(provider.submissions, 1);
-    assert.equal(effects.reserve, 1);
-    assert.equal(effects.debit, 0);
+    assert.equal(f.provider.submissions, 1);
+    assert.deepEqual(financialEffects(f.billingRepository), {
+      reservation: 1,
+      debit: 0,
+      reservation_release: 0,
+    });
 
     // Simulate process replacement: discard the first Express/service graph
     // and construct a new one against the same durable authorities.
-    const restartedApp = freshApp();
+    const restartedApp = f.freshApp();
 
     const completed = await customer(
       request(restartedApp).post(
@@ -287,23 +340,134 @@ describe("customer Video Auth -> immutable job -> Billing -> async settlement", 
 
     assert.equal(completed.status, 200);
     assert.equal(completed.body.status, "completed");
-    assert.equal(provider.submissions, 1);
-    assert.equal(provider.polls, 1);
-    assert.equal(effects.reserve, 1);
-    assert.equal(effects.debit, 1);
-    assert.equal(effects.release, 0);
+    assert.equal(f.provider.submissions, 1);
+    assert.equal(f.provider.polls, 1);
+    assert.equal(f.assetSaves(), 1);
+    assert.deepEqual(financialEffects(f.billingRepository), {
+      reservation: 1,
+      debit: 1,
+      reservation_release: 0,
+    });
 
+    const alreadySettledRestart = f.freshApp();
     const repeated = await customer(
-      request(restartedApp).post(
+      request(alreadySettledRestart).post(
         "/customer/generate-video/generation_video_restart_001/poll"
       )
     );
 
     assert.equal(repeated.status, 200);
     assert.equal(repeated.body.status, "completed");
-    assert.equal(provider.submissions, 1);
-    assert.equal(provider.polls, 1);
-    assert.equal(effects.debit, 1);
+    assert.equal(f.provider.submissions, 1);
+    assert.equal(f.provider.polls, 1);
+    assert.equal(f.assetSaves(), 1);
+    assert.deepEqual(financialEffects(f.billingRepository), {
+      reservation: 1,
+      debit: 1,
+      reservation_release: 0,
+    });
+  });
+
+  it("keeps a reconstructed reservation open while Video is still processing", async () => {
+    const f = await durableRestartFixture({ processingPolls: 1 });
+    await customer(request(f.freshApp()).post("/customer/generate-video")).send(
+      videoRequest({
+        execution_id: "execution_video_processing_restart",
+        generation_id: "generation_video_processing_restart",
+      })
+    );
+
+    const processing = await customer(
+      request(f.freshApp()).post(
+        "/customer/generate-video/generation_video_processing_restart/poll"
+      )
+    );
+    assert.equal(processing.status, 202);
+    assert.equal(processing.body.status, "processing");
+    assert.equal(f.provider.submissions, 1);
+    assert.deepEqual(financialEffects(f.billingRepository), {
+      reservation: 1,
+      debit: 0,
+      reservation_release: 0,
+    });
+  });
+
+  it("reconstructs and releases a terminal provider failure exactly once", async () => {
+    const f = await durableRestartFixture({ fail: true });
+    await customer(request(f.freshApp()).post("/customer/generate-video")).send(
+      videoRequest({
+        execution_id: "execution_video_failure_restart",
+        generation_id: "generation_video_failure_restart",
+      })
+    );
+
+    const failed = await customer(
+      request(f.freshApp()).post(
+        "/customer/generate-video/generation_video_failure_restart/poll"
+      )
+    );
+    assert.equal(failed.status, 502);
+    assert.deepEqual(financialEffects(f.billingRepository), {
+      reservation: 1,
+      debit: 0,
+      reservation_release: 1,
+    });
+
+    const repeated = await customer(
+      request(f.freshApp()).get(
+        "/customer/generate-video/generation_video_failure_restart"
+      )
+    );
+    assert.equal(repeated.status, 200);
+    assert.equal(repeated.body.status, "failed");
+    assert.deepEqual(financialEffects(f.billingRepository), {
+      reservation: 1,
+      debit: 0,
+      reservation_release: 1,
+    });
+  });
+
+  it("fails closed when reconstructed job or reservation authority is mismatched", async () => {
+    const f = await durableRestartFixture();
+    await customer(request(f.freshApp()).post("/customer/generate-video")).send(
+      videoRequest({
+        execution_id: "execution_video_mismatch_restart",
+        generation_id: "generation_video_mismatch_restart",
+      })
+    );
+    const [job] = [...f.generationJobRepository.jobsById.values()];
+    const forged = { ...job, execution_class: "video.premium" };
+    const restarted = new GenerationBillingOrchestrator({
+      billingService: f.billingService,
+      logger: { error() {} },
+    });
+    await assert.rejects(
+      restarted.settleSuccessfulExecution({ job: forged }),
+      (error) => error.code === "GENERATION_BILLING_UNAVAILABLE"
+    );
+
+    const canonicalLookup = f.billingRepository.findGenerationBillingState.bind(
+      f.billingRepository
+    );
+    f.billingRepository.findGenerationBillingState = async (input) => {
+      const state = await canonicalLookup(input);
+      return {
+        ...state,
+        reservation: { ...state.reservation, project_id: "project_b" },
+      };
+    };
+    await assert.rejects(
+      new GenerationBillingOrchestrator({
+        billingService: f.billingService,
+        logger: { error() {} },
+      }).settleSuccessfulExecution({ job }),
+      (error) => error.code === "GENERATION_BILLING_UNAVAILABLE"
+    );
+    assert.deepEqual(financialEffects(f.billingRepository), {
+      reservation: 1,
+      debit: 0,
+      reservation_release: 0,
+    });
   });
 
   it("denies cross-tenant status/poll access before provider or Billing settlement", async () => {

--- a/test/postgres-billing.integration.test.js
+++ b/test/postgres-billing.integration.test.js
@@ -481,6 +481,72 @@ postgresDescribe("PostgresBillingRepository real PostgreSQL adversarial proof", 
     assert.equal(entries.filter((entry) => entry.entry_type === "reservation").length, 1);
   });
 
+  it("reconstructs reserved, debited, and released generation state from PostgreSQL", async () => {
+    await fund("tenant_a", 20, "restart_reconstruction");
+    const firstProcess = new GenerationBillingOrchestrator({
+      billingService: service,
+      logger: { error() {} },
+    });
+    const completedJob = jobObject("job_video");
+    await firstProcess.beginExecution({
+      job: completedJob,
+      expectedExecutionClass: "video.normal",
+      operation: async () => ({ status: "submitted" }),
+    });
+
+    const reconstructedService = new BillingService({
+      repository: new PostgresBillingRepository({
+        pool,
+        now: () => new Date(NOW),
+      }),
+      now: () => new Date(NOW),
+    });
+    const forgedProcess = new GenerationBillingOrchestrator({
+      billingService: reconstructedService,
+      logger: { error() {} },
+    });
+    await assert.rejects(
+      forgedProcess.settleSuccessfulExecution({
+        job: { ...completedJob, execution_class: "video.premium" },
+      }),
+      GenerationBillingUnavailableError
+    );
+
+    const secondProcess = new GenerationBillingOrchestrator({
+      billingService: reconstructedService,
+      logger: { error() {} },
+    });
+    await secondProcess.settleSuccessfulExecution({ job: completedJob });
+    const thirdProcess = new GenerationBillingOrchestrator({
+      billingService: reconstructedService,
+      logger: { error() {} },
+    });
+    await thirdProcess.settleSuccessfulExecution({ job: completedJob });
+
+    const failedJob = jobObject("job_release");
+    await firstProcess.beginExecution({
+      job: failedJob,
+      expectedExecutionClass: "video.normal",
+      operation: async () => ({ status: "submitted" }),
+    });
+    await new GenerationBillingOrchestrator({
+      billingService: reconstructedService,
+      logger: { error() {} },
+    }).releaseFailedExecution({ job: failedJob });
+    await new GenerationBillingOrchestrator({
+      billingService: reconstructedService,
+      logger: { error() {} },
+    }).releaseFailedExecution({ job: failedJob });
+
+    const entries = await repository.listLedger("tenant_a");
+    assert.equal(entries.filter((entry) => entry.entry_type === "reservation").length, 2);
+    assert.equal(entries.filter((entry) => entry.entry_type === "debit").length, 1);
+    assert.equal(
+      entries.filter((entry) => entry.entry_type === "reservation_release").length,
+      1
+    );
+  });
+
   it("fails closed for concurrent global idempotency reuse across immutable authority", async () => {
     await fund("tenant_a", 10, "a");
     await fund("tenant_b", 10, "b");


### PR DESCRIPTION
References #39

## Summary

- adds a canonical Billing read seam that resolves a generation reservation and any debit/release from the existing immutable PostgreSQL credit ledger
- verifies tenant, project, generation job, execution correlation, execution class, and deterministic reserve/debit/release identities before reconstruction
- lets a fresh GenerationBillingOrchestrator settle or release an already-accepted async Video without process-local reservation/execution Promises
- preserves the in-memory state map only as a same-process coalescing optimization
- strengthens durable Video status authority checks against the immutable job
- replaces the prior false-positive restart fixture with genuinely fresh orchestrators and adds completed, processing, failed, mismatched, and already-settled coverage
- adds real PostgreSQL reconstruction coverage without adding a migration or another financial authority

## Verification

- focused restart / customer Video / generation Billing / composition suites: 26 passed
- full local suite: 377 tests, 79 suites, 377 passed, 0 failed, 0 skipped
- JavaScript syntax checks: passed
- PostgreSQL and Docker/Buildpack checks: delegated to the existing GitHub Actions CI jobs because this local host has no Docker or PostgreSQL runtime

## Safety

- no production or staging interaction
- no deployment or infrastructure change
- no Stripe behavior change
- no new ledger, side table, or migration
- no provider resubmission during restart settlement
