### PR TITLE
BG-LAUNCH-002F: add paid-beta capture foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,21 @@ The tests do not call Vertex AI and do not require Google Cloud credentials.
 - `POST /generate-video` — authenticated asynchronous video submission.
 - `GET /generate-video/:generationId` — reads current video generation state.
 - `POST /generate-video/:generationId/poll` — resumes an accepted operation.
+- `POST /public/paid-beta-interest` — disabled-by-default, write-only paid-beta
+  interest receipt; no public read/list route is exposed.
 
 The authenticated routes require the `x-admin-key` header to exactly match the
 `ADMIN_KEY` environment variable.
+
+## Paid-beta interest capture
+
+BG-LAUNCH-002F adds a strict, consent-aware public submission boundary backed
+by dedicated append-only PostgreSQL interest/receipt records and durable HMAC-
+pseudonymized abuse buckets. It is off by default, uses the existing exact-
+origin CORS allowlist, does not create Auth/Billing/tenant authority, and sends
+no email or external notification. The exact frontend request, privacy,
+retention, activation, Checkout return-route, and rollback contracts are in
+`docs/launch/PAID_BETA_CAPTURE_AND_CHECKOUT_RETURN.md`.
 
 ## Commercial policy and credit-ledger foundation
 

--- a/docs/activation/STAGING_ACTIVATION.md
+++ b/docs/activation/STAGING_ACTIVATION.md
@@ -95,6 +95,11 @@ reinterpret it for another tenant.
 | `VIDEO_PROVIDER_TIMEOUT_MS` | Optional bounded provider transport timeout |
 | `STRIPE_BILLING_ENABLED` | Composes Stripe only with active durable Billing |
 | `STRIPE_MODE` | Must be `test` in staging and `live` in production |
+| `STRIPE_SUCCESS_URL` | Approved frontend origin plus exact `/billing/checkout/success` path |
+| `STRIPE_CANCEL_URL` | Same frontend origin plus exact `/billing/checkout/cancel` path |
+| `PAID_BETA_CAPTURE_ENABLED` | Enables the write-only paid-beta route after its migration/configuration checks |
+| `PAID_BETA_SUBMISSION_HASH_SECRET` | Server-only request-fingerprint HMAC secret |
+| `PAID_BETA_CLIENT_HASH_SECRET` | Distinct server-only abuse-identity HMAC secret |
 | `CORS_ENABLED` | Enables separate-frontend CORS; otherwise requests carrying `Origin` are denied |
 | `CORS_ALLOWED_ORIGINS` | Comma-separated exact URL origins; `*`, paths, queries, and fragments are rejected |
 

--- a/docs/billing/STRIPE_SUBSCRIPTION_LIFECYCLE.md
+++ b/docs/billing/STRIPE_SUBSCRIPTION_LIFECYCLE.md
@@ -49,8 +49,8 @@ All values are server controlled:
 | `STRIPE_MODE` | Exactly `test` or `live` |
 | `STRIPE_SECRET_KEY` | Matching `sk_test_` or `sk_live_` server key |
 | `STRIPE_WEBHOOK_SECRET` | Endpoint-specific `whsec_` signing secret |
-| `STRIPE_SUCCESS_URL` | Approved Checkout success URL |
-| `STRIPE_CANCEL_URL` | Approved Checkout cancel URL |
+| `STRIPE_SUCCESS_URL` | Approved frontend origin plus exact `/billing/checkout/success` route |
+| `STRIPE_CANCEL_URL` | Same approved frontend origin plus exact `/billing/checkout/cancel` route |
 | `STRIPE_PRICE_STANDARD` | Approved Stripe recurring Price for Standard |
 | `STRIPE_POLICY_STANDARD` | Existing BG-BILL-002A policy ID for Standard |
 | `STRIPE_PRICE_PRO` | Approved Stripe recurring Price for Pro, if enabled |
@@ -58,6 +58,11 @@ All values are server controlled:
 | `STRIPE_PAST_DUE_GRACE_DAYS` | Server-owned grace duration; defaults to seven days |
 
 Live mode requires HTTPS return URLs. Test mode permits HTTPS or loopback HTTP.
+Both URLs must share an origin and use the exact routes above with no
+credentials, query, or fragment. Browser return is not financial authority;
+the frontend must retrieve tenant-authorized subscription/entitlement state
+from the backend after success. See
+`../launch/PAID_BETA_CAPTURE_AND_CHECKOUT_RETURN.md`.
 An event whose `livemode` or API version differs from the configured environment
 fails before any state change.
 

--- a/docs/launch/PAID_BETA_CAPTURE_AND_CHECKOUT_RETURN.md
+++ b/docs/launch/PAID_BETA_CAPTURE_AND_CHECKOUT_RETURN.md
@@ -1,0 +1,186 @@
+# Paid-beta capture and Checkout return contract
+
+**Task:** BG-LAUNCH-002F
+
+**Baseline:** `52d1c130a76db689f71b0f200fd4a6ded3eaa969` (tree `ce597d7b6959f92a9179afadd95f2e494e98420e`)
+
+**Authority:** `bizgenie-api` owns the server endpoint and durable PostgreSQL record. The standalone buyer-facing homepage remains a separate frontend artifact.
+
+**Mutation state:** repository implementation only; no environment, database, Stripe object, staging, cloud, or production state was changed.
+
+## Architecture decision
+
+The API exposes one write-only public boundary:
+
+```text
+POST /public/paid-beta-interest
+```
+
+There is no public list, lookup, update, or delete route. The endpoint writes to
+the dedicated `paid_beta_interests` and `paid_beta_interest_receipts` domain.
+Auth profiles, tenant memberships, Billing, Stripe, entitlements, credits,
+generation jobs, provider data, Sheets, Make, and a CRM are not involved.
+
+`paid_beta_interests` keeps one canonical follow-up record per normalized work
+email. `paid_beta_interest_receipts` keeps one opaque receipt and immutable
+consent evidence per client submission identity. A repeat email with a new
+submission identity adds consent/receipt evidence but cannot overwrite the
+first public record.
+
+## Exact frontend request contract
+
+Send `Content-Type: application/json` from an origin already approved in
+`CORS_ALLOWED_ORIGINS`. The complete, strict body is:
+
+```json
+{
+  "name": "Ada Lovelace",
+  "work_email": "ada@example.com",
+  "business_name": "Analytical Engines Ltd",
+  "website_or_social_profile": "https://example.com/ada",
+  "business_stage": "250k-1m",
+  "primary_marketing_challenge": "Keeping launch campaigns consistent.",
+  "privacy_contact_consent": true,
+  "source": "homepage-paid-beta",
+  "submission_id": "client-generated-stable-identity"
+}
+```
+
+| Field | Rule |
+| --- | --- |
+| `name` | required, trimmed, 1–120 characters |
+| `work_email` | required, trimmed, lower-cased, valid email, at most 254 characters |
+| `business_name` | required, trimmed, 1–160 characters |
+| `website_or_social_profile` | required HTTP(S) URL, at most 2,048 characters; credentials forbidden |
+| `business_stage` | `pre-revenue`, `under-250k`, `250k-1m`, `1m-5m`, or `5m-plus` |
+| `primary_marketing_challenge` | required, trimmed, 1–1,000 characters |
+| `privacy_contact_consent` | must be the boolean `true` |
+| `source` | required lower-case source label, 1–64 safe identifier characters |
+| `submission_id` | required stable client identity, 1–128 safe identifier characters |
+
+Unknown fields are rejected. Text is stored as data and is never returned or
+treated as trusted HTML. Generate `submission_id` once when a form attempt
+starts and reuse it for transport retries. Do not put an email, tenant ID,
+payment reference, or other authority in that value.
+
+Success and same-intent replay both return HTTP 202:
+
+```json
+{
+  "status": "received",
+  "reference_id": "pbi_safe-opaque-public-reference"
+}
+```
+
+The same submission identity and intent returns the same reference. A matching
+email under another identity receives the same status/shape with a different
+receipt reference, so prior capture is not disclosed. Reusing one submission
+identity for changed intent returns `IDEMPOTENCY_KEY_CONFLICT` without exposing
+stored data.
+
+## Consent, data handling, and privacy limits
+
+The server records consent version `paid-beta-contact-v1`, the exact wording:
+
+> I agree that BizGenie may use these details to contact me about the paid beta.
+
+It records the receipt time as both consent and audit time. Collected data is
+limited to the request fields, server-generated internal/receipt identities,
+an HMAC request fingerprint, consent evidence, and audit timestamps. Raw IP
+addresses are not stored; abuse buckets contain only an HMAC pseudonym and a
+short time window.
+
+Purpose is limited to paid-beta qualification and follow-up. This task sends no
+email or Slack message, pushes nothing to a CRM, adds no analytics/tracking,
+creates no account or tenant, and confers no payment/product authority.
+
+Before public activation, human privacy/legal review must confirm lawful basis,
+the displayed notice, controller/contact details, and consent wording/version.
+This engineering contract is not final legal policy or legal approval.
+
+Retention is unresolved and must be approved before activation for interest,
+receipt, and expired HMAC bucket records. Export/deletion workflows require a
+separately authorized administrator implementation. Until then, interest and
+consent rows are append-only. Database-owner/operator access is the only access
+boundary and must follow existing secret, audit, backup, and least-privilege
+controls.
+
+## Idempotency and abuse protection
+
+The request fingerprint is an HMAC of normalized input and the server consent
+version. PostgreSQL uniqueness protects normalized email, submission identity,
+and receipt reference. One transaction resolves replay, duplicate email, and
+concurrent inserts without a second canonical interest.
+
+Before JSON validation, every attempt consumes an atomic PostgreSQL bucket for
+an HMAC-pseudonymized socket identity. Defaults are five attempts per 15-minute
+window. This works across API instances and covers malformed/invalid attempts.
+It does not replace approved upstream WAF/edge protection, monitoring, or
+incident response for public launch.
+
+## Database and privilege contract
+
+Migration `20260901170000_create_paid_beta_interest_capture.sql` creates the two
+append-only canonical tables plus short-lived abuse buckets, applies database
+bounds, enables RLS without customer policies, revokes `PUBLIC`, `anon`,
+`authenticated`, and `service_role`, blocks ordinary evidence update/delete,
+and adds only email/idempotency, operator audit, and expiry-cleanup indexes.
+Writes occur through the direct server PostgreSQL boundary. No broad
+`service_role` grant is introduced.
+
+## Activation configuration
+
+Capture is off by default. Enabling it requires existing database/environment
+checks plus:
+
+| Environment value | Contract |
+| --- | --- |
+| `PAID_BETA_CAPTURE_ENABLED` | exactly `true` to mount the route |
+| `PAID_BETA_SUBMISSION_HASH_SECRET` | server-only HMAC secret, at least 32 characters |
+| `PAID_BETA_CLIENT_HASH_SECRET` | distinct server-only HMAC secret, at least 32 characters |
+| `PAID_BETA_RATE_LIMIT_MAX_ATTEMPTS` | optional integer 1–100; default 5 |
+| `PAID_BETA_RATE_LIMIT_WINDOW_SECONDS` | optional integer 60–86,400; default 900 |
+
+`BIZGENIE_ENVIRONMENT` remains mandatory. Production also requires the existing
+`PRODUCTION_ACTIVATION_ENABLED=true` gate. The migration and startup privilege/
+trigger checks must pass before the listener opens. No values were configured
+by this task.
+
+## Checkout return-route contract
+
+Stripe Checkout remains server configured and fail-closed:
+
+```text
+STRIPE_SUCCESS_URL=https://<approved-frontend-origin>/billing/checkout/success
+STRIPE_CANCEL_URL=https://<approved-frontend-origin>/billing/checkout/cancel
+```
+
+Both must share the approved frontend origin. Live mode requires HTTPS; test
+mode also permits loopback HTTP. Credentials, query strings, fragments, a
+different origin, the protected API root, or another path fail startup.
+Staging/production values must not change until the real frontend implements
+both routes and an operator authorizes the configuration change.
+
+Browser return paths and parameters are not financial authority. After success,
+the frontend must authenticate and retrieve current subscription/entitlement
+state from a tenant-authorized backend read boundary before showing access or
+credits. This repository currently lacks that customer-safe read route, so it
+is a required next dependency. Webhooks and the canonical Stripe Customer
+mapping remain state-changing authority.
+
+## Rollout, rollback, and next task
+
+Safe rollout is: decide legal/retention controls, merge, apply the additive
+migration in an authorized environment, configure secrets and exact CORS/
+frontend values, then run an approved non-personal synthetic smoke submission.
+
+Before environment mutation, rollback is closing/reverting this change. After
+data exists, disable `PAID_BETA_CAPTURE_ENABLED`, preserve/export records under
+the approved privacy procedure, and use a reviewed forward migration. Never
+drop consent evidence as an application rollback shortcut.
+
+Next: integrate the standalone homepage with this POST contract, implement both
+frontend return routes, add/approve a tenant-authorized customer subscription/
+entitlement read endpoint, complete legal/retention/operator-access decisions,
+then request separate staging configuration and smoke-test authority.
+Production activation remains a separate decision.

