### PR TITLE
BG-LAUNCH-002K trusted scope provisioning proof

### DIFF
--- a/docs/security/CUSTOMER_TOKEN_VERIFICATION.md
+++ b/docs/security/CUSTOMER_TOKEN_VERIFICATION.md
@@ -48,6 +48,36 @@ Both variables must be configured together. With neither configured, customer
 authentication remains fail-closed while existing administration continues to
 start. A partial or insecure configuration fails startup.
 
+## Trusted scope provisioning boundary
+
+BG-LAUNCH-002K adds a server-only provisioning helper for the backend/operator
+process that assigns the verified tenant/project/brand scope to a Supabase Auth
+user. The helper is not mounted as a public route and does not read credentials
+from browser-visible environment variables. A caller must inject a Supabase Auth
+admin client that is allowed to call `auth.admin.getUserById` and
+`auth.admin.updateUserById` from a trusted server context.
+
+The provisioner accepts only:
+
+- `auth_user_id`
+- `trusted_scope.tenant_id`
+- `trusted_scope.project_id`
+- `trusted_scope.brand_id`
+
+The request schema is strict. `user_metadata`, request-body identity fields,
+admin keys, provider credentials, billing state, publication state, and campaign
+payload fields are rejected by construction and never forwarded to Supabase. The
+helper fetches the existing Auth user, preserves existing object-shaped
+`app_metadata`, overlays the three BizGenie trusted-scope fields, and writes the
+result back as `app_metadata` only. Supabase/provider failures are converted to a
+single sanitized provisioning error.
+
+This proof does not create customers, apply migrations, mutate staging or
+production Supabase Auth, activate W4A billable generation, or decide the final
+account onboarding UX. A later operator-gated account setup flow must call the
+helper only after durable BizGenie tenant, project, membership, and approved
+Brand Brain records have been established.
+
 ## Principal separation
 
 - Customer: verified Supabase Auth UUID plus trusted `app_metadata` scope.

--- a/docs/security/CUSTOMER_TOKEN_VERIFICATION.md
+++ b/docs/security/CUSTOMER_TOKEN_VERIFICATION.md
@@ -72,11 +72,21 @@ helper fetches the existing Auth user, preserves existing object-shaped
 result back as `app_metadata` only. Supabase/provider failures are converted to a
 single sanitized provisioning error.
 
+After a successful write, existing customer access tokens must be treated as
+stale because their JWT claims may not yet contain the new `app_metadata` scope.
+The provisioner therefore returns `requires_session_refresh: true`. The
+operator/account-setup flow must refresh or reissue the Supabase customer
+session, or require the customer to sign in again, before attempting any
+BizGenie customer API request. Until the refreshed token carries the trusted
+scope, the web client remains `scope-missing` and the API continues to fail
+closed with `AUTHENTICATION_REQUIRED`.
+
 This proof does not create customers, apply migrations, mutate staging or
 production Supabase Auth, activate W4A billable generation, or decide the final
 account onboarding UX. A later operator-gated account setup flow must call the
 helper only after durable BizGenie tenant, project, membership, and approved
-Brand Brain records have been established.
+Brand Brain records have been established, then complete the session-refresh
+step before handing control back to the launch surface.
 
 ## Principal separation
 

--- a/src/authentication/customerScopeProvisioner.js
+++ b/src/authentication/customerScopeProvisioner.js
@@ -97,6 +97,7 @@ class CustomerScopeProvisioner {
     return Object.freeze({
       auth_user_id,
       trusted_scope,
+      requires_session_refresh: true,
     });
   }
 }

