### PR TITLE
BG-LAUNCH-002I-F: customer campaign APIs

### DIFF
--- a/docs/launch/CAMPAIGN_CUSTOMER_API_EVIDENCE.md
+++ b/docs/launch/CAMPAIGN_CUSTOMER_API_EVIDENCE.md
@@ -1,0 +1,40 @@
+# BG-LAUNCH-002I-F customer campaign API evidence
+
+**Status:** initial customer HTTP boundary implemented on branch
+`bg-launch-002i-f-customer-campaign-apis`.
+
+**Base:** merged `main` at `511933dd7b44faeb7770f1f2039721d46b6e800d`.
+
+## Implemented surface
+
+- `GET /customer/campaigns`
+- `POST /customer/campaigns`
+- `GET /customer/campaigns/:campaignId`
+- `PATCH /customer/campaigns/:campaignId`
+- `POST /customer/campaigns/:campaignId/content-items`
+- `POST /customer/campaigns/:campaignId/archive`
+- `POST /customer/campaigns/:campaignId/restore`
+
+The route layer uses customer Bearer-token authentication, existing tenant/project
+authorization, approved Brand Brain enforcement for campaign creation, the
+`campaign-spine.v1` command repository, idempotency keys and optimistic campaign
+versions. Customer responses expose campaign, item, variant, current content, stage
+counts and next action, while omitting events, raw Brand snapshots, command IDs,
+actor UUIDs, storage keys, provider details, prompts and internal finance data.
+
+## Verification
+
+- `node --test test/customer-campaigns.test.js`: 6/6 passed.
+- `npm test`: 444/444 passed.
+
+Disposable PostgreSQL integration did not run in this environment because no
+`TEST_DATABASE_URL` was configured; the full suite retained the existing skipped
+PostgreSQL integration tests. No staging, production, billing, connector, preview
+registry, publisher or deployment work was performed.
+
+## Out of scope
+
+I-F in this branch does not implement the I-C preview registry, real export/download
+transport, platform publishing, connector wiring, calendar UI, goal recommendation or
+field-sales onboarding. Those remain separate gates in the accepted dependency order:
+I-B -> I-D -> I-F -> I-C -> I-E -> launch surfaces -> field-sales pilot.

--- a/docs/mission-control/README.md
+++ b/docs/mission-control/README.md
@@ -18,9 +18,10 @@ The accepted historical pack is
 | Campaign/calendar customer journey | GAP; not implemented/proven by the staging-generation verdict or the I-A contract |
 | BG-LAUNCH-002I-A | Accepted and merged through PR #54; its contract remains normative |
 | BG-LAUNCH-002I-B | Accepted and merged through PR #55 at `8e71467ce23fb18867fbd0f0f08110a7272ad2c`; failed publication returns Approved, expires schedule, preserves approval, and requires explicit rescheduling |
