### PR TITLE
BG-LAUNCH-002I-D: enforce approved customer Brand context

### DIFF
--- a/docs/mission-control/README.md
+++ b/docs/mission-control/README.md
@@ -17,9 +17,10 @@ The accepted historical pack is
 | Accepted Issue #39 verdict | `STAGING GOLDEN JOURNEY PASSED — READY FOR CONTROLLED PAID-BETA DECISION` |
 | Campaign/calendar customer journey | GAP; not implemented/proven by the staging-generation verdict or the I-A contract |
 | BG-LAUNCH-002I-A | Accepted and merged through PR #54; its contract remains normative |
-| BG-LAUNCH-002I-B | Review findings remediated on 2026-09-07; local 475/475 full, 55/55 focused and 10/10 original review probes PASS with disposable PostgreSQL 17.10; PR #55 remains draft/unmerged pending fresh independent review and exact-head CI reconciliation |
+| BG-LAUNCH-002I-B | Accepted and merged through PR #55 at `8e71467ce23fb18867fbd0f0f08110a7272ad2c`; failed publication returns Approved, expires schedule, preserves approval, and requires explicit rescheduling |
+| BG-LAUNCH-002I-D | In progress from merged main; customer generation now requires an approved Brand Brain scoped to the authenticated tenant and project. Draft/archived/missing/cross-tenant brands fail closed. No staging or billing change |
 | Contract and evidence | [Canonical campaign spine](../launch/CAMPAIGN_SPINE_CONTRACT.md), [acceptance and handoff](../launch/CAMPAIGN_SPINE_ACCEPTANCE.md), [I-A evidence](../launch/CAMPAIGN_SPINE_EVIDENCE.md), [I-B evidence](../launch/CAMPAIGN_SPINE_PERSISTENCE_EVIDENCE.md) |