--- a/src/authentication/customerScopeProvisioner.js
+++ b/src/authentication/customerScopeProvisioner.js
@@ -1,0 +1,115 @@
+const { z } = require("zod");
+const { CustomerTrustedScopeSchema } = require("../authorization");
+
+class CustomerScopeProvisioningConfigurationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "CustomerScopeProvisioningConfigurationError";
+    this.code = "CUSTOMER_SCOPE_PROVISIONING_CONFIGURATION_ERROR";
+  }
+}
+
+class CustomerScopeProvisioningError extends Error {
+  constructor(message = "Customer scope could not be provisioned") {
+    super(message);
+    this.name = "CustomerScopeProvisioningError";
+    this.code = "CUSTOMER_SCOPE_PROVISIONING_FAILED";
+  }
+}
+
+const CustomerScopeProvisioningRequestSchema = z
+  .object({
+    auth_user_id: z.uuid(),
+    trusted_scope: CustomerTrustedScopeSchema,
+  })
+  .strict();
+
+function resolveAuthAdmin(supabaseAdminClient) {
+  const admin = supabaseAdminClient?.auth?.admin;
+  if (
+    !admin ||
+    typeof admin.getUserById !== "function" ||
+    typeof admin.updateUserById !== "function"
+  ) {
+    throw new CustomerScopeProvisioningConfigurationError(
+      "A Supabase Auth admin client with getUserById and updateUserById is required"
+    );
+  }
+  return admin;
+}
+
+function objectMetadata(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return { ...value };
+}
+
+function trustedAppMetadata(existingAppMetadata, trustedScope) {
+  return Object.freeze({
+    ...objectMetadata(existingAppMetadata),
+    tenant_id: trustedScope.tenant_id,
+    project_id: trustedScope.project_id,
+    brand_id: trustedScope.brand_id,
+  });
+}
+
+class CustomerScopeProvisioner {
+  constructor({ supabaseAdminClient }) {
+    this.admin = resolveAuthAdmin(supabaseAdminClient);
+  }
+
+  async provisionTrustedScope(request) {
+    const parsed = CustomerScopeProvisioningRequestSchema.safeParse(request);
+    if (!parsed.success) {
+      throw new CustomerScopeProvisioningError();
+    }
+
+    const { auth_user_id, trusted_scope } = parsed.data;
+
+    let existing;
+    try {
+      existing = await this.admin.getUserById(auth_user_id);
+    } catch {
+      throw new CustomerScopeProvisioningError();
+    }
+
+    if (existing?.error) {
+      throw new CustomerScopeProvisioningError();
+    }
+
+    const appMetadata = trustedAppMetadata(
+      existing?.data?.user?.app_metadata,
+      trusted_scope
+    );
+
+    let updated;
+    try {
+      updated = await this.admin.updateUserById(auth_user_id, {
+        app_metadata: appMetadata,
+      });
+    } catch {
+      throw new CustomerScopeProvisioningError();
+    }
+
+    if (updated?.error) {
+      throw new CustomerScopeProvisioningError();
+    }
+
+    return Object.freeze({
+      auth_user_id,
+      trusted_scope,
+    });
+  }
+}
+
+function createCustomerScopeProvisioner({ supabaseAdminClient } = {}) {
+  return new CustomerScopeProvisioner({ supabaseAdminClient });
+}
+
+module.exports = {
+  CustomerScopeProvisioningConfigurationError,
+  CustomerScopeProvisioningError,
+  CustomerScopeProvisioningRequestSchema,
+  CustomerScopeProvisioner,
+  createCustomerScopeProvisioner,
+  trustedAppMetadata,
+};

--- a/src/authentication/index.js
+++ b/src/authentication/index.js
@@ -1,11 +1,13 @@
 const boundary = require("./customerGenerationBoundary");
 const billingTenantResolver = require("./customerBillingTenantResolver");
+const scopeProvisioner = require("./customerScopeProvisioner");
 const videoStatusBoundary = require("./customerVideoStatusBoundary");
 const tokenVerifier = require("./tokenVerifier");
 
 module.exports = {
   ...boundary,
   ...billingTenantResolver,
+  ...scopeProvisioner,
   ...videoStatusBoundary,
   ...tokenVerifier,
 };