-| BG-LAUNCH-002I-D | In progress from merged main; customer generation now requires an approved Brand Brain scoped to the authenticated tenant and project. Draft/archived/missing/cross-tenant brands fail closed. No staging or billing change |
-| Contract and evidence | [Canonical campaign spine](../launch/CAMPAIGN_SPINE_CONTRACT.md), [acceptance and handoff](../launch/CAMPAIGN_SPINE_ACCEPTANCE.md), [I-A evidence](../launch/CAMPAIGN_SPINE_EVIDENCE.md), [I-B evidence](../launch/CAMPAIGN_SPINE_PERSISTENCE_EVIDENCE.md) |
-| Exact restart point | Review and verify the I-D branch/PR, then proceed to I-F only after I-D acceptance. No shared migration or staging deployment is authorized by this checkpoint |
+| BG-LAUNCH-002I-D | Accepted and merged through PR #57 at `511933dd7b44faeb7770f1f2039721d46b6e800d`; customer generation requires an approved Brand Brain scoped to the authenticated tenant and project. Draft/archived/missing/cross-tenant brands fail closed. No staging or billing change |
+| BG-LAUNCH-002I-F | In progress on branch `bg-launch-002i-f-customer-campaign-apis`; customer campaign create/list/read/detail-update/item-create/archive/restore API surface is being added without preview registry, publishing, billing or deployment scope |
+| Contract and evidence | [Canonical campaign spine](../launch/CAMPAIGN_SPINE_CONTRACT.md), [acceptance and handoff](../launch/CAMPAIGN_SPINE_ACCEPTANCE.md), [I-A evidence](../launch/CAMPAIGN_SPINE_EVIDENCE.md), [I-B evidence](../launch/CAMPAIGN_SPINE_PERSISTENCE_EVIDENCE.md), [I-F evidence](../launch/CAMPAIGN_CUSTOMER_API_EVIDENCE.md) |
+| Exact restart point | Continue BG-LAUNCH-002I-F from merged main `511933dd7b44faeb7770f1f2039721d46b6e800d`. Verify customer campaign API coverage and exact-head CI before any review/merge decision. No shared migration or staging deployment is authorized by this checkpoint |
 
 Review baseline on 2026-09-07: canonical main remains
 `3b7ded9dc16dbeec5b9a13b27b2b8bc6814db727`; one open PR (#55). The reviewed

--- a/index.js
+++ b/index.js
@@ -74,6 +74,11 @@ const {
   createServiceExecutionRouter,
 } = require("./src/service-execution");
 const {
+  InMemoryCampaignRepository,
+  PostgresCampaignRepository,
+  createCustomerCampaignRouter,
+} = require("./src/campaigns");
+const {
   createPaidBetaProductionComposition,
   createPaidBetaRouter,
 } = require("./src/paid-beta");
@@ -239,6 +244,7 @@ function createApp({
   videoProvider = new UnconfiguredVideoGenerationProvider(),
   videoAssetStore = new UnconfiguredVideoAssetStore(),
   videoReferenceAssetLoader = new UnconfiguredVideoReferenceAssetLoader(),
+  campaignRepository = new InMemoryCampaignRepository(),
   branding = brandingConfig,
   scriptGenerator = generateScriptWithVertex,
   authorizationRepository = new InMemoryAuthorizationRepository(),
@@ -439,6 +445,16 @@ function createApp({
     customerVideoRouter
   );
 
+  app.use(
+    "/customer/campaigns",
+    createCustomerCampaignRouter({
+      repository: campaignRepository,
+      tokenVerifier: customerTokenVerifier,
+      authorizationService: resolvedAuthorizationService,
+      logger,
+    })
+  );
+
   // Future bounded server-to-server execution seam. Customer generation is
   // currently executed in-process only after the mandatory job recorder
   // above succeeds; this route does not dispatch to Make or a provider.
@@ -460,7 +476,8 @@ function createApp({
         req.path.startsWith("/generate-video") ||
         req.path.startsWith("/customer/generate-image") ||
         req.path.startsWith("/customer/generate-video") ||
-        req.path.startsWith("/customer/generate-script")) &&
+        req.path.startsWith("/customer/generate-script") ||
+        req.path.startsWith("/customer/campaigns")) &&
       error instanceof SyntaxError &&
       error.status === 400 &&
       Object.hasOwn(error, "body")
@@ -512,6 +529,15 @@ function createApp({
         });
       }
 
+      if (req.path.startsWith("/customer/campaigns")) {
+        return res.status(400).json({
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Malformed JSON request body",
+          },
+        });
+      }
+
       return res.status(400).json({
         error: {
           code: "VALIDATION_ERROR",
@@ -553,6 +579,10 @@ async function createProductionApp({ env = process.env, logger = console } = {})
     pool: brandBrainRepository.pool,
   });
   await videoGenerationRepository.initialize();
+  const campaignRepository = new PostgresCampaignRepository({
+    pool: brandBrainRepository.pool,
+  });
+  await campaignRepository.initialize();
   const billing = await createPostgresBillingProductionComposition({
     pool: brandBrainRepository.pool,
     env,
@@ -583,6 +613,7 @@ async function createProductionApp({ env = process.env, logger = console } = {})
       generationBillingOrchestrator: billing.generationBillingOrchestrator,
       imageProvider: media.imageProvider,
       videoGenerationRepository,
+      campaignRepository,
       servicePrincipalVerifier,
       stripeSubscriptionService: stripe.stripeSubscriptionService,
       paidBetaCaptureService: paidBeta.service,
@@ -597,6 +628,7 @@ async function createProductionApp({ env = process.env, logger = console } = {})
     customerTokenVerifier,
     generationJobRepository,
     videoGenerationRepository,
+    campaignRepository,
     billingRepository: billing.billingRepository,
     billingService: billing.billingService,
     generationBillingOrchestrator: billing.generationBillingOrchestrator,

--- a/src/campaigns/index.js
+++ b/src/campaigns/index.js
@@ -2,5 +2,6 @@ const errors = require("./errors");
 const schema = require("./schema");
 const repository = require("./repository");
 const postgres = require("./postgresRepository");
+const router = require("./router");
 
-module.exports = { ...errors, ...schema, ...repository, ...postgres };
+module.exports = { ...errors, ...schema, ...repository, ...postgres, ...router };

--- a/src/campaigns/router.js
+++ b/src/campaigns/router.js
@@ -1,0 +1,333 @@
+const express = require("express");
+const { z } = require("zod");
+const {
+  AuthenticationRequiredError,
+  AuthorizationDeniedError,
+} = require("../authorization");
+const {
+  CampaignError,
+  CampaignPersistenceError,
+  CampaignResourceError,
+  CampaignValidationError,
+  CampaignVersionError,
+} = require("./errors");
+const { identifier, uuid } = require("./schema");
+
+const AUTHENTICATION_ERROR = Object.freeze({
+  code: "AUTHENTICATION_REQUIRED",
+  message: "Customer authentication is required",
+});
+const AUTHORIZATION_ERROR = Object.freeze({
+  code: "RESOURCE_NOT_AVAILABLE",
+  message: "The requested resource is not available",
+});
+const AUTHORIZATION_UNAVAILABLE_ERROR = Object.freeze({
+  code: "AUTHORIZATION_UNAVAILABLE",
+  message: "Customer authorization is temporarily unavailable",
+});
+
+const idempotencyKey = identifier;
+const expectedVersion = z.number().int().min(0).max(2147483647);
+const queryScope = z.object({ tenant_id: identifier, project_id: identifier }).strict();
+const bodyScope = queryScope.extend({ idempotency_key: idempotencyKey }).strict();
+
+const createCampaignBody = bodyScope.extend({
+  brand_id: identifier,
+  name: z.string(),
+  goal: z.string(),
+  display_timezone: z.string(),
+}).strict();
+const updateCampaignBody = bodyScope.extend({
+  expected_campaign_version: expectedVersion,
+  name: z.string(),
+  display_timezone: z.string(),
+}).strict();
+const itemBody = bodyScope.extend({
+  expected_campaign_version: expectedVersion,
+  name: z.string(),
+  format: z.enum(["text", "image", "video"]),
+  platform: z.enum(["linkedin", "instagram", "facebook", "tiktok", "youtube", "email", "other"]),
+  placement: identifier,
+  destination_label: z.string(),
+  destination_key: uuid.optional(),
+  initial_content: z.unknown().optional(),
+}).strict();
+const archiveBody = bodyScope.extend({
+  expected_campaign_version: expectedVersion,
+  reason: z.string(),
+}).strict();
+
+function extractBearerToken(authorizationHeader) {
+  if (typeof authorizationHeader !== "string") throw new AuthenticationRequiredError();
+  const match = authorizationHeader.match(/^Bearer ([^\s,]+)$/i);
+  if (!match) throw new AuthenticationRequiredError();
+  return match[1];
+}
+
+function parse(schema, value) {
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) throw new CampaignValidationError();
+  return parsed.data;
+}
+
+function contextFromAuthorization(authorization) {
+  return {
+    actor: authorization.actor,
+    tenant_id: authorization.tenant_id,
+    project_id: authorization.project_id,
+    membership_role: authorization.membership_role,
+    policy_version: "campaign-owner.v1",
+  };
+}
+
+async function authorize({ req, tokenVerifier, authorizationService, tenantId, projectId, brandId, action }) {
+  const actor = await tokenVerifier.verifyAccessToken(extractBearerToken(req.header("authorization")));
+  const authorization = brandId
+    ? await authorizationService.authorizeProjectBrand({
+        actor,
+        tenantId,
+        projectId,
+        brandId,
+        action,
+        requireApprovedBrand: true,
+      })
+    : await authorizationService.authorizeProject({ actor, tenantId, projectId, action });
+  return contextFromAuthorization(authorization);
+}
+
+function command({ body, campaignId, commandType, expectedVersion, payload }) {
+  return {
+    contract_version: "campaign-spine.v1",
+    idempotency_key: body.idempotency_key,
+    expected_campaign_version: expectedVersion,
+    command_type: commandType,
+    tenant_id: body.tenant_id,
+    project_id: body.project_id,
+    ...(campaignId ? { campaign_id: campaignId } : {}),
+    payload,
+  };
+}
+
+function stageAction(campaign) {
+  for (const item of campaign.items.values()) {
+    if (item.archived_at) continue;
+    for (const variant of item.variants.values()) {
+      if (variant.pending_attempt_id) return { code: "resolve_publication_attempt", label: "Resolve publication attempt" };
+      if (variant.workflow === "draft") return { code: "finish_draft", label: "Finish draft" };
+      if (variant.workflow === "review") return { code: "review_preview", label: "Review preview" };
+      if (variant.workflow === "approved") return { code: "schedule_or_publish", label: "Schedule or publish manually" };
+      if (variant.workflow === "scheduled") return { code: "manual_action_required", label: "Manual action required" };
+    }
+  }
+  return { code: "create_content_item", label: "Create content item" };
+}
+
+function safeVariant(variant, item) {
+  const current = variant.revisions.get(variant.current_revision_id);
+  return {
+    variant_id: variant.variant_id,
+    content_item_id: item.content_item_id,
+    platform: variant.platform,
+    placement: variant.placement,
+    destination_label: variant.destination_label,
+    workflow: variant.workflow,
+    current_revision_id: variant.current_revision_id,
+    current_content: current?.content || null,
+    active_approval_id: variant.active_approval_id,
+    active_schedule_id: variant.active_schedule_id,
+    pending_attempt_id: variant.pending_attempt_id,
+    publication_id: variant.publication_id,
+    updated_at: variant.updated_at,
+  };
+}
+
+function safeCampaign(campaign, { detail = false } = {}) {
+  const base = {
+    campaign_id: campaign.campaign_id,
+    tenant_id: campaign.tenant_id,
+    project_id: campaign.project_id,
+    brand_id: campaign.brand_id,
+    name: campaign.name,
+    goal: campaign.goal,
+    display_timezone: campaign.display_timezone,
+    version: campaign.version,
+    status: campaign.status,
+    counts: campaign.counts,
+    archived_at: campaign.archived_at,
+    created_at: campaign.created_at,
+    updated_at: campaign.updated_at,
+    next_action: stageAction(campaign),
+  };
+  if (!detail) return base;
+  return {
+    ...base,
+    items: [...campaign.items.values()].map((item) => ({
+      content_item_id: item.content_item_id,
+      name: item.name,
+      format: item.format,
+      status: item.status,
+      counts: item.counts,
+      archived_at: item.archived_at,
+      created_at: item.created_at,
+      updated_at: item.updated_at,
+      variants: [...item.variants.values()].map((variant) => safeVariant(variant, item)),
+    })),
+  };
+}
+
+function safeResult(result) {
+  return {
+    campaign_id: result.campaign_id,
+    campaign_version: result.campaign_version,
+    created_ids: result.created_ids,
+  };
+}
+
+function sendCampaignError(error, res, logger) {
+  if (error instanceof AuthenticationRequiredError) {
+    return res.status(401).json({ error: AUTHENTICATION_ERROR });
+  }
+  if (error instanceof AuthorizationDeniedError || error instanceof CampaignResourceError) {
+    return res.status(404).json({ error: AUTHORIZATION_ERROR });
+  }
+  if (error instanceof CampaignValidationError) {
+    return res.status(400).json({ error: { code: error.code, message: error.message } });
+  }
+  if (error instanceof CampaignVersionError) {
+    return res.status(409).json({ error: { code: error.code, message: error.message } });
+  }
+  if (error instanceof CampaignPersistenceError) {
+    return res.status(503).json({ error: { code: error.code, message: error.message } });
+  }
+  if (error instanceof CampaignError) {
+    return res.status(409).json({ error: { code: error.code, message: error.message } });
+  }
+  logger.error?.("customer campaign route failed", { name: error?.name || "Error", code: error?.code || null });
+  return res.status(503).json({ error: AUTHORIZATION_UNAVAILABLE_ERROR });
+}
+
+function createCustomerCampaignRouter({
+  repository,
+  tokenVerifier,
+  authorizationService,
+  logger = console,
+}) {
+  if (!repository || !tokenVerifier || !authorizationService) {
+    throw new TypeError("Customer campaigns require repository, token verifier and authorization service");
+  }
+  const router = express.Router();
+
+  router.get("/", async (req, res) => {
+    try {
+      const scope = parse(queryScope, req.query);
+      const context = await authorize({ req, tokenVerifier, authorizationService, tenantId: scope.tenant_id, projectId: scope.project_id, action: "project:read" });
+      const campaigns = await repository.listCampaigns(context);
+      return res.json({ campaigns: campaigns.map((campaign) => safeCampaign(campaign)) });
+    } catch (error) {
+      return sendCampaignError(error, res, logger);
+    }
+  });
+
+  router.post("/", async (req, res) => {
+    try {
+      const body = parse(createCampaignBody, req.body);
+      const context = await authorize({ req, tokenVerifier, authorizationService, tenantId: body.tenant_id, projectId: body.project_id, brandId: body.brand_id, action: "project:write" });
+      const result = await repository.executeCommand(context, command({
+        body,
+        commandType: "create_campaign",
+        expectedVersion: 0,
+        payload: {
+          brand_id: body.brand_id,
+          name: body.name,
+          goal: body.goal,
+          display_timezone: body.display_timezone,
+        },
+      }));
+      return res.status(201).json({ result: safeResult(result), campaign: safeCampaign(await repository.getCampaign(context, result.campaign_id), { detail: true }) });
+    } catch (error) {
+      return sendCampaignError(error, res, logger);
+    }
+  });
+
+  router.get("/:campaignId", async (req, res) => {
+    try {
+      const scope = parse(queryScope, req.query);
+      const campaignId = parse(uuid, req.params.campaignId);
+      const context = await authorize({ req, tokenVerifier, authorizationService, tenantId: scope.tenant_id, projectId: scope.project_id, action: "project:read" });
+      return res.json({ campaign: safeCampaign(await repository.getCampaign(context, campaignId), { detail: true }) });
+    } catch (error) {
+      return sendCampaignError(error, res, logger);
+    }
+  });
+
+  router.patch("/:campaignId", async (req, res) => {
+    try {
+      const body = parse(updateCampaignBody, req.body);
+      const campaignId = parse(uuid, req.params.campaignId);
+      const context = await authorize({ req, tokenVerifier, authorizationService, tenantId: body.tenant_id, projectId: body.project_id, action: "project:write" });
+      const result = await repository.executeCommand(context, command({
+        body,
+        campaignId,
+        commandType: "update_campaign_details",
+        expectedVersion: body.expected_campaign_version,
+        payload: { name: body.name, display_timezone: body.display_timezone },
+      }));
+      return res.json({ result: safeResult(result), campaign: safeCampaign(await repository.getCampaign(context, campaignId), { detail: true }) });
+    } catch (error) {
+      return sendCampaignError(error, res, logger);
+    }
+  });
+
+  router.post("/:campaignId/content-items", async (req, res) => {
+    try {
+      const body = parse(itemBody, req.body);
+      const campaignId = parse(uuid, req.params.campaignId);
+      const context = await authorize({ req, tokenVerifier, authorizationService, tenantId: body.tenant_id, projectId: body.project_id, action: "project:write" });
+      const result = await repository.executeCommand(context, command({
+        body,
+        campaignId,
+        commandType: "create_content_item",
+        expectedVersion: body.expected_campaign_version,
+        payload: {
+          name: body.name,
+          format: body.format,
+          platform: body.platform,
+          placement: body.placement,
+          destination_label: body.destination_label,
+          ...(body.destination_key ? { destination_key: body.destination_key } : {}),
+          ...(body.initial_content ? { initial_content: body.initial_content } : {}),
+        },
+      }));
+      return res.status(201).json({ result: safeResult(result), campaign: safeCampaign(await repository.getCampaign(context, campaignId), { detail: true }) });
+    } catch (error) {
+      return sendCampaignError(error, res, logger);
+    }
+  });
+
+  for (const [path, commandType] of [["archive", "archive_campaign"], ["restore", "restore_campaign"]]) {
+    router.post(`/:campaignId/${path}`, async (req, res) => {
+      try {
+        const body = parse(archiveBody, req.body);
+        const campaignId = parse(uuid, req.params.campaignId);
+        const context = await authorize({ req, tokenVerifier, authorizationService, tenantId: body.tenant_id, projectId: body.project_id, action: "project:write" });
+        const result = await repository.executeCommand(context, command({
+          body,
+          campaignId,
+          commandType,
+          expectedVersion: body.expected_campaign_version,
+          payload: { reason: body.reason },
+        }));
+        return res.json({ result: safeResult(result), campaign: safeCampaign(await repository.getCampaign(context, campaignId), { detail: true }) });
+      } catch (error) {
+        return sendCampaignError(error, res, logger);
+      }
+    });
+  }
+
+  return router;
+}
+
+module.exports = {
+  createCustomerCampaignRouter,
+  safeCampaign,
+};

--- a/src/campaigns/router.js
+++ b/src/campaigns/router.js
@@ -133,10 +133,6 @@ function safeVariant(variant, item) {
     workflow: variant.workflow,
     current_revision_id: variant.current_revision_id,
     current_content: current?.content || null,
-    active_approval_id: variant.active_approval_id,
-    active_schedule_id: variant.active_schedule_id,
-    pending_attempt_id: variant.pending_attempt_id,
-    publication_id: variant.publication_id,
     updated_at: variant.updated_at,
   };
 }

--- a/test/customer-campaigns.test.js
+++ b/test/customer-campaigns.test.js
@@ -1,0 +1,292 @@
+const assert = require("node:assert/strict");
+const { beforeEach, describe, it } = require("node:test");
+const request = require("supertest");
+
+const { createApp } = require("../index");
+const {
+  AuthenticationRequiredError,
+  InMemoryAuthorizationRepository,
+  createCustomerActorFromVerifiedIdentity,
+} = require("../src/authorization");
+const { InMemoryCampaignRepository } = require("../src/campaigns");
+
+const ADMIN_KEY = "customer-campaign-admin-key";
+const USER_A = "11111111-1111-4111-8111-111111111111";
+const USER_B = "22222222-2222-4222-8222-222222222222";
+const IDS = Array.from(
+  { length: 120 },
+  (_, index) => `${String(index + 1).padStart(8, "0")}-0000-4000-8000-000000000000`
+);
+
+class FixtureTokenVerifier {
+  async verifyAccessToken(token) {
+    if (token === "token-a") {
+      return createCustomerActorFromVerifiedIdentity({ verifiedAuthUserId: USER_A });
+    }
+    if (token === "token-b") {
+      return createCustomerActorFromVerifiedIdentity({ verifiedAuthUserId: USER_B });
+    }
+    throw new AuthenticationRequiredError();
+  }
+}
+
+function authorizationRepository() {
+  return new InMemoryAuthorizationRepository({
+    customerProfiles: [
+      { auth_user_id: USER_A, display_name: "Customer A" },
+      { auth_user_id: USER_B, display_name: "Customer B" },
+    ],
+    tenants: [
+      { tenant_id: "tenant_a", name: "Tenant A", created_by: USER_A },
+      { tenant_id: "tenant_b", name: "Tenant B", created_by: USER_B },
+    ],
+    memberships: [
+      { tenant_id: "tenant_a", auth_user_id: USER_A, role: "owner" },
+      { tenant_id: "tenant_b", auth_user_id: USER_B, role: "owner" },
+    ],
+    projects: [
+      { project_id: "project_a", tenant_id: "tenant_a", name: "Project A" },
+      { project_id: "project_b", tenant_id: "tenant_b", name: "Project B" },
+    ],
+    brands: [
+      { brand_id: "brand_a", project_id: "project_a", name: "Brand A", status: "approved" },
+      { brand_id: "brand_draft", project_id: "project_a", name: "Draft Brand", status: "draft" },
+      { brand_id: "brand_b", project_id: "project_b", name: "Brand B", status: "approved" },
+    ],
+  });
+}
+
+function campaignRepository() {
+  let id = 0;
+  return new InMemoryCampaignRepository({
+    now: () => new Date("2026-09-08T12:00:00.000Z"),
+    idFactory: () => IDS[id++],
+    authorize: async () => true,
+    captureBrandSnapshot: async (context, brandId) => {
+      if (
+        context.tenant_id !== "tenant_a" ||
+        context.project_id !== "project_a" ||
+        brandId !== "brand_a"
+      ) {
+        return null;
+      }
+      return {
+        brand_snapshot_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        tenant_id: "tenant_a",
+        project_id: "project_a",
+        brand_id: "brand_a",
+        source_version: 1,
+        source_updated_at: "2026-09-08T10:00:00.000Z",
+        source_schema_version: "brand-brain.v1",
+        snapshot: { name: "Brand A", private_positioning: "do-not-expose" },
+        snapshot_hash: "a".repeat(64),
+        captured_at: "2026-09-08T12:00:00.000Z",
+      };
+    },
+  });
+}
+
+function fixture() {
+  const app = createApp({
+    authorizationRepository: authorizationRepository(),
+    campaignRepository: campaignRepository(),
+    customerTokenVerifier: new FixtureTokenVerifier(),
+    logger: { info() {}, warn() {}, error() {} },
+  });
+  return request(app);
+}
+
+function customer(client, token = "token-a") {
+  return client.set("authorization", `Bearer ${token}`);
+}
+
+function createBody(overrides = {}) {
+  return {
+    tenant_id: "tenant_a",
+    project_id: "project_a",
+    brand_id: "brand_a",
+    idempotency_key: "create_campaign_1",
+    name: "September launch",
+    goal: "Launch the campaign clearly",
+    display_timezone: "Europe/London",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  process.env.ADMIN_KEY = ADMIN_KEY;
+});
+
+describe("customer campaign API", () => {
+  it("creates, lists, reads and resumes a campaign through customer-safe DTOs", async () => {
+    const client = fixture();
+    const created = await customer(client.post("/customer/campaigns")).send(createBody());
+
+    assert.equal(created.status, 201);
+    assert.equal(created.body.campaign.name, "September launch");
+    assert.equal(created.body.campaign.status, "draft");
+    assert.deepEqual(created.body.campaign.next_action, {
+      code: "create_content_item",
+      label: "Create content item",
+    });
+    assert.equal(created.body.campaign.items.length, 0);
+    assert.doesNotMatch(JSON.stringify(created.body), /brand_snapshots|events|command_id|auth_user_id|private_positioning/);
+
+    const listed = await customer(
+      client.get("/customer/campaigns").query({ tenant_id: "tenant_a", project_id: "project_a" })
+    );
+    assert.equal(listed.status, 200);
+    assert.equal(listed.body.campaigns.length, 1);
+    assert.equal(listed.body.campaigns[0].campaign_id, created.body.campaign.campaign_id);
+
+    const read = await customer(
+      client.get(`/customer/campaigns/${created.body.campaign.campaign_id}`).query({
+        tenant_id: "tenant_a",
+        project_id: "project_a",
+      })
+    );
+    assert.equal(read.status, 200);
+    assert.deepEqual(read.body.campaign, created.body.campaign);
+  });
+
+  it("adds a content item and derives campaign progress without storing a writable stage", async () => {
+    const client = fixture();
+    const created = await customer(client.post("/customer/campaigns")).send(createBody());
+    const item = await customer(
+      client.post(`/customer/campaigns/${created.body.campaign.campaign_id}/content-items`)
+    ).send({
+      tenant_id: "tenant_a",
+      project_id: "project_a",
+      idempotency_key: "item_1",
+      expected_campaign_version: 1,
+      name: "Instagram post",
+      format: "text",
+      platform: "instagram",
+      placement: "feed",
+      destination_label: "Instagram",
+      initial_content: {
+        title: null,
+        body: "A simple launch update.",
+        caption: null,
+        alt_text: null,
+        asset_refs: [],
+      },
+    });
+
+    assert.equal(item.status, 201);
+    assert.equal(item.body.campaign.version, 2);
+    assert.equal(item.body.campaign.status, "draft");
+    assert.equal(item.body.campaign.items[0].variants[0].workflow, "draft");
+    assert.equal(item.body.campaign.items[0].variants[0].current_content.body, "A simple launch update.");
+    assert.equal(item.body.campaign.items[0].variants[0].destination_label, "Instagram");
+    assert.equal(item.body.campaign.items[0].variants[0].destination_key, undefined);
+  });
+
+  it("updates only customer-editable campaign details with idempotency and version protection", async () => {
+    const client = fixture();
+    const created = await customer(client.post("/customer/campaigns")).send(createBody());
+    const update = {
+      tenant_id: "tenant_a",
+      project_id: "project_a",
+      idempotency_key: "update_1",
+      expected_campaign_version: 1,
+      name: "Updated launch",
+      display_timezone: "UTC",
+    };
+
+    const first = await customer(
+      client.patch(`/customer/campaigns/${created.body.campaign.campaign_id}`)
+    ).send(update);
+    const replay = await customer(
+      client.patch(`/customer/campaigns/${created.body.campaign.campaign_id}`)
+    ).send(update);
+    const stale = await customer(
+      client.patch(`/customer/campaigns/${created.body.campaign.campaign_id}`)
+    ).send({ ...update, idempotency_key: "update_2" });
+
+    assert.equal(first.status, 200);
+    assert.equal(replay.status, 200);
+    assert.deepEqual(replay.body.result, first.body.result);
+    assert.equal(first.body.campaign.name, "Updated launch");
+    assert.equal(stale.status, 409);
+    assert.equal(stale.body.error.code, "VERSION_CONFLICT");
+  });
+
+  it("fails closed for missing auth, body identity spoofing, draft brands and cross-tenant reads", async () => {
+    const client = fixture();
+    const missing = await client.post("/customer/campaigns").send(createBody());
+    assert.equal(missing.status, 401);
+
+    const spoof = await customer(client.post("/customer/campaigns")).send({
+      ...createBody(),
+      user_id: USER_B,
+    });
+    assert.equal(spoof.status, 400);
+
+    const draftBrand = await customer(client.post("/customer/campaigns")).send({
+      ...createBody({ brand_id: "brand_draft", idempotency_key: "draft_brand" }),
+    });
+    assert.equal(draftBrand.status, 404);
+
+    const created = await customer(client.post("/customer/campaigns")).send(createBody());
+    const foreignRead = await customer(
+      client.get(`/customer/campaigns/${created.body.campaign.campaign_id}`).query({
+        tenant_id: "tenant_b",
+        project_id: "project_b",
+      }),
+      "token-b"
+    );
+    assert.equal(foreignRead.status, 404);
+  });
+
+  it("archives and restores without exposing an alternative lifecycle state", async () => {
+    const client = fixture();
+    const created = await customer(client.post("/customer/campaigns")).send(createBody());
+    const archive = await customer(
+      client.post(`/customer/campaigns/${created.body.campaign.campaign_id}/archive`)
+    ).send({
+      tenant_id: "tenant_a",
+      project_id: "project_a",
+      idempotency_key: "archive_1",
+      expected_campaign_version: 1,
+      reason: "No longer needed",
+    });
+    const listed = await customer(
+      client.get("/customer/campaigns").query({ tenant_id: "tenant_a", project_id: "project_a" })
+    );
+    const restore = await customer(
+      client.post(`/customer/campaigns/${created.body.campaign.campaign_id}/restore`)
+    ).send({
+      tenant_id: "tenant_a",
+      project_id: "project_a",
+      idempotency_key: "restore_1",
+      expected_campaign_version: 2,
+      reason: "Needed again",
+    });
+
+    assert.equal(archive.status, 200);
+    assert.equal(archive.body.campaign.status, "draft");
+    assert.ok(archive.body.campaign.archived_at);
+    assert.equal(listed.body.campaigns.length, 0);
+    assert.equal(restore.status, 200);
+    assert.equal(restore.body.campaign.archived_at, null);
+    assert.equal(restore.body.campaign.status, "draft");
+  });
+
+  it("returns a bounded malformed-json error", async () => {
+    const response = await customer(
+      fixture()
+        .post("/customer/campaigns")
+        .set("content-type", "application/json")
+        .send('{"tenant_id":')
+    );
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(response.body, {
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Malformed JSON request body",
+      },
+    });
+  });
+});

--- a/test/customer-campaigns.test.js
+++ b/test/customer-campaigns.test.js
@@ -13,6 +13,17 @@ const { InMemoryCampaignRepository } = require("../src/campaigns");
 const ADMIN_KEY = "customer-campaign-admin-key";
 const USER_A = "11111111-1111-4111-8111-111111111111";
 const USER_B = "22222222-2222-4222-8222-222222222222";
+const FORBIDDEN_CUSTOMER_DTO_FIELDS = [
+  "active_approval_id",
+  "active_schedule_id",
+  "pending_attempt_id",
+  "publication_id",
+  "brand_snapshots",
+  "events",
+  "command_id",
+  "auth_user_id",
+  "private_positioning",
+];
 const IDS = Array.from(
   { length: 120 },
   (_, index) => `${String(index + 1).padStart(8, "0")}-0000-4000-8000-000000000000`
@@ -130,7 +141,9 @@ describe("customer campaign API", () => {
       label: "Create content item",
     });
     assert.equal(created.body.campaign.items.length, 0);
-    assert.doesNotMatch(JSON.stringify(created.body), /brand_snapshots|events|command_id|auth_user_id|private_positioning/);
+    for (const field of FORBIDDEN_CUSTOMER_DTO_FIELDS) {
+      assert.doesNotMatch(JSON.stringify(created.body), new RegExp(field));
+    }
 
     const listed = await customer(
       client.get("/customer/campaigns").query({ tenant_id: "tenant_a", project_id: "project_a" })
@@ -180,6 +193,10 @@ describe("customer campaign API", () => {
     assert.equal(item.body.campaign.items[0].variants[0].current_content.body, "A simple launch update.");
     assert.equal(item.body.campaign.items[0].variants[0].destination_label, "Instagram");
     assert.equal(item.body.campaign.items[0].variants[0].destination_key, undefined);
+    for (const field of FORBIDDEN_CUSTOMER_DTO_FIELDS) {
+      assert.equal(item.body.campaign.items[0].variants[0][field], undefined);
+      assert.doesNotMatch(JSON.stringify(item.body), new RegExp(field));
+    }
   });
 
   it("updates only customer-editable campaign details with idempotency and version protection", async () => {
@@ -212,7 +229,7 @@ describe("customer campaign API", () => {
     assert.equal(stale.body.error.code, "VERSION_CONFLICT");
   });
 
-  it("fails closed for missing auth, body identity spoofing, draft brands and cross-tenant reads", async () => {
+  it("fails closed for missing auth, body identity spoofing, draft brands and cross-tenant access", async () => {
     const client = fixture();
     const missing = await client.post("/customer/campaigns").send(createBody());
     assert.equal(missing.status, 401);
@@ -236,7 +253,36 @@ describe("customer campaign API", () => {
       }),
       "token-b"
     );
+    const foreignList = await customer(
+      client.get("/customer/campaigns").query({
+        tenant_id: "tenant_b",
+        project_id: "project_b",
+      })
+    );
+    const foreignParam = await customer(
+      client.post(`/customer/campaigns/${created.body.campaign.campaign_id}/content-items`),
+      "token-b"
+    ).send({
+      tenant_id: "tenant_b",
+      project_id: "project_b",
+      idempotency_key: "foreign_item",
+      expected_campaign_version: 1,
+      name: "Foreign item",
+      format: "text",
+      platform: "instagram",
+      placement: "feed",
+      destination_label: "Instagram",
+      initial_content: {
+        title: null,
+        body: "Should not attach to another tenant campaign.",
+        caption: null,
+        alt_text: null,
+        asset_refs: [],
+      },
+    });
     assert.equal(foreignRead.status, 404);
+    assert.equal(foreignList.status, 404);
+    assert.equal(foreignParam.status, 404);
   });
 
   it("archives and restores without exposing an alternative lifecycle state", async () => {


### PR DESCRIPTION
## Scope

BG-LAUNCH-002I-F customer campaign API surface.

Adds customer-authenticated Campaign APIs for:
- list customer campaigns
- create campaign from approved Brand Brain context
- read campaign safely
- update customer-editable campaign details
- create content items
- archive/restore campaigns

## Guardrails

- Reuses the existing campaign-spine.v1 repository and lifecycle rules.
- Campaign status is derived from content item/variant state, not stored as a writable customer field.
- Customer responses omit internal events, actor UUIDs, raw Brand Brain snapshots, storage/provider details, prompts, finance internals, command IDs, and unsafe lifecycle identifiers.
- Enforces Bearer authentication plus tenant/project/Brand boundary checks before repository commands.
- Preview Registry, publishing/connectors, billing, UI, staging, production, and migrations are out of scope.

## Verification

Local verification before branch upload/remediation:
- node --test test/customer-campaigns.test.js: 6/6 passed
- npm test: 444/444 passed
- git diff --check: passed
- PostgreSQL campaign tests: not run locally because TEST_DATABASE_URL was unavailable

Remediation verification:
- Removed active_approval_id, active_schedule_id, pending_attempt_id, and publication_id from customer variant DTOs.
- Added negative DTO assertions and extra cross-tenant access coverage.
- CI run 116 on head 41d463c36d8fa2cb808d6856b3d8626d91e1f1c0 passed.

No staging, production, billing, connector, media-generation, or deployment action was performed.