--- a/index.js
+++ b/index.js
@@ -73,6 +73,10 @@ const {
 const {
   createServiceExecutionRouter,
 } = require("./src/service-execution");
+const {
+  createPaidBetaProductionComposition,
+  createPaidBetaRouter,
+} = require("./src/paid-beta");
 
 // The single scope this task defines. A future task may add narrower,
 // per-execution-class scopes; for now every generation job authorizes
@@ -245,6 +249,7 @@ function createApp({
   generationBillingOrchestrator = new UnconfiguredGenerationBillingOrchestrator(),
   servicePrincipalVerifier = new UnconfiguredServiceCredentialVerifier(),
   stripeSubscriptionService,
+  paidBetaCaptureService,
   corsConfig = { enabled: false, allowedOrigins: [] },
   logger = console,
 } = {}) {
@@ -285,6 +290,15 @@ function createApp({
         }),
         logger,
       })
+    );
+  }
+
+  // The public capture boundary owns its bounded parser and durable abuse
+  // check, so mount it before the application's general JSON parser.
+  if (paidBetaCaptureService) {
+    app.use(
+      "/public/paid-beta-interest",
+      createPaidBetaRouter({ service: paidBetaCaptureService, logger })
     );
   }
 
@@ -553,6 +567,10 @@ async function createProductionApp({ env = process.env, logger = console } = {})
     billingService: billing.billingService,
     env,
   });
+  const paidBeta = await createPaidBetaProductionComposition({
+    pool: brandBrainRepository.pool,
+    env,
+  });
   const servicePrincipalVerifier = createServiceCredentialVerifierFromEnv({
     env,
   });
@@ -567,6 +585,7 @@ async function createProductionApp({ env = process.env, logger = console } = {})
       videoGenerationRepository,
       servicePrincipalVerifier,
       stripeSubscriptionService: stripe.stripeSubscriptionService,
+      paidBetaCaptureService: paidBeta.service,
       videoProvider: media.videoProvider,
       videoAssetStore: media.videoAssetStore,
       videoReferenceAssetLoader: media.videoReferenceAssetLoader,
@@ -586,6 +605,9 @@ async function createProductionApp({ env = process.env, logger = console } = {})
     servicePrincipalVerifier,
     stripeSubscriptionService: stripe.stripeSubscriptionService,
     stripe,
+    paidBetaCaptureRepository: paidBeta.repository,
+    paidBetaCaptureService: paidBeta.service,
+    paidBeta,
   };
 }
 

--- a/src/billing/stripe/config.js
+++ b/src/billing/stripe/config.js
@@ -11,6 +11,9 @@ const testUrl = z.string().url().refine((value) => {
     (url.protocol === "http:" && ["localhost", "127.0.0.1"].includes(url.hostname));
 });
 