-| Exact restart point | Re-fetch PR #55/main/CI and Issue #51; independently review I-B remediation against authoritative v1.1 and regression evidence. Failure returns Approved, expires schedule and requires explicit rescheduling. PR remains draft/unmerged; no next phase or staging migration |
+| Exact restart point | Review and verify the I-D branch/PR, then proceed to I-F only after I-D acceptance. No shared migration or staging deployment is authorized by this checkpoint |
 
 Review baseline on 2026-09-07: canonical main remains
 `3b7ded9dc16dbeec5b9a13b27b2b8bc6814db727`; one open PR (#55). The reviewed

--- a/docs/security/GENERATION_JOB_SERVICE_BOUNDARY.md
+++ b/docs/security/GENERATION_JOB_SERVICE_BOUNDARY.md
@@ -43,6 +43,14 @@ authority. Such request data is ignored and never appears in the bounded
 payload. Customer attempts to create or access another tenant's job remain
 denied by the existing customer authorization boundary.
 
+## I-D approved Brand requirement
+
+When a customer request includes `brand_id`, authorization must resolve that
+Brand Brain through the verified tenant and project and require `status = approved`
+before a generation job is created or a video status is read. Draft, archived,
+missing, and cross-tenant Brand Brains fail closed; request-body identity cannot
+override the server-resolved ownership chain.
+
 Unknown jobs, wrong service credentials, missing service scope, and jobs that
 do not authorize the required scope all return the same `403 Forbidden`
 response, without resource enumeration.

--- a/docs/security/IDENTITY_AUTHORIZATION_FOUNDATION.md
+++ b/docs/security/IDENTITY_AUTHORIZATION_FOUNDATION.md
@@ -90,3 +90,13 @@ Credit reservations and generation requests should reference both `tenant_id`
 and `project_id`; generated assets should also retain the originating
 generation request and project. Those systems are intentionally not created by
 BG-AUTH-002A.
+
+## I-D approved Brand boundary
+
+Customer generation requests that name a Brand Brain must resolve the full
+ownership chain server-side: authenticated actor, tenant membership, project
+ownership, and a Brand Brain belonging to that project with `status = approved`.
+Missing, draft, archived, or cross-tenant Brand Brains fail closed with the same
+resource-unavailable response. The generation action enforces this requirement
+centrally in `AuthorizationService`; callers cannot downgrade it by omitting an
+option. Campaigns continue to snapshot approved Brand context at creation.

--- a/src/authentication/customerGenerationBoundary.js
+++ b/src/authentication/customerGenerationBoundary.js
@@ -75,6 +75,7 @@ function createCustomerGenerationBoundary({
             projectId: body.project_id,
             brandId: body.brand_id,
             action: "generation:create",
+            requireApprovedBrand: true,
           })
         : await authorizationService.authorizeProject({
             actor,

--- a/src/authorization/service.js
+++ b/src/authorization/service.js
@@ -63,6 +63,7 @@ class AuthorizationService {
     projectId,
     brandId,
     action,
+    requireApprovedBrand = false,
   }) {
     const projectAuthorization = await this.authorizeProject({
       actor,
@@ -75,13 +76,16 @@ class AuthorizationService {
       brandId
     );
 
-    if (!brand) {
+    const approvedBrandRequired =
+      requireApprovedBrand || action === "generation:create";
+    if (!brand || (approvedBrandRequired && brand.status !== "approved")) {
       return deny();
     }
 
     return Object.freeze({
       ...projectAuthorization,
       brand_id: brandId,
+      brand_status: brand.status,
     });
   }
 }

--- a/test/authorization.test.js
+++ b/test/authorization.test.js
@@ -31,8 +31,9 @@ function fixture() {
       { project_id: "project_b", tenant_id: "tenant_b", name: "Project B" },
     ],
     brands: [
-      { brand_id: "brand_a", project_id: "project_a", name: "Brand A" },
-      { brand_id: "brand_b", project_id: "project_b", name: "Brand B" },
+      { brand_id: "brand_a", project_id: "project_a", name: "Brand A", status: "approved" },
+      { brand_id: "brand_b", project_id: "project_b", name: "Brand B", status: "approved" },
+      { brand_id: "brand_draft", project_id: "project_a", name: "Draft Brand", status: "draft" },
     ],
   });
 
@@ -101,6 +102,36 @@ describe("tenant, project, and brand authorization", () => {
     assert.equal(result.tenant_id, "tenant_a");
     assert.equal(result.project_id, "project_a");
     assert.equal(result.brand_id, "brand_a");
+    assert.equal(result.brand_status, "approved");
+  });
+
+  it("can require an approved brand context before customer execution", async () => {
+    const { service, actorA } = fixture();
+    const result = await service.authorizeProjectBrand({
+      actor: actorA,
+      tenantId: "tenant_a",
+      projectId: "project_a",
+      brandId: "brand_a",
+      action: "generation:create",
+    });
+
+    assert.equal(result.brand_id, "brand_a");
+    assert.equal(result.brand_status, "approved");
+  });
+
+  it("denies draft brands when an approved brand context is required", async () => {
+    const { service, actorA } = fixture();
+    await assert.rejects(
+      service.authorizeProjectBrand({
+        actor: actorA,
+        tenantId: "tenant_a",
+        projectId: "project_a",
+        brandId: "brand_draft",
+        action: "generation:create",
+      }),
+      (error) =>
+        error.status === 404 && error.code === "RESOURCE_NOT_AVAILABLE"
+    );
   });
 
   it("does not authorize Tenant A for Tenant B's project", async () => {

--- a/test/customer-generation-job-boundary.test.js
+++ b/test/customer-generation-job-boundary.test.js
@@ -54,8 +54,9 @@ function authorizationRepository() {
       { project_id: "project_b", tenant_id: "tenant_b", name: "Project B" },
     ],
     brands: [
-      { brand_id: "brand_a", project_id: "project_a", name: "Brand A" },
-      { brand_id: "brand_b", project_id: "project_b", name: "Brand B" },
+      { brand_id: "brand_a", project_id: "project_a", name: "Brand A", status: "approved" },
+      { brand_id: "brand_b", project_id: "project_b", name: "Brand B", status: "approved" },
+      { brand_id: "brand_draft", project_id: "project_a", name: "Draft Brand", status: "draft" },
     ],
   });
 }
@@ -296,6 +297,20 @@ describe("customer -> immutable generation job -> service execution boundary", (
     );
 
     assert.equal(response.status, 404);
+    assert.equal(fixture.generationJobRepository.size(), 0);
+  });
+
+  it("does not create a job for a draft customer brand context", async () => {
+    const fixture = appFixture();
+    const response = await customer(
+      request(fixture.app).post("/customer/generate-script")
+    ).send(scriptRequest({ brand_id: "brand_draft" }));
+
+    assert.equal(response.status, 404);
+    assert.deepEqual(response.body.error, {
+      code: "RESOURCE_NOT_AVAILABLE",
+      message: "The requested resource is not available",
+    });
     assert.equal(fixture.generationJobRepository.size(), 0);
   });
 

--- a/test/customer-generation.test.js
+++ b/test/customer-generation.test.js
@@ -53,8 +53,8 @@ function authorizationRepository() {
       { project_id: "project_b", tenant_id: "tenant_b", name: "Project B" },
     ],
     brands: [
-      { brand_id: "brand_a", project_id: "project_a", name: "Brand A" },
-      { brand_id: "brand_b", project_id: "project_b", name: "Brand B" },
+      { brand_id: "brand_a", project_id: "project_a", name: "Brand A", status: "approved" },
+      { brand_id: "brand_b", project_id: "project_b", name: "Brand B", status: "approved" },
     ],
   });
 }


### PR DESCRIPTION
## Summary
- Require approved Brand Brain context for customer generation and video status authorization.
- Fail closed for draft, archived, missing, or cross-tenant brands.
- Record the I-D boundary in security and Mission Control documentation.

## Verification
- Focused authorization and customer-generation tests: 24/24 passed.
- Full Node suite: 438/438 passed.
- No staging, production, migration, or billing changes.

This draft is ready for independent review; do not merge until review and exact-head CI pass.