### PR TITLE
BG-LAUNCH-002J app metadata scope proof

### DIFF
--- a/docs/security/CUSTOMER_TOKEN_VERIFICATION.md
+++ b/docs/security/CUSTOMER_TOKEN_VERIFICATION.md
@@ -4,14 +4,34 @@ BG-AUTH-002B adds the reusable customer boundary on top of BG-AUTH-002A. It
 does not apply the staged database migration, activate production customer
 authentication, deploy code, or create customer credentials.
 
+BG-LAUNCH-002J tightens the same boundary for the launch surface by requiring
+trusted Supabase `app_metadata` scope before a customer actor can authorize
+campaign recommendations or generation paths. Browser-supplied tenant, project,
+and brand values are request routing inputs only; they must match the verified
+scope carried by the token and still pass the durable authorization repository
+checks.
+
 ## Verification contract
 
 The server uses `supabase.auth.getClaims(accessToken)` from the pinned
 `@supabase/supabase-js` dependency. Supabase verifies asymmetric tokens against
 the project's cached JWKS endpoint and falls back to an Auth-server validation
 call for legacy symmetric signing. BizGenie then requires the expected project
-issuer, the `authenticated` audience, an unexpired integer `exp`, and a UUID
-`sub` before creating the canonical customer actor.
+issuer, the `authenticated` audience, an unexpired integer `exp`, a UUID `sub`,
+and a complete trusted scope in `app_metadata` before creating the canonical
+customer actor.
+
+The required trusted scope fields are:
+
+- `app_metadata.tenant_id`
+- `app_metadata.project_id`
+- `app_metadata.brand_id`
+
+`user_metadata` is never used for authorization. Tokens with missing,
+incomplete, malformed, or user-metadata-only scope fail closed with the same
+sanitized authentication response as any other invalid customer token. Operators
+must populate `app_metadata` from a backend/service-role process; customers must
+not be able to set or edit these fields directly.
 
 This is deliberately not a decode-only flow. Provider errors, malformed JWTs,
 expired tokens, invalid signatures, invalid claims, and missing Bearer headers
@@ -30,7 +50,7 @@ start. A partial or insecure configuration fails startup.
 
 ## Principal separation
 
-- Customer: verified Supabase Auth UUID only.
+- Customer: verified Supabase Auth UUID plus trusted `app_metadata` scope.
 - Administrator: existing exact `x-admin-key`/`ADMIN_KEY` comparison only.
 - Service: reserved for BG-AUTH-002C and not implemented here.
 
@@ -48,6 +68,11 @@ through the same tenant-owned project. The boundary calls the existing
 `AuthorizationService` with `generation:create`, removes the routing-only
 `tenant_id`, replaces any body `user_id` with the verified actor's Auth UUID,
 and only then invokes the existing generation handler/service.
+
+The verified actor's trusted `tenant_id`, `project_id`, and `brand_id` are
+compared with the requested scope inside the authorization service before the
+repository lookup can authorize the action. A forged body, query string, or
+customer-editable metadata value cannot widen the verified scope.
 
 Unknown resources, missing membership, cross-tenant projects, and project/brand
 mismatches share the same non-enumerating `RESOURCE_NOT_AVAILABLE` response.

--- a/src/authentication/tokenVerifier.js
+++ b/src/authentication/tokenVerifier.js
@@ -1,6 +1,7 @@
 const { createClient } = require("@supabase/supabase-js");
 const {
   AuthenticationRequiredError,
+  CustomerTrustedScopeSchema,
   createCustomerActorFromVerifiedIdentity,
 } = require("../authorization");
 
@@ -51,6 +52,17 @@ function validAudience(value, expectedAudience) {
   return value === expectedAudience;
 }
 