+const CHECKOUT_SUCCESS_PATH = "/billing/checkout/success";
+const CHECKOUT_CANCEL_PATH = "/billing/checkout/cancel";
+
 const plan = z.object({
   priceId: z.string().regex(/^price_[A-Za-z0-9]+$/),
   policyId: z.string().trim().min(1).max(128),
@@ -33,6 +36,22 @@ const StripeBillingConfigSchema = z.object({
   for (const key of ["successUrl", "cancelUrl"]) {
     if (!urlSchema.safeParse(config[key]).success) {
       ctx.addIssue({ code: "custom", path: [key], message: "Unsafe Stripe return URL" });
+    }
+  }
+  const success = new URL(config.successUrl);
+  const cancel = new URL(config.cancelUrl);
+  if (success.origin !== cancel.origin) {
+    ctx.addIssue({ code: "custom", path: ["cancelUrl"], message: "Stripe return origins must match" });
+  }
+  for (const [key, url, expectedPath] of [
+    ["successUrl", success, CHECKOUT_SUCCESS_PATH],
+    ["cancelUrl", cancel, CHECKOUT_CANCEL_PATH],
+  ]) {
+    if (
+      url.pathname !== expectedPath || url.search || url.hash ||
+      url.username || url.password
+    ) {
+      ctx.addIssue({ code: "custom", path: [key], message: "Unsafe Stripe return route" });
     }
   }
   if (Object.keys(config.plans).length === 0) {
@@ -87,6 +106,8 @@ function createStripeClient({ config }) {
 }
 
 module.exports = {
+  CHECKOUT_CANCEL_PATH,
+  CHECKOUT_SUCCESS_PATH,
   STRIPE_API_VERSION,
   STRIPE_SDK_VERSION,
   StripeBillingConfigSchema,

--- a/src/paid-beta/config.js
+++ b/src/paid-beta/config.js
@@ -1,0 +1,62 @@
+const { activationFlag, requireActivationEnvironment } = require("../activation/config");
+const { PaidBetaConfigurationError } = require("./errors");
+
+const PAID_BETA_CONSENT_VERSION = "paid-beta-contact-v1";
+const PAID_BETA_CONSENT_WORDING =
+  "I agree that BizGenie may use these details to contact me about the paid beta.";
+
+function boundedInteger(value, fallback, { name, minimum, maximum }) {
+  const candidate = value === undefined || value === "" ? fallback : Number(value);
+  if (!Number.isSafeInteger(candidate) || candidate < minimum || candidate > maximum) {
+    throw new PaidBetaConfigurationError(`${name} is invalid`);
+  }
+  return candidate;
+}
+
+function secret(value, name) {
+  if (typeof value !== "string" || value.length < 32) {
+    throw new PaidBetaConfigurationError(`${name} must contain at least 32 characters`);
+  }
+  return value;
+}
+
+function loadPaidBetaCaptureConfig({ env = process.env } = {}) {
+  const enabled = activationFlag(env, "PAID_BETA_CAPTURE_ENABLED");
+  if (!enabled) return Object.freeze({ enabled: false });
+  const environment = requireActivationEnvironment(env);
+  const submissionHashSecret = secret(
+    env.PAID_BETA_SUBMISSION_HASH_SECRET,
+    "PAID_BETA_SUBMISSION_HASH_SECRET"
+  );
+  const clientHashSecret = secret(
+    env.PAID_BETA_CLIENT_HASH_SECRET,
+    "PAID_BETA_CLIENT_HASH_SECRET"
+  );
+  if (submissionHashSecret === clientHashSecret) {
+    throw new PaidBetaConfigurationError("Paid-beta HMAC secrets must be distinct");
+  }
+  return Object.freeze({
+    enabled: true,
+    environment,
+    submissionHashSecret,
+    clientHashSecret,
+    consentVersion: PAID_BETA_CONSENT_VERSION,
+    consentWording: PAID_BETA_CONSENT_WORDING,
+    rateLimitMaxAttempts: boundedInteger(env.PAID_BETA_RATE_LIMIT_MAX_ATTEMPTS, 5, {
+      name: "PAID_BETA_RATE_LIMIT_MAX_ATTEMPTS",
+      minimum: 1,
+      maximum: 100,
+    }),
+    rateLimitWindowSeconds: boundedInteger(env.PAID_BETA_RATE_LIMIT_WINDOW_SECONDS, 900, {
+      name: "PAID_BETA_RATE_LIMIT_WINDOW_SECONDS",
+      minimum: 60,
+      maximum: 86400,
+    }),
+  });
+}
+
+module.exports = {
+  PAID_BETA_CONSENT_VERSION,
+  PAID_BETA_CONSENT_WORDING,
+  loadPaidBetaCaptureConfig,
+};

--- a/src/paid-beta/errors.js
+++ b/src/paid-beta/errors.js
@@ -1,0 +1,71 @@
+class PaidBetaError extends Error {
+  constructor(status, code, message, details) {
+    super(message);
+    this.name = this.constructor.name;
+    this.status = status;
+    this.code = code;
+    if (details) this.details = details;
+  }
+}
+
+class PaidBetaValidationError extends PaidBetaError {
+  constructor(details) {
+    super(400, "VALIDATION_ERROR", "Request validation failed", details);
+  }
+}
+
+class PaidBetaPayloadTooLargeError extends PaidBetaError {
+  constructor() {
+    super(413, "PAYLOAD_TOO_LARGE", "Request payload is too large");
+  }
+}
+
+class PaidBetaRateLimitError extends PaidBetaError {
+  constructor() {
+    super(429, "PAID_BETA_RATE_LIMITED", "Request could not be accepted");
+  }
+}
+
+class PaidBetaIdempotencyConflictError extends PaidBetaError {
+  constructor() {
+    super(409, "IDEMPOTENCY_KEY_CONFLICT", "Submission identity was reused inconsistently");
+  }
+}
+
+class PaidBetaPersistenceError extends PaidBetaError {
+  constructor() {
+    super(503, "PAID_BETA_CAPTURE_UNAVAILABLE", "Paid-beta interest capture is unavailable");
+  }
+}
+
+class PaidBetaConfigurationError extends Error {
+  constructor(message = "Paid-beta capture configuration is invalid") {
+    super(message);
+    this.name = "PaidBetaConfigurationError";
+    this.code = "PAID_BETA_CONFIGURATION_INVALID";
+  }
+}
+
+function sendPaidBetaError(error, res) {
+  if (!(error instanceof PaidBetaError)) return false;
+  const body = {
+    error: {
+      code: error.code,
+      message: error.message,
+    },
+  };
+  if (error.details) body.error.details = error.details;
+  res.status(error.status).json(body);
+  return true;
+}
+
+module.exports = {
+  PaidBetaConfigurationError,
+  PaidBetaError,
+  PaidBetaIdempotencyConflictError,
+  PaidBetaPayloadTooLargeError,
+  PaidBetaPersistenceError,
+  PaidBetaRateLimitError,
+  PaidBetaValidationError,
+  sendPaidBetaError,
+};

--- a/src/paid-beta/index.js
+++ b/src/paid-beta/index.js
@@ -1,0 +1,10 @@
+module.exports = {
+  ...require("./config"),
+  ...require("./errors"),
+  ...require("./postgresRepository"),
+  ...require("./productionComposition"),
+  ...require("./repository"),
+  ...require("./router"),
+  ...require("./schema"),
+  ...require("./service"),
+};

--- a/src/paid-beta/postgresRepository.js
+++ b/src/paid-beta/postgresRepository.js
@@ -1,0 +1,196 @@
+const {
+  PaidBetaConfigurationError,
+  PaidBetaIdempotencyConflictError,
+  PaidBetaPersistenceError,
+  PaidBetaRateLimitError,
+} = require("./errors");
+const { PaidBetaRepository } = require("./repository");
+
+class PostgresPaidBetaRepository extends PaidBetaRepository {
+  constructor({ pool }) {
+    super();
+    if (!pool || typeof pool.query !== "function") {
+      throw new PaidBetaConfigurationError("A PostgreSQL pool is required");
+    }
+    this.pool = pool;
+    this.lastCleanupAt = 0;
+  }
+
+  async initialize() {
+    try {
+      const result = await this.pool.query(`
+        SELECT
+          to_regclass('public.paid_beta_interests') AS interests,
+          to_regclass('public.paid_beta_interest_receipts') AS receipts,
+          to_regclass('public.paid_beta_rate_limit_buckets') AS rate_limits,
+          (SELECT relrowsecurity FROM pg_class
+            WHERE oid = 'public.paid_beta_interests'::regclass) AS interests_rls,
+          (SELECT relrowsecurity FROM pg_class
+            WHERE oid = 'public.paid_beta_interest_receipts'::regclass) AS receipts_rls,
+          EXISTS (
+            SELECT 1 FROM pg_trigger
+             WHERE tgrelid = 'public.paid_beta_interests'::regclass
+               AND tgname = 'protect_paid_beta_interests'
+               AND NOT tgisinternal
+          ) AS interests_immutable,
+          EXISTS (
+            SELECT 1 FROM pg_trigger
+             WHERE tgrelid = 'public.paid_beta_interest_receipts'::regclass
+               AND tgname = 'protect_paid_beta_interest_receipts'
+               AND NOT tgisinternal
+          ) AS receipts_immutable`);
+      const row = result.rows[0];
+      if (
+        !row?.interests || !row.receipts || !row.rate_limits ||
+        row.interests_rls !== true || row.receipts_rls !== true ||
+        row.interests_immutable !== true || row.receipts_immutable !== true
+      ) {
+        throw new PaidBetaConfigurationError();
+      }
+      const unsafe = await this.pool.query(`
+        SELECT grantee, table_name
+          FROM information_schema.role_table_grants
+         WHERE table_schema = 'public'
+           AND table_name IN (
+             'paid_beta_interests',
+             'paid_beta_interest_receipts',
+             'paid_beta_rate_limit_buckets'
+           )
+           AND grantee IN ('anon', 'authenticated', 'service_role')`);
+      if (unsafe.rowCount > 0) throw new PaidBetaConfigurationError();
+    } catch (error) {
+      if (error instanceof PaidBetaConfigurationError) throw error;
+      throw new PaidBetaConfigurationError();
+    }
+  }
+
+  async cleanupExpiredRateLimits(now) {
+    const nowMs = Date.parse(now);
+    if (!Number.isFinite(nowMs) || nowMs - this.lastCleanupAt < 3600000) return;
+    this.lastCleanupAt = nowMs;
+    await this.pool.query(`
+      WITH expired AS (
+        SELECT client_hash, window_started_at
+          FROM public.paid_beta_rate_limit_buckets
+         WHERE expires_at < $1
+         ORDER BY expires_at
+         LIMIT 500
+      )
+      DELETE FROM public.paid_beta_rate_limit_buckets AS bucket
+       USING expired
+       WHERE bucket.client_hash = expired.client_hash
+         AND bucket.window_started_at = expired.window_started_at`, [now]);
+  }
+
+  async consumeRateLimit({
+    client_hash,
+    window_started_at,
+    expires_at,
+    maximum_attempts,
+    now,
+  }) {
+    try {
+      await this.cleanupExpiredRateLimits(now);
+      const result = await this.pool.query(`
+        INSERT INTO public.paid_beta_rate_limit_buckets
+          (client_hash, window_started_at, attempt_count, expires_at, created_at, updated_at)
+        VALUES ($1, $2, 1, $3, $4, $4)
+        ON CONFLICT (client_hash, window_started_at) DO UPDATE
+          SET attempt_count = public.paid_beta_rate_limit_buckets.attempt_count + 1,
+              updated_at = EXCLUDED.updated_at
+        WHERE public.paid_beta_rate_limit_buckets.attempt_count < $5
+        RETURNING attempt_count`,
+      [client_hash, window_started_at, expires_at, now, maximum_attempts]);
+      if (result.rowCount === 0) throw new PaidBetaRateLimitError();
+    } catch (error) {
+      if (error instanceof PaidBetaRateLimitError) throw error;
+      throw new PaidBetaPersistenceError();
+    }
+  }
+
+  async captureInterest(input) {
+    let client;
+    try {
+      client = await this.pool.connect();
+      await client.query("BEGIN");
+      const existing = await client.query(`
+        SELECT reference_id, request_fingerprint
+          FROM public.paid_beta_interest_receipts
+         WHERE submission_identity = $1`, [input.submission_identity]);
+      if (existing.rows[0]) {
+        if (existing.rows[0].request_fingerprint !== input.request_fingerprint) {
+          throw new PaidBetaIdempotencyConflictError();
+        }
+        await client.query("COMMIT");
+        return { reference_id: existing.rows[0].reference_id, replay: true };
+      }
+
+      let interest = await client.query(`
+        INSERT INTO public.paid_beta_interests
+          (interest_id, name, work_email, business_name, website_or_social_profile,
+           business_stage, primary_marketing_challenge, source, created_at, updated_at)
+        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$9)
+        ON CONFLICT (work_email) DO NOTHING
+        RETURNING interest_id`, [
+        input.interest.interest_id,
+        input.interest.name,
+        input.interest.work_email,
+        input.interest.business_name,
+        input.interest.website_or_social_profile,
+        input.interest.business_stage,
+        input.interest.primary_marketing_challenge,
+        input.interest.source,
+        input.interest.created_at,
+      ]);
+      if (interest.rowCount === 0) {
+        interest = await client.query(
+          "SELECT interest_id FROM public.paid_beta_interests WHERE work_email = $1",
+          [input.interest.work_email]
+        );
+      }
+      if (!interest.rows[0]) throw new PaidBetaPersistenceError();
+
+      const receipt = await client.query(`
+        INSERT INTO public.paid_beta_interest_receipts
+          (receipt_id, reference_id, interest_id, submission_identity,
+           request_fingerprint, consent_version, consent_wording, consented_at,
+           source, created_at)
+        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+        ON CONFLICT (submission_identity) DO NOTHING
+        RETURNING reference_id, request_fingerprint`, [
+        input.receipt.receipt_id,
+        input.receipt.reference_id,
+        interest.rows[0].interest_id,
+        input.submission_identity,
+        input.request_fingerprint,
+        input.receipt.consent_version,
+        input.receipt.consent_wording,
+        input.receipt.consented_at,
+        input.receipt.source,
+        input.receipt.created_at,
+      ]);
+      let resolved = receipt.rows[0];
+      if (!resolved) {
+        resolved = (await client.query(`
+          SELECT reference_id, request_fingerprint
+            FROM public.paid_beta_interest_receipts
+           WHERE submission_identity = $1`, [input.submission_identity])).rows[0];
+      }
+      if (!resolved) throw new PaidBetaPersistenceError();
+      if (resolved.request_fingerprint !== input.request_fingerprint) {
+        throw new PaidBetaIdempotencyConflictError();
+      }
+      await client.query("COMMIT");
+      return { reference_id: resolved.reference_id, replay: receipt.rowCount === 0 };
+    } catch (error) {
+      try { await client?.query("ROLLBACK"); } catch {}
+      if (error instanceof PaidBetaIdempotencyConflictError) throw error;
+      if (error instanceof PaidBetaPersistenceError) throw error;
+      throw new PaidBetaPersistenceError();
+    } finally {
+      client?.release();
+    }
+  }
+}
+
+module.exports = { PostgresPaidBetaRepository };

--- a/src/paid-beta/productionComposition.js
+++ b/src/paid-beta/productionComposition.js
@@ -1,0 +1,24 @@
+const { loadPaidBetaCaptureConfig } = require("./config");
+const { PostgresPaidBetaRepository } = require("./postgresRepository");
+const { PaidBetaCaptureService } = require("./service");
+
+async function createPaidBetaProductionComposition({
+  pool,
+  env = process.env,
+  now = () => new Date(),
+} = {}) {
+  const config = loadPaidBetaCaptureConfig({ env });
+  if (!config.enabled) {
+    return Object.freeze({ enabled: false, repository: null, service: null });
+  }
+  const repository = new PostgresPaidBetaRepository({ pool });
+  await repository.initialize();
+  return Object.freeze({
+    enabled: true,
+    config,
+    repository,
+    service: new PaidBetaCaptureService({ repository, config, now }),
+  });
+}
+
+module.exports = { createPaidBetaProductionComposition };

--- a/src/paid-beta/repository.js
+++ b/src/paid-beta/repository.js
@@ -1,0 +1,70 @@
+const {
+  PaidBetaIdempotencyConflictError,
+  PaidBetaRateLimitError,
+} = require("./errors");
+
+function copy(value) {
+  return value ? structuredClone(value) : value;
+}
+
+class PaidBetaRepository {
+  async initialize() {}
+  async consumeRateLimit(_input) {
+    throw new Error("PaidBetaRepository.consumeRateLimit is not implemented");
+  }
+  async captureInterest(_input) {
+    throw new Error("PaidBetaRepository.captureInterest is not implemented");
+  }
+}
+
+class InMemoryPaidBetaRepository extends PaidBetaRepository {
+  constructor() {
+    super();
+    this.interestsByEmail = new Map();
+    this.receiptsBySubmissionIdentity = new Map();
+    this.rateLimits = new Map();
+  }
+
+  async consumeRateLimit({ client_hash, window_started_at, expires_at, maximum_attempts }) {
+    const key = `${client_hash}\u0000${window_started_at}`;
+    const current = this.rateLimits.get(key);
+    if (current && current.attempt_count >= maximum_attempts) {
+      throw new PaidBetaRateLimitError();
+    }
+    this.rateLimits.set(key, {
+      client_hash,
+      window_started_at,
+      expires_at,
+      attempt_count: (current?.attempt_count || 0) + 1,
+    });
+  }
+
+  async captureInterest(input) {
+    const existingReceipt = this.receiptsBySubmissionIdentity.get(input.submission_identity);
+    if (existingReceipt) {
+      if (existingReceipt.request_fingerprint !== input.request_fingerprint) {
+        throw new PaidBetaIdempotencyConflictError();
+      }
+      return copy({ reference_id: existingReceipt.reference_id, replay: true });
+    }
+
+    let interest = this.interestsByEmail.get(input.interest.work_email);
+    if (!interest) {
+      interest = copy(input.interest);
+      this.interestsByEmail.set(interest.work_email, interest);
+    }
+    const receipt = copy({
+      ...input.receipt,
+      interest_id: interest.interest_id,
+      submission_identity: input.submission_identity,
+      request_fingerprint: input.request_fingerprint,
+    });
+    this.receiptsBySubmissionIdentity.set(input.submission_identity, receipt);
+    return copy({ reference_id: receipt.reference_id, replay: false });
+  }
+}
+
+module.exports = {
+  InMemoryPaidBetaRepository,
+  PaidBetaRepository,
+};

--- a/src/paid-beta/router.js
+++ b/src/paid-beta/router.js
@@ -1,0 +1,76 @@
+const express = require("express");
+const {
+  PaidBetaPayloadTooLargeError,
+  PaidBetaValidationError,
+  sendPaidBetaError,
+} = require("./errors");
+
+function defaultClientIdentity(req) {
+  return req.socket?.remoteAddress || req.ip || "unresolved-client";
+}
+
+function createPaidBetaRouter({
+  service,
+  logger = console,
+  resolveClientIdentity = defaultClientIdentity,
+}) {
+  if (!service) throw new TypeError("A paid-beta capture service is required");
+  const router = express.Router();
+
+  router.post(
+    "/",
+    async (req, _res, next) => {
+      try {
+        await service.consumeAttempt({ clientIdentity: resolveClientIdentity(req) });
+        next();
+      } catch (error) {
+        next(error);
+      }
+    },
+    express.json({ limit: "16kb", strict: true }),
+    async (req, res, next) => {
+      try {
+        const result = await service.capture(req.body);
+        logger.info?.("paid-beta interest received", {
+          reference_id: result.reference_id,
+        });
+        return res.status(202).json(result);
+      } catch (error) {
+        logger.warn?.("paid-beta interest rejected", {
+          code: error?.code || "PAID_BETA_CAPTURE_INTERNAL_ERROR",
+        });
+        return next(error);
+      }
+    }
+  );
+
+  router.use((error, _req, res, _next) => {
+    if (error?.type === "entity.too.large") {
+      return sendPaidBetaError(new PaidBetaPayloadTooLargeError(), res);
+    }
+    if (error instanceof SyntaxError && error.status === 400) {
+      return sendPaidBetaError(new PaidBetaValidationError([{
+        path: "",
+        code: "invalid_json",
+        message: "Malformed JSON request body",
+      }]), res);
+    }
+    if (sendPaidBetaError(error, res)) return;
+    logger.error?.("paid-beta capture internal error", {
+      code: error?.code || "PAID_BETA_CAPTURE_INTERNAL_ERROR",
+    });
+    return res.status(500).json({
+      error: {
+        code: "PAID_BETA_CAPTURE_INTERNAL_ERROR",
+        message: "Paid-beta interest capture failed",
+      },
+    });
+  });
+
+  return router;
+}
+
+module.exports = {
+  createPaidBetaRouter,
+  defaultClientIdentity,
+};

--- a/src/paid-beta/schema.js
+++ b/src/paid-beta/schema.js
@@ -1,0 +1,54 @@
+const { z } = require("zod");
+const { PaidBetaValidationError } = require("./errors");
+
+const PAID_BETA_STAGES = Object.freeze([
+  "pre-revenue",
+  "under-250k",
+  "250k-1m",
+  "1m-5m",
+  "5m-plus",
+]);
+
+const boundedText = (maximum) => z.string().trim().min(1).max(maximum);
+const httpUrl = z.string().trim().min(1).max(2048).url().refine((value) => {
+  const url = new URL(value);
+  return ["http:", "https:"].includes(url.protocol) && !url.username && !url.password;
+}, "Website or social profile must be an HTTP(S) URL");
+
+const PaidBetaSubmissionSchema = z.object({
+  name: boundedText(120),
+  work_email: z.string().trim().max(254).transform((value) => value.toLowerCase())
+    .pipe(z.string().email().max(254)),
+  business_name: boundedText(160),
+  website_or_social_profile: httpUrl,
+  business_stage: z.enum(PAID_BETA_STAGES),
+  primary_marketing_challenge: boundedText(1000),
+  privacy_contact_consent: z.literal(true),
+  source: z.string().trim().toLowerCase().min(1).max(64)
+    .regex(/^[a-z0-9][a-z0-9._:-]*$/),
+  submission_id: z.string().trim().min(1).max(128)
+    .regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/),
+}).strict();
+
+function validationDetails(issues) {
+  return issues.map((issue) => ({
+    path: issue.path.join("."),
+    code: issue.code,
+    message: issue.message,
+  }));
+}
+
+function parsePaidBetaSubmission(value) {
+  const result = PaidBetaSubmissionSchema.safeParse(value);
+  if (!result.success) {
+    throw new PaidBetaValidationError(validationDetails(result.error.issues));
+  }
+  return result.data;
+}
+
+module.exports = {
+  PAID_BETA_STAGES,
+  PaidBetaSubmissionSchema,
+  parsePaidBetaSubmission,
+  validationDetails,
+};

--- a/src/paid-beta/service.js
+++ b/src/paid-beta/service.js
@@ -1,0 +1,95 @@
+const { createHmac, randomBytes, randomUUID } = require("node:crypto");
+const { parsePaidBetaSubmission } = require("./schema");
+
+function hmac(secret, value) {
+  return createHmac("sha256", secret).update(value).digest("hex");
+}
+
+function canonicalSubmission(input, consentVersion) {
+  return JSON.stringify({
+    name: input.name,
+    work_email: input.work_email,
+    business_name: input.business_name,
+    website_or_social_profile: input.website_or_social_profile,
+    business_stage: input.business_stage,
+    primary_marketing_challenge: input.primary_marketing_challenge,
+    privacy_contact_consent: input.privacy_contact_consent,
+    source: input.source,
+    consent_version: consentVersion,
+  });
+}
+
+class PaidBetaCaptureService {
+  constructor({
+    repository,
+    config,
+    now = () => new Date(),
+    idFactory = randomUUID,
+    referenceFactory = () => `pbi_${randomBytes(18).toString("base64url")}`,
+  }) {
+    if (!repository || !config?.enabled) {
+      throw new TypeError("Paid-beta repository and enabled configuration are required");
+    }
+    this.repository = repository;
+    this.config = config;
+    this.now = now;
+    this.idFactory = idFactory;
+    this.referenceFactory = referenceFactory;
+  }
+
+  async consumeAttempt({ clientIdentity }) {
+    const identity = typeof clientIdentity === "string" && clientIdentity
+      ? clientIdentity
+      : "unresolved-client";
+    const now = this.now();
+    const windowMs = this.config.rateLimitWindowSeconds * 1000;
+    const windowStart = new Date(Math.floor(now.getTime() / windowMs) * windowMs);
+    await this.repository.consumeRateLimit({
+      client_hash: hmac(this.config.clientHashSecret, identity),
+      window_started_at: windowStart.toISOString(),
+      expires_at: new Date(windowStart.getTime() + windowMs).toISOString(),
+      maximum_attempts: this.config.rateLimitMaxAttempts,
+      now: now.toISOString(),
+    });
+  }
+
+  async capture(value) {
+    const input = parsePaidBetaSubmission(value);
+    const timestamp = this.now().toISOString();
+    const requestFingerprint = hmac(
+      this.config.submissionHashSecret,
+      canonicalSubmission(input, this.config.consentVersion)
+    );
+    const result = await this.repository.captureInterest({
+      submission_identity: input.submission_id,
+      request_fingerprint: requestFingerprint,
+      interest: {
+        interest_id: this.idFactory(),
+        name: input.name,
+        work_email: input.work_email,
+        business_name: input.business_name,
+        website_or_social_profile: input.website_or_social_profile,
+        business_stage: input.business_stage,
+        primary_marketing_challenge: input.primary_marketing_challenge,
+        source: input.source,
+        created_at: timestamp,
+      },
+      receipt: {
+        receipt_id: this.idFactory(),
+        reference_id: this.referenceFactory(),
+        consent_version: this.config.consentVersion,
+        consent_wording: this.config.consentWording,
+        consented_at: timestamp,
+        source: input.source,
+        created_at: timestamp,
+      },
+    });
+    return Object.freeze({ status: "received", reference_id: result.reference_id });
+  }
+}
+
+module.exports = {
+  PaidBetaCaptureService,
+  canonicalSubmission,
+  hmac,
+};

--- a/supabase/migrations/20260901170000_create_paid_beta_interest_capture.sql
+++ b/supabase/migrations/20260901170000_create_paid_beta_interest_capture.sql
@@ -1,0 +1,156 @@
+create schema if not exists paid_beta_private;
+revoke all on schema paid_beta_private from public;
+
+create table if not exists public.paid_beta_interests (
+  interest_id uuid primary key,
+  name text not null,
+  work_email text not null,
+  business_name text not null,
+  website_or_social_profile text not null,
+  business_stage text not null,
+  primary_marketing_challenge text not null,
+  source text not null,
+  created_at timestamptz not null default current_timestamp,
+  updated_at timestamptz not null default current_timestamp,
+  constraint paid_beta_interests_email_unique unique (work_email),
+  constraint paid_beta_interests_name_bounds check (
+    name = btrim(name) and length(name) between 1 and 120
+  ),
+  constraint paid_beta_interests_email_bounds check (
+    work_email = lower(btrim(work_email))
+    and length(work_email) between 3 and 254
+    and work_email ~ '^[^[:space:]@]+@[^[:space:]@]+[.][^[:space:]@]+$'
+  ),
+  constraint paid_beta_interests_business_name_bounds check (
+    business_name = btrim(business_name) and length(business_name) between 1 and 160
+  ),
+  constraint paid_beta_interests_profile_bounds check (
+    website_or_social_profile = btrim(website_or_social_profile)
+    and length(website_or_social_profile) between 1 and 2048
+    and website_or_social_profile ~ '^https?://'
+  ),
+  constraint paid_beta_interests_stage_allowed check (
+    business_stage in ('pre-revenue', 'under-250k', '250k-1m', '1m-5m', '5m-plus')
+  ),
+  constraint paid_beta_interests_challenge_bounds check (
+    primary_marketing_challenge = btrim(primary_marketing_challenge)
+    and length(primary_marketing_challenge) between 1 and 1000
+  ),
+  constraint paid_beta_interests_source_bounds check (
+    length(source) between 1 and 64
+    and source ~ '^[a-z0-9][a-z0-9._:-]*$'
+  ),
+  constraint paid_beta_interests_timestamp_order check (updated_at >= created_at)
+);
+
+create table if not exists public.paid_beta_interest_receipts (
+  receipt_id uuid primary key,
+  reference_id text not null,
+  interest_id uuid not null references public.paid_beta_interests (interest_id),
+  submission_identity text not null,
+  request_fingerprint character(64) not null,
+  consent_version text not null,
+  consent_wording text not null,
+  consented_at timestamptz not null,
+  source text not null,
+  created_at timestamptz not null default current_timestamp,
+  constraint paid_beta_interest_receipts_reference_unique unique (reference_id),
+  constraint paid_beta_interest_receipts_submission_unique unique (submission_identity),
+  constraint paid_beta_interest_receipts_reference_format check (
+    reference_id ~ '^pbi_[A-Za-z0-9_-]{24}$'
+  ),
+  constraint paid_beta_interest_receipts_submission_bounds check (
+    length(submission_identity) between 1 and 128
+    and submission_identity ~ '^[A-Za-z0-9][A-Za-z0-9._:-]*$'
+  ),
+  constraint paid_beta_interest_receipts_fingerprint_format check (
+    request_fingerprint ~ '^[a-f0-9]{64}$'
+  ),
+  constraint paid_beta_interest_receipts_consent_bounds check (
+    length(consent_version) between 1 and 64
+    and length(consent_wording) between 1 and 500
+  ),
+  constraint paid_beta_interest_receipts_source_bounds check (
+    length(source) between 1 and 64
+    and source ~ '^[a-z0-9][a-z0-9._:-]*$'
+  ),
+  constraint paid_beta_interest_receipts_consent_time check (consented_at = created_at)
+);
+
+create table if not exists public.paid_beta_rate_limit_buckets (
+  client_hash character(64) not null,
+  window_started_at timestamptz not null,
+  attempt_count integer not null,
+  expires_at timestamptz not null,
+  created_at timestamptz not null default current_timestamp,
+  updated_at timestamptz not null default current_timestamp,
+  primary key (client_hash, window_started_at),
+  constraint paid_beta_rate_limit_hash_format check (client_hash ~ '^[a-f0-9]{64}$'),
+  constraint paid_beta_rate_limit_attempt_bounds check (attempt_count between 1 and 100000),
+  constraint paid_beta_rate_limit_window check (
+    expires_at > window_started_at and updated_at >= created_at
+  )
+);
+
+create index if not exists paid_beta_interests_created_idx
+  on public.paid_beta_interests (created_at desc);
+create index if not exists paid_beta_interest_receipts_interest_created_idx
+  on public.paid_beta_interest_receipts (interest_id, created_at desc);
+create index if not exists paid_beta_rate_limit_expiry_idx
+  on public.paid_beta_rate_limit_buckets (expires_at);
+
+create or replace function paid_beta_private.reject_interest_mutation()
+returns trigger
+language plpgsql
+set search_path = pg_catalog, public, paid_beta_private
+as $$
+begin
+  raise exception 'Paid-beta interest and consent evidence is append-only'
+    using errcode = '23514';
+end;
+$$;
+
+drop trigger if exists protect_paid_beta_interests on public.paid_beta_interests;
+create trigger protect_paid_beta_interests
+before update or delete on public.paid_beta_interests
+for each row execute function paid_beta_private.reject_interest_mutation();
+
+drop trigger if exists protect_paid_beta_interest_receipts
+  on public.paid_beta_interest_receipts;
+create trigger protect_paid_beta_interest_receipts
+before update or delete on public.paid_beta_interest_receipts
+for each row execute function paid_beta_private.reject_interest_mutation();
+
+alter table public.paid_beta_interests enable row level security;
+alter table public.paid_beta_interest_receipts enable row level security;
+alter table public.paid_beta_rate_limit_buckets enable row level security;
+
+revoke all on table public.paid_beta_interests from public;
+revoke all on table public.paid_beta_interest_receipts from public;
+revoke all on table public.paid_beta_rate_limit_buckets from public;
+revoke all on function paid_beta_private.reject_interest_mutation() from public;
+
+do $$
+declare
+  role_name text;
+begin
+  foreach role_name in array array['anon', 'authenticated', 'service_role'] loop
+    if exists (select 1 from pg_roles where rolname = role_name) then
+      execute format('revoke all on table public.paid_beta_interests from %I', role_name);
+      execute format('revoke all on table public.paid_beta_interest_receipts from %I', role_name);
+      execute format('revoke all on table public.paid_beta_rate_limit_buckets from %I', role_name);
+      execute format(
+        'revoke all on function paid_beta_private.reject_interest_mutation() from %I',
+        role_name
+      );
+    end if;
+  end loop;
+end;
+$$;
+
+comment on table public.paid_beta_interests is
+  'Server-only canonical paid-beta follow-up records; no Auth, Billing, tenant, generation, or public read authority.';
+comment on table public.paid_beta_interest_receipts is
+  'Append-only public submission receipt and consent evidence; writes are mediated by bizgenie-api.';
+comment on table public.paid_beta_rate_limit_buckets is
+  'Short-lived HMAC-pseudonymized public endpoint abuse buckets; raw network addresses are not stored.';

--- a/test/activation-composition.test.js
+++ b/test/activation-composition.test.js
@@ -20,6 +20,12 @@ const {
   GoogleVertexVeoProvider,
   UnconfiguredVideoGenerationProvider,
 } = require("../src/video-generation");
+const {
+  PaidBetaCaptureService,
+  PaidBetaConfigurationError,
+  createPaidBetaProductionComposition,
+  loadPaidBetaCaptureConfig,
+} = require("../src/paid-beta");
 const { createApp } = require("../index");
 
 function mediaPool() {
@@ -72,8 +78,8 @@ function stripeEnv(overrides = {}) {
     STRIPE_MODE: "test",
     STRIPE_SECRET_KEY: "sk_test_staging",
     STRIPE_WEBHOOK_SECRET: "whsec_staging",
-    STRIPE_SUCCESS_URL: "https://staging-frontend.example/billing/success",
-    STRIPE_CANCEL_URL: "https://staging-frontend.example/billing/cancel",
+    STRIPE_SUCCESS_URL: "https://staging-frontend.example/billing/checkout/success",
+    STRIPE_CANCEL_URL: "https://staging-frontend.example/billing/checkout/cancel",
     STRIPE_PRICE_STANDARD: "price_StagingStandard",
     STRIPE_POLICY_STANDARD: "policy_staging_standard_v1",
     ...overrides,
@@ -164,6 +170,74 @@ describe("Stripe production composition gates", () => {
         ...dependencies,
         env: stripeEnv({ BIZGENIE_ENVIRONMENT: "production" }),
       }),
+      ActivationConfigurationError
+    );
+  });
+});
+
+describe("paid-beta production composition gates", () => {
+  const pool = {
+    async query(sql) {
+      if (sql.includes("to_regclass('public.paid_beta_interests')")) {
+        return { rows: [{
+          interests: "paid_beta_interests",
+          receipts: "paid_beta_interest_receipts",
+          rate_limits: "paid_beta_rate_limit_buckets",
+          interests_rls: true,
+          receipts_rls: true,
+          interests_immutable: true,
+          receipts_immutable: true,
+        }] };
+      }
+      if (sql.includes("information_schema.role_table_grants")) {
+        return { rowCount: 0, rows: [] };
+      }
+      throw new Error("unexpected paid-beta initialization query");
+    },
+  };
+
+  function captureEnv(overrides = {}) {
+    return {
+      BIZGENIE_ENVIRONMENT: "staging",
+      PAID_BETA_CAPTURE_ENABLED: "true",
+      PAID_BETA_SUBMISSION_HASH_SECRET: "s".repeat(32),
+      PAID_BETA_CLIENT_HASH_SECRET: "c".repeat(32),
+      ...overrides,
+    };
+  }
+
+  it("keeps public capture disabled by default", async () => {
+    const result = await createPaidBetaProductionComposition({ pool, env: {} });
+    assert.equal(result.enabled, false);
+    assert.equal(result.service, null);
+  });
+
+  it("enables capture only with explicit staging configuration and durable tables", async () => {
+    const result = await createPaidBetaProductionComposition({
+      pool,
+      env: captureEnv(),
+    });
+    assert.equal(result.enabled, true);
+    assert.ok(result.service instanceof PaidBetaCaptureService);
+  });
+
+  it("fails closed for weak/shared secrets and production without its gate", () => {
+    assert.throws(
+      () => loadPaidBetaCaptureConfig({ env: captureEnv({
+        PAID_BETA_SUBMISSION_HASH_SECRET: "weak",
+      }) }),
+      PaidBetaConfigurationError
+    );
+    assert.throws(
+      () => loadPaidBetaCaptureConfig({ env: captureEnv({
+        PAID_BETA_CLIENT_HASH_SECRET: "s".repeat(32),
+      }) }),
+      PaidBetaConfigurationError
+    );
+    assert.throws(
+      () => loadPaidBetaCaptureConfig({ env: captureEnv({
+        BIZGENIE_ENVIRONMENT: "production",
+      }) }),
       ActivationConfigurationError
     );
   });

--- a/test/paid-beta-capture.test.js
+++ b/test/paid-beta-capture.test.js
@@ -1,0 +1,238 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+const request = require("supertest");
+const { createApp } = require("../index");
+const { loadCorsConfig } = require("../src/activation");
+const {
+  InMemoryPaidBetaRepository,
+  PAID_BETA_CONSENT_VERSION,
+  PAID_BETA_CONSENT_WORDING,
+  PaidBetaCaptureService,
+  PaidBetaPersistenceError,
+} = require("../src/paid-beta");
+
+const NOW = "2026-09-01T17:00:00.000Z";
+
+function payload(overrides = {}) {
+  return {
+    name: "  Ada Lovelace  ",
+    work_email: "Ada@Example.COM",
+    business_name: "Analytical Engines Ltd",
+    website_or_social_profile: "https://example.com/ada",
+    business_stage: "250k-1m",
+    primary_marketing_challenge: "Keeping launch campaigns consistent.",
+    privacy_contact_consent: true,
+    source: "homepage-paid-beta",
+    submission_id: "submit_001",
+    ...overrides,
+  };
+}
+
+function setup({ maximumAttempts = 100 } = {}) {
+  const repository = new InMemoryPaidBetaRepository();
+  const service = new PaidBetaCaptureService({
+    repository,
+    config: {
+      enabled: true,
+      submissionHashSecret: "s".repeat(32),
+      clientHashSecret: "c".repeat(32),
+      consentVersion: PAID_BETA_CONSENT_VERSION,
+      consentWording: PAID_BETA_CONSENT_WORDING,
+      rateLimitMaxAttempts: maximumAttempts,
+      rateLimitWindowSeconds: 900,
+    },
+    now: () => new Date(NOW),
+  });
+  const app = createApp({
+    paidBetaCaptureService: service,
+    logger: { info() {}, warn() {}, error() {} },
+  });
+  return { app, repository, service };
+}
+
+describe("public paid-beta interest capture", () => {
+  it("accepts a valid interest and safely normalizes email and bounded text", async () => {
+    const { app, repository } = setup();
+    const response = await request(app).post("/public/paid-beta-interest").send(payload());
+    assert.equal(response.status, 202);
+    assert.equal(response.body.status, "received");
+    assert.match(response.body.reference_id, /^pbi_[A-Za-z0-9_-]{24}$/);
+    assert.equal(repository.interestsByEmail.size, 1);
+    const stored = repository.interestsByEmail.get("ada@example.com");
+    assert.equal(stored.name, "Ada Lovelace");
+    assert.equal(stored.work_email, "ada@example.com");
+    const receipt = repository.receiptsBySubmissionIdentity.get("submit_001");
+    assert.equal(receipt.consent_version, PAID_BETA_CONSENT_VERSION);
+    assert.equal(receipt.consent_wording, PAID_BETA_CONSENT_WORDING);
+    assert.equal(receipt.consented_at, NOW);
+  });
+
+  it("returns structured sanitized validation for every invalid contract class", async () => {
+    for (const invalid of [
+      { name: undefined },
+      { work_email: "not-an-email" },
+      { business_stage: "enterprise" },
+      { privacy_contact_consent: false },
+      { primary_marketing_challenge: "x".repeat(1001) },
+      { unknown_authority: "tenant_a" },
+    ]) {
+      const { app, repository } = setup();
+      const candidate = payload(invalid);
+      if (invalid.name === undefined) delete candidate.name;
+      const response = await request(app).post("/public/paid-beta-interest").send(candidate);
+      assert.equal(response.status, 400);
+      assert.equal(response.body.error.code, "VALIDATION_ERROR");
+      assert.equal(response.body.error.message, "Request validation failed");
+      assert.ok(Array.isArray(response.body.error.details));
+      assert.equal(JSON.stringify(response.body).includes("tenant_a"), false);
+      assert.equal(repository.interestsByEmail.size, 0);
+    }
+  });
+
+  it("treats injection-like text as data and never reflects it in the receipt", async () => {
+    const { app, repository } = setup();
+    const injection = "<script>alert('x')</script>'; DROP TABLE paid_beta_interests; --";
+    const response = await request(app).post("/public/paid-beta-interest").send(payload({
+      primary_marketing_challenge: injection,
+    }));
+    assert.equal(response.status, 202);
+    assert.equal(JSON.stringify(response.body).includes("script"), false);
+    assert.equal(
+      repository.interestsByEmail.get("ada@example.com").primary_marketing_challenge,
+      injection
+    );
+  });
+
+  it("replays one submission identity without a second record", async () => {
+    const { app, repository } = setup();
+    const first = await request(app).post("/public/paid-beta-interest").send(payload());
+    const replay = await request(app).post("/public/paid-beta-interest").send(payload());
+    assert.equal(replay.status, 202);
+    assert.equal(replay.body.reference_id, first.body.reference_id);
+    assert.equal(repository.interestsByEmail.size, 1);
+    assert.equal(repository.receiptsBySubmissionIdentity.size, 1);
+  });
+
+  it("deduplicates matching email across identities without revealing it", async () => {
+    const { app, repository } = setup();
+    const first = await request(app).post("/public/paid-beta-interest").send(payload());
+    const duplicate = await request(app).post("/public/paid-beta-interest").send(payload({
+      work_email: "ada@example.com",
+      submission_id: "submit_002",
+    }));
+    assert.equal(duplicate.status, first.status);
+    assert.deepEqual(Object.keys(duplicate.body).sort(), Object.keys(first.body).sort());
+    assert.notEqual(duplicate.body.reference_id, first.body.reference_id);
+    assert.equal(repository.interestsByEmail.size, 1);
+    assert.equal(repository.receiptsBySubmissionIdentity.size, 2);
+  });
+
+  it("converges concurrent duplicate submission", async () => {
+    const { service, repository } = setup();
+    const [first, second] = await Promise.all([
+      service.capture(payload()),
+      service.capture(payload()),
+    ]);
+    assert.equal(first.reference_id, second.reference_id);
+    assert.equal(repository.interestsByEmail.size, 1);
+    assert.equal(repository.receiptsBySubmissionIdentity.size, 1);
+  });
+
+  it("rejects reuse of a submission identity for different intent", async () => {
+    const { app, repository } = setup();
+    await request(app).post("/public/paid-beta-interest").send(payload());
+    const response = await request(app).post("/public/paid-beta-interest").send(payload({
+      business_name: "Different Business",
+    }));
+    assert.equal(response.status, 409);
+    assert.equal(response.body.error.code, "IDEMPOTENCY_KEY_CONFLICT");
+    assert.equal(repository.interestsByEmail.size, 1);
+    assert.equal(repository.receiptsBySubmissionIdentity.size, 1);
+  });
+
+  it("applies durable-boundary abuse semantics and sanitizes malformed/oversized payloads", async () => {
+    const { app } = setup({ maximumAttempts: 2 });
+    const malformed = await request(app)
+      .post("/public/paid-beta-interest")
+      .set("content-type", "application/json")
+      .send("{");
+    assert.equal(malformed.status, 400);
+    assert.equal(malformed.body.error.code, "VALIDATION_ERROR");
+    const invalid = await request(app).post("/public/paid-beta-interest").send({});
+    assert.equal(invalid.status, 400);
+    const limited = await request(app).post("/public/paid-beta-interest").send(payload());
+    assert.equal(limited.status, 429);
+    assert.equal(limited.body.error.code, "PAID_BETA_RATE_LIMITED");
+
+    const oversizedSetup = setup();
+    const oversized = await request(oversizedSetup.app)
+      .post("/public/paid-beta-interest")
+      .send(payload({ primary_marketing_challenge: "x".repeat(20000) }));
+    assert.equal(oversized.status, 413);
+    assert.equal(oversized.body.error.code, "PAYLOAD_TOO_LARGE");
+  });
+
+  it("exposes no public read/list route and leaves unrelated API behavior unchanged", async () => {
+    const { app } = setup();
+    const list = await request(app).get("/public/paid-beta-interest");
+    assert.equal(list.status, 404);
+    const root = await request(app).get("/");
+    assert.equal(root.status, 200);
+    const admin = await request(app).get("/_admin/ping");
+    assert.equal(admin.status, 403);
+  });
+
+  it("sanitizes persistence failure without leaking stored data or database details", async () => {
+    const repository = new InMemoryPaidBetaRepository();
+    repository.captureInterest = async () => {
+      throw new PaidBetaPersistenceError("postgresql://secret@example.invalid");
+    };
+    const service = new PaidBetaCaptureService({
+      repository,
+      config: {
+        enabled: true,
+        submissionHashSecret: "s".repeat(32),
+        clientHashSecret: "c".repeat(32),
+        consentVersion: PAID_BETA_CONSENT_VERSION,
+        consentWording: PAID_BETA_CONSENT_WORDING,
+        rateLimitMaxAttempts: 5,
+        rateLimitWindowSeconds: 900,
+      },
+      now: () => new Date(NOW),
+    });
+    const app = createApp({
+      paidBetaCaptureService: service,
+      logger: { info() {}, warn() {}, error() {} },
+    });
+    const response = await request(app).post("/public/paid-beta-interest").send(payload());
+    assert.equal(response.status, 503);
+    assert.equal(response.body.error.code, "PAID_BETA_CAPTURE_UNAVAILABLE");
+    assert.equal(JSON.stringify(response.body).includes("postgresql"), false);
+    assert.equal(JSON.stringify(response.body).includes("ada@example.com"), false);
+  });
+
+  it("uses only the existing exact-origin CORS allowlist", async () => {
+    const { service } = setup();
+    const corsConfig = loadCorsConfig({ env: {
+      BIZGENIE_ENVIRONMENT: "staging",
+      CORS_ENABLED: "true",
+      CORS_ALLOWED_ORIGINS: "https://homepage.example",
+    } });
+    const app = createApp({
+      paidBetaCaptureService: service,
+      corsConfig,
+      logger: { info() {}, warn() {}, error() {} },
+    });
+    const denied = await request(app)
+      .post("/public/paid-beta-interest")
+      .set("origin", "https://attacker.example")
+      .send(payload());
+    assert.equal(denied.status, 403);
+    const allowed = await request(app)
+      .post("/public/paid-beta-interest")
+      .set("origin", "https://homepage.example")
+      .send(payload());
+    assert.equal(allowed.status, 202);
+    assert.equal(allowed.headers["access-control-allow-origin"], "https://homepage.example");
+  });
+});

--- a/test/paid-beta-migration.test.js
+++ b/test/paid-beta-migration.test.js
@@ -1,0 +1,48 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { describe, it } = require("node:test");
+
+const migration = fs.readFileSync(path.join(
+  __dirname,
+  "..",
+  "supabase",
+  "migrations",
+  "20260901170000_create_paid_beta_interest_capture.sql"
+), "utf8");
+
+describe("paid-beta capture migration contract", () => {
+  it("creates a dedicated domain without Auth, Billing, tenant, or generation authority", () => {
+    assert.match(migration, /create table if not exists public\.paid_beta_interests/i);
+    assert.match(migration, /create table if not exists public\.paid_beta_interest_receipts/i);
+    assert.match(migration, /create table if not exists public\.paid_beta_rate_limit_buckets/i);
+    const tableDefinitions = migration.slice(0, migration.indexOf("create index"));
+    assert.doesNotMatch(tableDefinitions, /tenant_id|auth_user_id|subscription|entitlement|credit|generation_job|provider|model/i);
+  });
+
+  it("enforces dedupe, idempotency, consent evidence, bounds, and justified indexes", () => {
+    assert.match(migration, /paid_beta_interests_email_unique unique \(work_email\)/i);
+    assert.match(migration, /paid_beta_interest_receipts_submission_unique unique \(submission_identity\)/i);
+    assert.match(migration, /consent_version text not null/i);
+    assert.match(migration, /consent_wording text not null/i);
+    assert.match(migration, /consented_at timestamptz not null/i);
+    assert.match(migration, /primary_marketing_challenge[\s\S]*length\(primary_marketing_challenge\) between 1 and 1000/i);
+    assert.match(migration, /paid_beta_interests_created_idx/i);
+    assert.match(migration, /paid_beta_rate_limit_expiry_idx/i);
+  });
+
+  it("enables RLS, revokes customer-facing roles, and protects evidence mutation", () => {
+    for (const table of [
+      "paid_beta_interests",
+      "paid_beta_interest_receipts",
+      "paid_beta_rate_limit_buckets",
+    ]) {
+      assert.match(migration, new RegExp(`alter table public\\.${table} enable row level security`, "i"));
+      assert.match(migration, new RegExp(`revoke all on table public\\.${table}`, "i"));
+    }
+    assert.match(migration, /array\['anon', 'authenticated', 'service_role'\]/i);
+    assert.match(migration, /protect_paid_beta_interests[\s\S]*before update or delete/i);
+    assert.match(migration, /protect_paid_beta_interest_receipts[\s\S]*before update or delete/i);
+    assert.doesNotMatch(migration, /create policy/i);
+  });
+});

--- a/test/postgres-billing.integration.test.js
+++ b/test/postgres-billing.integration.test.js
@@ -23,6 +23,13 @@ const {
   PostgresMediaAssetRepository,
   objectKey,
 } = require("../src/media");
+const {
+  PAID_BETA_CONSENT_VERSION,
+  PAID_BETA_CONSENT_WORDING,
+  PaidBetaCaptureService,
+  PaidBetaRateLimitError,
+  PostgresPaidBetaRepository,
+} = require("../src/paid-beta");
 
 const ADMIN_DATABASE_URL = process.env.TEST_DATABASE_URL;
 const postgresDescribe = ADMIN_DATABASE_URL ? describe : describe.skip;
@@ -124,6 +131,9 @@ postgresDescribe("PostgresBillingRepository real PostgreSQL adversarial proof", 
   async function resetFixture() {
     await pool.query(`
       TRUNCATE TABLE
+        public.paid_beta_interest_receipts,
+        public.paid_beta_interests,
+        public.paid_beta_rate_limit_buckets,
         public.media_assets,
         public.stripe_bolt_on_payment_evidence,
         public.stripe_webhook_events,
@@ -866,6 +876,130 @@ postgresDescribe("PostgresBillingRepository real PostgreSQL adversarial proof", 
         client.release();
       }
     }
+  });
+
+  it("captures and deduplicates paid-beta interest under real PostgreSQL concurrency", async () => {
+    const paidBetaRepository = new PostgresPaidBetaRepository({ pool });
+    await paidBetaRepository.initialize();
+    const paidBetaService = new PaidBetaCaptureService({
+      repository: paidBetaRepository,
+      config: {
+        enabled: true,
+        submissionHashSecret: "s".repeat(32),
+        clientHashSecret: "c".repeat(32),
+        consentVersion: PAID_BETA_CONSENT_VERSION,
+        consentWording: PAID_BETA_CONSENT_WORDING,
+        rateLimitMaxAttempts: 20,
+        rateLimitWindowSeconds: 900,
+      },
+      now: () => new Date("2026-09-01T17:00:00.000Z"),
+    });
+    const submission = {
+      name: "Ada Lovelace",
+      work_email: "ADA@example.com",
+      business_name: "Analytical Engines Ltd",
+      website_or_social_profile: "https://example.com/ada",
+      business_stage: "250k-1m",
+      primary_marketing_challenge: "Consistent launch campaigns",
+      privacy_contact_consent: true,
+      source: "homepage-paid-beta",
+      submission_id: "postgres_concurrent_001",
+    };
+    const results = await Promise.all(
+      Array.from({ length: 8 }, () => paidBetaService.capture(submission))
+    );
+    assert.equal(new Set(results.map((result) => result.reference_id)).size, 1);
+    const counts = await pool.query(`
+      SELECT
+        (SELECT count(*)::integer FROM public.paid_beta_interests) AS interests,
+        (SELECT count(*)::integer FROM public.paid_beta_interest_receipts) AS receipts`);
+    assert.deepEqual(counts.rows[0], { interests: 1, receipts: 1 });
+
+    const duplicateEmail = await paidBetaService.capture({
+      ...submission,
+      work_email: "ada@example.com",
+      submission_id: "postgres_concurrent_002",
+    });
+    assert.notEqual(duplicateEmail.reference_id, results[0].reference_id);
+    const deduplicated = await pool.query(`
+      SELECT
+        (SELECT count(*)::integer FROM public.paid_beta_interests) AS interests,
+        (SELECT count(*)::integer FROM public.paid_beta_interest_receipts) AS receipts`);
+    assert.deepEqual(deduplicated.rows[0], { interests: 1, receipts: 2 });
+  });
+
+  it("rate-limits paid-beta attempts atomically across real PostgreSQL sessions", async () => {
+    const paidBetaRepository = new PostgresPaidBetaRepository({ pool });
+    const input = {
+      client_hash: "a".repeat(64),
+      window_started_at: "2026-09-01T17:00:00.000Z",
+      expires_at: "2026-09-01T17:15:00.000Z",
+      maximum_attempts: 3,
+      now: "2026-09-01T17:00:01.000Z",
+    };
+    const attempts = await Promise.allSettled(
+      Array.from({ length: 5 }, () => paidBetaRepository.consumeRateLimit(input))
+    );
+    assert.equal(attempts.filter((result) => result.status === "fulfilled").length, 3);
+    for (const rejected of attempts.filter((result) => result.status === "rejected")) {
+      assert.ok(rejected.reason instanceof PaidBetaRateLimitError);
+    }
+    const bucket = await pool.query(
+      "SELECT attempt_count FROM public.paid_beta_rate_limit_buckets WHERE client_hash = $1",
+      [input.client_hash]
+    );
+    assert.equal(bucket.rows[0].attempt_count, 3);
+  });
+
+  it("denies direct paid-beta table access and mutation for every Data API role", async () => {
+    for (const role of ["anon", "authenticated", "service_role"]) {
+      const client = await pool.connect();
+      try {
+        await client.query("BEGIN");
+        await client.query(`SET LOCAL ROLE ${role}`);
+        await assert.rejects(
+          client.query("SELECT * FROM public.paid_beta_interests"),
+          (error) => error.code === "42501"
+        );
+        await client.query("ROLLBACK");
+      } finally {
+        client.release();
+      }
+    }
+
+    const paidBetaRepository = new PostgresPaidBetaRepository({ pool });
+    const paidBetaService = new PaidBetaCaptureService({
+      repository: paidBetaRepository,
+      config: {
+        enabled: true,
+        submissionHashSecret: "s".repeat(32),
+        clientHashSecret: "c".repeat(32),
+        consentVersion: PAID_BETA_CONSENT_VERSION,
+        consentWording: PAID_BETA_CONSENT_WORDING,
+        rateLimitMaxAttempts: 5,
+        rateLimitWindowSeconds: 900,
+      },
+      now: () => new Date("2026-09-01T17:00:00.000Z"),
+    });
+    await paidBetaService.capture({
+      name: "Grace Hopper",
+      work_email: "grace@example.com",
+      business_name: "Compiler Co",
+      website_or_social_profile: "https://example.com/grace",
+      business_stage: "1m-5m",
+      primary_marketing_challenge: "Launch measurement",
+      privacy_contact_consent: true,
+      source: "homepage-paid-beta",
+      submission_id: "postgres_immutable_001",
+    });
+    await assert.rejects(
+      pool.query("UPDATE public.paid_beta_interest_receipts SET consent_version = 'changed'"),
+      (error) => error.code === "23514"
+    );
+    await assert.rejects(
+      pool.query("DELETE FROM public.paid_beta_interests"),
+      (error) => error.code === "23514"
+    );
   });
 
   it("persists tenant/project media authority and denies cross-boundary lookup", async () => {

--- a/test/stripe-billing.test.js
+++ b/test/stripe-billing.test.js
@@ -154,8 +154,8 @@ function setup({ policies, entitlements, config: configOverrides } = {}) {
     mode: "test",
     secretKey: "sk_test_offline_only",
     webhookSecret: WEBHOOK_SECRET,
-    successUrl: "https://app.bizgenie.test/billing/success",
-    cancelUrl: "https://app.bizgenie.test/billing/cancel",
+    successUrl: "https://app.bizgenie.test/billing/checkout/success",
+    cancelUrl: "https://app.bizgenie.test/billing/checkout/cancel",
     pastDueGraceDays: 7,
     plans: {
       standard: {
@@ -230,8 +230,8 @@ describe("Stripe server configuration", () => {
       STRIPE_MODE: "test",
       STRIPE_SECRET_KEY: "sk_test_configured",
       STRIPE_WEBHOOK_SECRET: "whsec_configured",
-      STRIPE_SUCCESS_URL: "http://localhost:3000/billing/success",
-      STRIPE_CANCEL_URL: "http://localhost:3000/billing/cancel",
+      STRIPE_SUCCESS_URL: "http://localhost:3000/billing/checkout/success",
+      STRIPE_CANCEL_URL: "http://localhost:3000/billing/checkout/cancel",
       STRIPE_PRICE_STANDARD: "price_StandardTest",
       STRIPE_POLICY_STANDARD: "policy_standard_v1",
     } });
@@ -252,6 +252,27 @@ describe("Stripe server configuration", () => {
       STRIPE_POLICY_STANDARD: "policy_standard_v1",
     } }));
   });
+
+  it("rejects unsafe, malformed, or non-contract Checkout return destinations", () => {
+    const base = {
+      STRIPE_MODE: "test",
+      STRIPE_SECRET_KEY: "sk_test_configured",
+      STRIPE_WEBHOOK_SECRET: "whsec_configured",
+      STRIPE_SUCCESS_URL: "https://app.bizgenie.test/billing/checkout/success",
+      STRIPE_CANCEL_URL: "https://app.bizgenie.test/billing/checkout/cancel",
+      STRIPE_PRICE_STANDARD: "price_StandardTest",
+      STRIPE_POLICY_STANDARD: "policy_standard_v1",
+    };
+    for (const override of [
+      { STRIPE_SUCCESS_URL: "https://api.bizgenie.test/" },
+      { STRIPE_SUCCESS_URL: "https://app.bizgenie.test/billing/checkout/success?trusted=true" },
+      { STRIPE_CANCEL_URL: "https://app.bizgenie.test/billing/checkout/cancel#fragment" },
+      { STRIPE_CANCEL_URL: "https://attacker.test/billing/checkout/cancel" },
+      { STRIPE_SUCCESS_URL: "javascript:alert(1)" },
+    ]) {
+      assert.throws(() => loadStripeBillingConfig({ env: { ...base, ...override } }));
+    }
+  });
 });
 
 describe("Stripe Checkout boundary", () => {
@@ -267,7 +288,7 @@ describe("Stripe Checkout boundary", () => {
       { price: "price_StandardTest", quantity: 1 },
     ]);
     assert.equal(calls.sessions[0][0].customer, "cus_tenant_a");
-    assert.equal(calls.sessions[0][0].success_url, "https://app.bizgenie.test/billing/success");
+    assert.equal(calls.sessions[0][0].success_url, "https://app.bizgenie.test/billing/checkout/success");
     assert.deepEqual(calls.sessions[0][0].subscription_data.billing_mode, { type: "flexible" });
     assert.match(calls.sessions[0][1].idempotencyKey, /^bizgenie:checkout:tenant_a:/);
   });


### PR DESCRIPTION
## Architecture decision

Adds one disabled-by-default, write-only public boundary: `POST /public/paid-beta-interest`.

The API owns the durable capture record. The standalone buyer-facing homepage remains a separate frontend artifact. Capture is isolated from Auth profiles, tenant membership, Billing, Stripe authority, entitlements, credits, generation jobs, providers, Sheets, Make, CRM, email, and analytics. There is no public read/list/update/delete endpoint.

## Migration and data model

Migration `20260901170000_create_paid_beta_interest_capture.sql` adds:

- `paid_beta_interests`: one canonical follow-up record per normalized email.
- `paid_beta_interest_receipts`: one immutable consent/audit receipt per client submission identity.
- `paid_beta_abuse_buckets`: short-lived, HMAC-pseudonymized request-rate buckets.

The migration applies database bounds, unique email/idempotency/receipt constraints, append-only triggers for interest and consent evidence, RLS with no customer policies, and explicit revocation from `PUBLIC`, `anon`, `authenticated`, and `service_role`. It adds only email/idempotency, operator-audit, and expiry-cleanup indexes.

## Endpoint contract

`POST /public/paid-beta-interest` accepts a strict JSON object containing:

- `name`
- `work_email`
- `business_name`
- `website_or_social_profile`
- `business_stage`
- `primary_marketing_challenge`
- `privacy_contact_consent: true`
- `source`
- `submission_id`

Unknown fields are rejected. Success and same-intent replay return HTTP 202:

```json
{"status":"received","reference_id":"pbi_<opaque-reference>"}
```

A duplicate email under a new submission identity returns the same status/shape with a distinct receipt reference and cannot overwrite the canonical record.

## Idempotency and abuse protection

The normalized intent is HMAC-fingerprinted using a server-only secret. The same submission identity and intent returns the same receipt; changed intent returns sanitized `IDEMPOTENCY_KEY_CONFLICT`.

Before JSON validation, every request consumes an atomic PostgreSQL bucket keyed by a distinct HMAC-pseudonymized socket identity. Defaults are 5 attempts per 15 minutes, shared across API instances and inclusive of malformed/invalid submissions. Raw IP addresses are not persisted. Approved edge/WAF protection remains required for public launch.

## Privacy limitations

The server owns consent version `paid-beta-contact-v1`, wording, receipt time, and audit time. Purpose is limited to paid-beta qualification and contact.

Before public activation, a human privacy/legal owner must approve the lawful basis, displayed notice, controller/contact details, consent wording/version, retention periods, and operator access. Export/deletion workflows remain a separately authorized task. Until then, interest and receipt evidence is append-only. This change sends no email, posts no CRM/Slack data, adds no analytics/tracking, creates no account/tenant, and grants no product/payment authority.

## Checkout return-route contract

Stripe configuration now requires:

- success: exact `/billing/checkout/success`
- cancel: exact `/billing/checkout/cancel`
- both on the same approved frontend origin
- no credentials, query, or fragment
- HTTPS in live mode; HTTPS or loopback HTTP in test mode

A browser redirect is never financial authority. After success, the frontend must authenticate and retrieve tenant-authorized subscription/entitlement state before showing access or credits. The repository does not yet expose that customer-safe read boundary, so it is a named next dependency. Webhooks and canonical Stripe Customer mapping remain state-changing authority.

## Verification

- Focused paid-beta/migration/Stripe/activation suite: **57/57 passed**.
- Full unit/contract suite: **398/398 passed**, 83 suites, no failures or skips.
- Syntax and whitespace checks: passed.
- The local environment has no `TEST_DATABASE_URL`, so the real-PostgreSQL suite correctly skipped locally.
- Disposable PostgreSQL 17 CI: **21/21 passed**, including concurrent dedupe, atomic rate limiting, RLS read denial, and append-only consent checks.
- The complete CI run passed both Node tests/syntax and Docker/Buildpack artifact smoke jobs. With PostgreSQL available, the full CI test invocation passed **419/419**.

## Deployment and configuration

No environment was configured or deployed. Capture remains off unless `PAID_BETA_CAPTURE_ENABLED=true`. Activation also requires:

- `PAID_BETA_SUBMISSION_HASH_SECRET`: server-only, at least 32 characters
- `PAID_BETA_CLIENT_HASH_SECRET`: distinct, server-only, at least 32 characters
- optional bounded rate-limit values
- existing database/environment and production activation checks
- the additive migration
- approved exact CORS/frontend origins

## Mutation statement

**Production: UNTOUCHED and UNAUTHORISED.**

**Staging: UNTOUCHED.**

No cloud deploy, database migration, environment-variable change, Stripe object/configuration change, personal-data submission, or external notification was performed.

## Rollback

Before any environment mutation, close or revert this change. After records exist, disable `PAID_BETA_CAPTURE_ENABLED`, preserve/export records under the approved privacy procedure, and use a reviewed forward migration. Do not drop consent evidence as an application rollback shortcut.

## Exact frontend integration follow-up

The next task must:

1. Wire the standalone homepage form to this exact POST contract and reuse one stable `submission_id` across transport retries.
2. Implement both exact Checkout return routes.
3. Add and approve a tenant-authorized customer subscription/entitlement read endpoint.
4. Complete privacy/legal, retention, operator-access, and edge-protection decisions.
5. Request separate staging configuration and synthetic smoke-test authority.

Production activation remains a separate decision.

Closes neither #51 nor any launch task automatically; this PR is intentionally unmerged, CI is green, and it awaits review.