--- a/test/customer-scope-provisioner.test.js
+++ b/test/customer-scope-provisioner.test.js
@@ -61,6 +61,7 @@ describe("customer trusted scope provisioning", () => {
     assert.deepEqual(result, {
       auth_user_id: USER_A,
       trusted_scope: TRUSTED_SCOPE,
+      requires_session_refresh: true,
     });
     assert.deepEqual(calls, [
       ["getUserById", USER_A],
@@ -78,6 +79,18 @@ describe("customer trusted scope provisioning", () => {
         },
       ],
     ]);
+  });
+
+  it("signals that existing customer JWTs must be refreshed before API use", async () => {
+    const { client } = adminClient();
+    const provisioner = createCustomerScopeProvisioner({ supabaseAdminClient: client });
+
+    const result = await provisioner.provisionTrustedScope({
+      auth_user_id: USER_A,
+      trusted_scope: TRUSTED_SCOPE,
+    });
+
+    assert.equal(result.requires_session_refresh, true);
   });
 
   it("does not write user_metadata or accept client-supplied extra fields", async () => {

--- a/test/customer-scope-provisioner.test.js
+++ b/test/customer-scope-provisioner.test.js
@@ -1,0 +1,166 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+
+const {
+  CustomerScopeProvisioningConfigurationError,
+  CustomerScopeProvisioningError,
+  createCustomerScopeProvisioner,
+  trustedAppMetadata,
+} = require("../src/authentication");
+
+const USER_A = "11111111-1111-4111-8111-111111111111";
+const TRUSTED_SCOPE = Object.freeze({
+  tenant_id: "tenant_a",
+  project_id: "project_a",
+  brand_id: "brand_a",
+});
+
+function adminClient({
+  existingAppMetadata = { provider: "email", preserved_flag: true },
+  getUserById = async (authUserId) => ({
+    data: {
+      user: {
+        id: authUserId,
+        app_metadata: existingAppMetadata,
+      },
+    },
+    error: null,
+  }),
+  updateUserById = async () => ({ data: { user: { id: USER_A } }, error: null }),
+} = {}) {
+  const calls = [];
+  return {
+    calls,
+    client: {
+      auth: {
+        admin: {
+          async getUserById(...args) {
+            calls.push(["getUserById", ...args]);
+            return getUserById(...args);
+          },
+          async updateUserById(...args) {
+            calls.push(["updateUserById", ...args]);
+            return updateUserById(...args);
+          },
+        },
+      },
+    },
+  };
+}
+
+describe("customer trusted scope provisioning", () => {
+  it("merges trusted tenant/project/brand scope into existing app_metadata only", async () => {
+    const { client, calls } = adminClient();
+    const provisioner = createCustomerScopeProvisioner({ supabaseAdminClient: client });
+
+    const result = await provisioner.provisionTrustedScope({
+      auth_user_id: USER_A,
+      trusted_scope: TRUSTED_SCOPE,
+    });
+
+    assert.deepEqual(result, {
+      auth_user_id: USER_A,
+      trusted_scope: TRUSTED_SCOPE,
+    });
+    assert.deepEqual(calls, [
+      ["getUserById", USER_A],
+      [
+        "updateUserById",
+        USER_A,
+        {
+          app_metadata: {
+            provider: "email",
+            preserved_flag: true,
+            tenant_id: "tenant_a",
+            project_id: "project_a",
+            brand_id: "brand_a",
+          },
+        },
+      ],
+    ]);
+  });
+
+  it("does not write user_metadata or accept client-supplied extra fields", async () => {
+    const { client, calls } = adminClient();
+    const provisioner = createCustomerScopeProvisioner({ supabaseAdminClient: client });
+
+    await assert.rejects(
+      provisioner.provisionTrustedScope({
+        auth_user_id: USER_A,
+        trusted_scope: TRUSTED_SCOPE,
+        user_metadata: {
+          tenant_id: "tenant_b",
+          project_id: "project_b",
+          brand_id: "brand_b",
+        },
+      }),
+      CustomerScopeProvisioningError
+    );
+
+    assert.deepEqual(calls, []);
+  });
+
+  it("rejects incomplete or malformed trusted scope before calling Supabase", async () => {
+    const { client, calls } = adminClient();
+    const provisioner = createCustomerScopeProvisioner({ supabaseAdminClient: client });
+
+    for (const request of [
+      { auth_user_id: USER_A },
+      {
+        auth_user_id: USER_A,
+        trusted_scope: { tenant_id: "tenant_a", project_id: "project_a" },
+      },
+      {
+        auth_user_id: USER_A,
+        trusted_scope: {
+          tenant_id: "tenant a",
+          project_id: "project_a",
+          brand_id: "brand_a",
+        },
+      },
+    ]) {
+      await assert.rejects(
+        provisioner.provisionTrustedScope(request),
+        CustomerScopeProvisioningError
+      );
+    }
+
+    assert.deepEqual(calls, []);
+  });
+
+  it("requires an injected Supabase Auth admin client", () => {
+    for (const supabaseAdminClient of [undefined, {}, { auth: {} }, { auth: { admin: {} } }]) {
+      assert.throws(
+        () => createCustomerScopeProvisioner({ supabaseAdminClient }),
+        CustomerScopeProvisioningConfigurationError
+      );
+    }
+  });
+
+  it("returns sanitized failures without leaking provider diagnostics", async () => {
+    const { client } = adminClient({
+      async updateUserById() {
+        throw new Error("service role rejected raw provider details");
+      },
+    });
+    const provisioner = createCustomerScopeProvisioner({ supabaseAdminClient: client });
+
+    await assert.rejects(
+      provisioner.provisionTrustedScope({
+        auth_user_id: USER_A,
+        trusted_scope: TRUSTED_SCOPE,
+      }),
+      (error) => {
+        assert.ok(error instanceof CustomerScopeProvisioningError);
+        assert.equal(error.code, "CUSTOMER_SCOPE_PROVISIONING_FAILED");
+        assert.doesNotMatch(error.message, /service role|provider|raw/i);
+        return true;
+      }
+    );
+  });
+
+  it("normalizes non-object existing app_metadata before writing trusted scope", () => {
+    assert.deepEqual(trustedAppMetadata(null, TRUSTED_SCOPE), TRUSTED_SCOPE);
+    assert.deepEqual(trustedAppMetadata(["bad"], TRUSTED_SCOPE), TRUSTED_SCOPE);
+  });
+});


### PR DESCRIPTION
## Summary

BG-LAUNCH-002K adds the smallest backend-side proof for provisioning trusted Supabase customer scope after the merged BG-LAUNCH-002J token boundary.

- Add a server-only `CustomerScopeProvisioner` helper that accepts a strict `auth_user_id` plus trusted tenant/project/brand scope.
- Require an injected Supabase Auth admin client with `getUserById` and `updateUserById`; no browser-visible service-role/admin credentials are introduced.
- Preserve existing object-shaped `app_metadata`, overlay `tenant_id`, `project_id`, and `brand_id`, and write only `app_metadata`.
- Reject `user_metadata`, extra request fields, incomplete/malformed scope, and provider failures with sanitized errors.
- Return `requires_session_refresh: true` after provisioning so the account setup flow treats the current JWT as stale and refreshes/reissues the customer session before calling BizGenie APIs.
- Document the provisioning boundary and keep account onboarding/live Supabase mutation out of scope.

## Scope / Safety

- API repo only.
- No public route mounted.
- No migration.
- No staging/production Supabase Auth mutation.
- No W4A billable generation activation.
- No deployment, billing, publishing, provider, launch-surface, or field-sales work.

## Verification

Connector inspection performed against live GitHub main `0cbf497941828c37ee79b66e444d8bd7c104d784`.

Local tests were **not run** in this connector-only flow. Please let CI run, then independently review exact head before merge.

Recommended focused check once a checkout is available:

```bash
node --test test/customer-scope-provisioner.test.js test/customer-authentication.test.js test/authorization.test.js
npm test
```

## Restart Point

Review this draft PR exact head after CI completes. W4A remains HOLD.