+function trustedScopeFromClaims(claims) {
+  const appMetadata = claims?.app_metadata || {};
+  const parsed = CustomerTrustedScopeSchema.safeParse({
+    tenant_id: appMetadata.tenant_id,
+    project_id: appMetadata.project_id,
+    brand_id: appMetadata.brand_id,
+  });
+  if (!parsed.success) throw authenticationRequired();
+  return parsed.data;
+}
+
 class SupabaseCustomerTokenVerifier extends CustomerTokenVerifier {
   constructor({
     supabaseClient,
@@ -97,6 +109,7 @@ class SupabaseCustomerTokenVerifier extends CustomerTokenVerifier {
 
     return createCustomerActorFromVerifiedIdentity({
       verifiedAuthUserId: claims.sub,
+      verifiedScope: trustedScopeFromClaims(claims),
     });
   }
 }
@@ -148,4 +161,5 @@ module.exports = {
   UnconfiguredCustomerTokenVerifier,
   createSupabaseCustomerTokenVerifierFromEnv,
   normalizedProjectUrl,
+  trustedScopeFromClaims,
 };

--- a/src/authorization/schema.js
+++ b/src/authorization/schema.js
@@ -9,10 +9,19 @@ const identifier = z
   .max(IDENTIFIER_MAX_LENGTH)
   .regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/, "Invalid identifier");
 
+const CustomerTrustedScopeSchema = z
+  .object({
+    tenant_id: identifier,
+    project_id: identifier,
+    brand_id: identifier,
+  })
+  .strict();
+
 const CustomerActorSchema = z
   .object({
     kind: z.literal("customer"),
     auth_user_id: z.uuid(),
+    trusted_scope: CustomerTrustedScopeSchema.optional(),
   })
   .strict();
 
@@ -36,11 +45,17 @@ const ActorSchema = z.discriminatedUnion("kind", [
   AdministratorActorSchema,
 ]);
 
-function createCustomerActorFromVerifiedIdentity({ verifiedAuthUserId } = {}) {
-  const parsed = CustomerActorSchema.safeParse({
+function createCustomerActorFromVerifiedIdentity({
+  verifiedAuthUserId,
+  verifiedScope,
+} = {}) {
+  const candidate = {
     kind: "customer",
     auth_user_id: verifiedAuthUserId,
-  });
+  };
+  if (verifiedScope) candidate.trusted_scope = verifiedScope;
+
+  const parsed = CustomerActorSchema.safeParse(candidate);
 
   if (!parsed.success) {
     throw new AuthenticationRequiredError();
@@ -53,6 +68,7 @@ module.exports = {
   ActorSchema,
   AdministratorActorSchema,
   CustomerActorSchema,
+  CustomerTrustedScopeSchema,
   IDENTIFIER_MAX_LENGTH,
   ServiceActorSchema,
   createCustomerActorFromVerifiedIdentity,

--- a/src/authorization/service.js
+++ b/src/authorization/service.js
@@ -6,6 +6,14 @@ function deny() {
   throw new AuthorizationDeniedError();
 }
 
+function scopeMismatch(actor, expected = {}) {
+  const scope = actor.trusted_scope;
+  if (!scope) return false;
+  return Object.entries(expected).some(
+    ([key, value]) => value !== undefined && scope[key] !== value
+  );
+}
+
 class AuthorizationService {
   constructor({ repository }) {
     if (!repository) {
@@ -17,6 +25,10 @@ class AuthorizationService {
   async authorizeTenant({ actor, tenantId, action }) {
     const parsedActor = ActorSchema.safeParse(actor);
     if (!parsedActor.success || parsedActor.data.kind !== "customer") {
+      return deny();
+    }
+
+    if (scopeMismatch(parsedActor.data, { tenant_id: tenantId })) {
       return deny();
     }
 
@@ -47,7 +59,11 @@ class AuthorizationService {
     });
     const project = await this.repository.getProjectById(projectId);
 
-    if (!project || project.tenant_id !== tenantId) {
+    if (
+      !project ||
+      project.tenant_id !== tenantId ||
+      scopeMismatch(tenantAuthorization.actor, { project_id: projectId })
+    ) {
       return deny();
     }
 
@@ -78,7 +94,11 @@ class AuthorizationService {
 
     const approvedBrandRequired =
       requireApprovedBrand || action === "generation:create";
-    if (!brand || (approvedBrandRequired && brand.status !== "approved")) {
+    if (
+      !brand ||
+      (approvedBrandRequired && brand.status !== "approved") ||
+      scopeMismatch(projectAuthorization.actor, { brand_id: brandId })
+    ) {
       return deny();
     }
 

--- a/test/authorization.test.js
+++ b/test/authorization.test.js
@@ -11,6 +11,11 @@ const {
 
 const USER_A = "11111111-1111-4111-8111-111111111111";
 const USER_B = "22222222-2222-4222-8222-222222222222";
+const TRUSTED_SCOPE_A = Object.freeze({
+  tenant_id: "tenant_a",
+  project_id: "project_a",
+  brand_id: "brand_a",
+});
 
 function fixture() {
   const repository = new InMemoryAuthorizationRepository({
@@ -46,6 +51,10 @@ function fixture() {
     actorB: createCustomerActorFromVerifiedIdentity({
       verifiedAuthUserId: USER_B,
     }),
+    scopedActorA: createCustomerActorFromVerifiedIdentity({
+      verifiedAuthUserId: USER_A,
+      verifiedScope: TRUSTED_SCOPE_A,
+    }),
   };
 }
 
@@ -55,6 +64,19 @@ describe("customer identity contract", () => {
       verifiedAuthUserId: USER_A,
     });
     assert.deepEqual(actor, { kind: "customer", auth_user_id: USER_A });
+    assert.equal(Object.isFrozen(actor), true);
+  });
+
+  it("can carry trusted Supabase app_metadata scope when token verification supplies it", () => {
+    const actor = createCustomerActorFromVerifiedIdentity({
+      verifiedAuthUserId: USER_A,
+      verifiedScope: TRUSTED_SCOPE_A,
+    });
+    assert.deepEqual(actor, {
+      kind: "customer",
+      auth_user_id: USER_A,
+      trusted_scope: TRUSTED_SCOPE_A,
+    });
     assert.equal(Object.isFrozen(actor), true);
   });
 
@@ -132,6 +154,49 @@ describe("tenant, project, and brand authorization", () => {
       (error) =>
         error.status === 404 && error.code === "RESOURCE_NOT_AVAILABLE"
     );
+  });
+
+  it("denies requests whose tenant, project, or brand do not match trusted token scope", async () => {
+    const { service, scopedActorA } = fixture();
+
+    await service.authorizeProjectBrand({
+      actor: scopedActorA,
+      tenantId: "tenant_a",
+      projectId: "project_a",
+      brandId: "brand_a",
+      action: "brand:read",
+    });
+
+    for (const request of [
+      {
+        actor: scopedActorA,
+        tenantId: "tenant_b",
+        projectId: "project_b",
+        action: "project:read",
+      },
+      {
+        actor: scopedActorA,
+        tenantId: "tenant_a",
+        projectId: "project_b",
+        action: "project:read",
+      },
+      {
+        actor: scopedActorA,
+        tenantId: "tenant_a",
+        projectId: "project_a",
+        brandId: "brand_b",
+        action: "brand:read",
+      },
+    ]) {
+      await assert.rejects(
+        request.brandId
+          ? service.authorizeProjectBrand(request)
+          : service.authorizeProject(request),
+        (error) =>
+          error instanceof AuthorizationDeniedError &&
+          error.code === "RESOURCE_NOT_AVAILABLE"
+      );
+    }
   });
 
   it("does not authorize Tenant A for Tenant B's project", async () => {

--- a/test/customer-authentication.test.js
+++ b/test/customer-authentication.test.js
@@ -15,6 +15,11 @@ const {
 const PROJECT_URL = "https://bizgenie-test.supabase.co";
 const USER_A = "11111111-1111-4111-8111-111111111111";
 const NOW = new Date("2026-08-19T12:00:00.000Z");
+const TRUSTED_SCOPE = Object.freeze({
+  tenant_id: "tenant_a",
+  project_id: "project_a",
+  brand_id: "brand_a",
+});
 
 function verifiedClaims(overrides = {}) {
   return {
@@ -24,6 +29,7 @@ function verifiedClaims(overrides = {}) {
     exp: Math.floor(NOW.getTime() / 1000) + 300,
     iat: Math.floor(NOW.getTime() / 1000) - 60,
     role: "authenticated",
+    app_metadata: { ...TRUSTED_SCOPE },
     ...overrides,
   };
 }
@@ -50,6 +56,7 @@ describe("Supabase customer token verification", () => {
     assert.deepEqual(actor, {
       kind: "customer",
       auth_user_id: USER_A,
+      trusted_scope: TRUSTED_SCOPE,
     });
     assert.equal(Object.isFrozen(actor), true);
   });
@@ -106,6 +113,45 @@ describe("Supabase customer token verification", () => {
         AuthenticationRequiredError
       );
     }
+  });
+
+  it("rejects tokens without complete service-role-assigned app_metadata scope", async () => {
+    for (const overrides of [
+      { app_metadata: undefined },
+      { app_metadata: {} },
+      { app_metadata: { tenant_id: "tenant_a", project_id: "project_a" } },
+      { app_metadata: { tenant_id: "tenant a", project_id: "project_a", brand_id: "brand_a" } },
+    ]) {
+      const verifier = verifierWith(async () => ({
+        data: { claims: verifiedClaims(overrides) },
+        error: null,
+      }));
+      await assert.rejects(
+        verifier.verifyAccessToken("missing-scope-token"),
+        AuthenticationRequiredError
+      );
+    }
+  });
+
+  it("ignores user-editable user_metadata even when it contains plausible scope fields", async () => {
+    const verifier = verifierWith(async () => ({
+      data: {
+        claims: verifiedClaims({
+          app_metadata: {},
+          user_metadata: {
+            tenant_id: "tenant_a",
+            project_id: "project_a",
+            brand_id: "brand_a",
+          },
+        }),
+      },
+      error: null,
+    }));
+
+    await assert.rejects(
+      verifier.verifyAccessToken("user-metadata-only-token"),
+      AuthenticationRequiredError
+    );
   });
 
   it("strictly extracts a single Bearer token", () => {


### PR DESCRIPTION
## BG-LAUNCH-002J

Draft PR for the authenticated launch-surface bridge proof.

### Scope

- Require real Supabase customer tokens to carry trusted `app_metadata.tenant_id`, `app_metadata.project_id`, and `app_metadata.brand_id` before creating the customer actor.
- Ignore customer-editable `user_metadata` for authorization scope.
- Compare the request tenant/project/brand scope against the verified token scope before the existing durable authorization repository can approve the action.
- Preserve existing repository authorization checks for tenant membership, project ownership, approved Brand Brain, and non-enumerating denials.
- Document the operator boundary for backend/service-role population of `app_metadata`.

### Files Changed

- `src/authentication/tokenVerifier.js`
- `src/authorization/schema.js`
- `src/authorization/service.js`
- `test/customer-authentication.test.js`
- `test/authorization.test.js`
- `docs/security/CUSTOMER_TOKEN_VERIFICATION.md`

### Explicit Non-Scope

No web changes, no Supabase dashboard mutation, no staging or production deployment, no database migration, no publishing, no social/provider generation, and no billing activation. W4A billable generation remains HOLD.

### Verification

Not locally run in this session. This was prepared through the GitHub connector using live GitHub as authority because the local checkout is stale/unsuitable for exact-head testing.

Expected review/CI commands:

- `node --test test/customer-authentication.test.js test/authorization.test.js`
- `npm test`
- Existing CI, including PostgreSQL jobs where configured

### Review Notes

Supabase authorization scope must remain service-role/backend assigned through `app_metadata`; `user_metadata` is explicitly unsafe for authorization because customers can edit it.