### PR TITLE
BG-ACT-001J: wire bounded post-debit refund policy

### DIFF
--- a/src/billing/index.js
+++ b/src/billing/index.js
@@ -6,6 +6,7 @@ const {
 } = require("./repository");
 const schema = require("./schema");
 const stripe = require("./stripe");
+const refundPolicy = require("./refundPolicy");
 const { BillingService } = require("./service");
 const postgres = require("./postgresRepository");
 const composition = require("./productionComposition");
@@ -14,6 +15,7 @@ module.exports = {
   ...errors,
   ...schema,
   ...stripe,
+  ...refundPolicy,
   ...postgres,
   ...composition,
   BillingRepository,

--- a/src/billing/productionComposition.js
+++ b/src/billing/productionComposition.js
@@ -1,6 +1,7 @@
 const { GenerationBillingOrchestrator, UnconfiguredGenerationBillingOrchestrator } = require("../generation-billing");
 const { BillingConfigurationError } = require("./errors");
 const { PostgresBillingRepository } = require("./postgresRepository");
+const { qualifiesForBoundedPostDebitRefund } = require("./refundPolicy");
 const { executionClass, identifier } = require("./schema");
 const { BillingService } = require("./service");
 
@@ -63,6 +64,7 @@ async function createPostgresBillingProductionComposition({
   });
   const generationBillingOrchestrator = new GenerationBillingOrchestrator({
     billingService,
+    qualifiesForRefund: qualifiesForBoundedPostDebitRefund,
     logger,
   });
   return Object.freeze({

--- a/src/billing/refundPolicy.js
+++ b/src/billing/refundPolicy.js
@@ -1,0 +1,24 @@
+const BOUNDED_POST_DEBIT_REFUND_REASONS = Object.freeze([
+  "durable_output_unavailable_after_debit",
+]);
+
+const approvedReasons = new Set(BOUNDED_POST_DEBIT_REFUND_REASONS);
+
+function qualifiesForBoundedPostDebitRefund({ job, debit, reason } = {}) {
+  if (!job || !debit || typeof reason !== "string") return false;
+  if (!approvedReasons.has(reason)) return false;
+
+  return (
+    typeof job.job_id === "string" &&
+    typeof job.tenant_id === "string" &&
+    typeof debit.ledger_entry_id === "string" &&
+    debit.entry_type === "debit" &&
+    debit.tenant_id === job.tenant_id &&
+    debit.generation_id === job.job_id
+  );
+}
+
+module.exports = {
+  BOUNDED_POST_DEBIT_REFUND_REASONS,
+  qualifiesForBoundedPostDebitRefund,
+};

--- a/test/refund-policy.test.js
+++ b/test/refund-policy.test.js
@@ -1,0 +1,75 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+
+const {
+  BOUNDED_POST_DEBIT_REFUND_REASONS,
+  qualifiesForBoundedPostDebitRefund,
+} = require("../src/billing");
+
+const job = Object.freeze({
+  job_id: "job_refund_policy_001",
+  tenant_id: "tenant_a",
+});
+
+const debit = Object.freeze({
+  ledger_entry_id: "ledger_debit_001",
+  entry_type: "debit",
+  tenant_id: "tenant_a",
+  generation_id: "job_refund_policy_001",
+});
+
+describe("bounded post-debit refund policy", () => {
+  it("qualifies only the approved durable-output post-debit failure", () => {
+    assert.deepEqual(BOUNDED_POST_DEBIT_REFUND_REASONS, [
+      "durable_output_unavailable_after_debit",
+    ]);
+    assert.equal(
+      qualifiesForBoundedPostDebitRefund({
+        job,
+        debit,
+        reason: "durable_output_unavailable_after_debit",
+      }),
+      true
+    );
+  });
+
+  it("fails closed for non-qualifying, malformed, or missing reasons", () => {
+    for (const reason of [
+      "provider_failure_before_debit",
+      "reservation_release_failure",
+      "customer_requested_refund",
+      "",
+      null,
+      undefined,
+    ]) {
+      assert.equal(qualifiesForBoundedPostDebitRefund({ job, debit, reason }), false);
+    }
+  });
+
+  it("fails closed when immutable debit/job authority does not match", () => {
+    assert.equal(
+      qualifiesForBoundedPostDebitRefund({
+        job,
+        debit: { ...debit, generation_id: "different_job" },
+        reason: "durable_output_unavailable_after_debit",
+      }),
+      false
+    );
+    assert.equal(
+      qualifiesForBoundedPostDebitRefund({
+        job,
+        debit: { ...debit, tenant_id: "tenant_b" },
+        reason: "durable_output_unavailable_after_debit",
+      }),
+      false
+    );
+    assert.equal(
+      qualifiesForBoundedPostDebitRefund({
+        job,
+        debit: { ...debit, entry_type: "reservation_release" },
+        reason: "durable_output_unavailable_after_debit",
+      }),
+      false
+    );
+  });
+});


### PR DESCRIPTION
Closes #49

Implements only the verified BG-ACT-001J production-wiring gap.

- adds a server-owned fail-closed bounded refund qualification policy;
- permits only the explicit `durable_output_unavailable_after_debit` reason;
- additionally requires immutable debit/job tenant + generation authority to match;
- wires the policy into durable Billing production composition;
- preserves the existing GenerationBillingOrchestrator exactly-once refund/idempotency machinery;
- adds deterministic policy tests for qualifying, non-qualifying and authority-mismatch cases.

No production deployment or configuration mutation is included. Existing pre-debit release behavior and successful Text/Image/Video paid paths are unchanged.

CI/full-suite result is required before merge.